### PR TITLE
feat(tokenless): add QwenPaw plugin adapter

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/QUICKSTART.md
+++ b/docs/user-guide/en/token-saving/tokenless/QUICKSTART.md
@@ -123,6 +123,7 @@ anolisa adapter scan
 | DeepSeek Harness (dsh) | `anolisa adapter enable tokenless dsh --profile <profile>` |
 | OpenCode | `anolisa adapter enable tokenless opencode` |
 | Qwen Code | `anolisa adapter enable tokenless qwencode` |
+| QwenPaw | `anolisa adapter enable tokenless qwenpaw` |
 
 Restart the Agent CLI or IDE after setting it up. OpenClaw also requires
 `openclaw gateway restart`; if its security check rejects the plugin, follow

--- a/docs/user-guide/en/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/en/token-saving/tokenless/framework-integration.md
@@ -19,6 +19,7 @@ product adapters. The Python SDK and its AgentScope-specific child document live
 | DeepSeek Harness | `dsh` | — | — | Delegates accepted single-text results to Core; supports Marker command recovery | Core-selected for replaceable text | — |
 | OpenCode | `opencode` | Hard-disabled | Replaces Bash input | Replaces tool output | Pipeline-selected for replaceable text | ✅ |
 | Qwen Code | `qwencode` | Hard-disabled | Emits rewritten shell input | Passes through because the host has no replacement field | — | — |
+| QwenPaw | `qwenpaw` | — | Replaces the `execute_shell_command` input | Replaces text blocks of the tool result inside the AgentScope middleware chain | Core-selected for replaceable text | ✅ |
 
 “—” means that the capability is not available: the current adapter does not register it, or current host releases do not run it. The corresponding Tokenless CLI command may still be available.
 
@@ -193,6 +194,7 @@ anolisa adapter enable tokenless claude-code
 anolisa adapter enable tokenless codex
 anolisa adapter enable tokenless opencode
 anolisa adapter enable tokenless qwencode
+anolisa adapter enable tokenless qwenpaw
 anolisa adapter enable tokenless dsh \
   --profile web \
   --profile headless
@@ -250,7 +252,7 @@ The npm postinstall script attempts to copy adapter resources under:
 
 Confirm that this directory exists. Adapter copying is supplementary and fails open with a warning; a successful binary install can therefore exist without this copy. If it is absent, review the npm postinstall warning and prefer an anolisa-managed installation.
 
-An npm install does not create an anolisa component installation record, so do not assume that `anolisa adapter enable` can manage it. OpenClaw, Hermes, Qoder, Claude Code, Codex, OpenCode, and Qwen Code provide their own install scripts:
+An npm install does not create an anolisa component installation record, so do not assume that `anolisa adapter enable` can manage it. OpenClaw, Hermes, Qoder, Claude Code, Codex, OpenCode, Qwen Code, and QwenPaw provide their own install scripts:
 
 ```bash
 bash ~/.local/share/anolisa/adapters/tokenless/<framework>/scripts/install.sh
@@ -331,6 +333,12 @@ OpenCode discovers global local plugins at startup. Use the bundled Tokenless li
 ### Qwen Code
 
 The extension loads in a new Qwen Code session. Restart and run one tool call to verify it.
+
+### QwenPaw
+
+The adapter is a QwenPaw plugin: `anolisa adapter enable tokenless qwenpaw` and the bundled install script both run `qwenpaw plugin install <bundle> --force`, so QwenPaw copies the plugin into `<working dir>/plugins/tokenless/` and installs its `requirements.txt` into QwenPaw's own Python environment. That requirement is the `anolisa_tokenless` wheel from the matching GitHub Release, so the first install needs network access. QwenPaw only runs pip when `anolisa_tokenless` is missing from its interpreter's package metadata, so on an offline host `pip install` the wheel into QwenPaw's Python environment first; the same rule means an already installed older wheel is never upgraded by `plugin install`. The install script therefore checks, through the interpreter behind the `qwenpaw` command, that `anolisa_tokenless` imports and carries the SDK surface the plugin needs, and fails when no wheel matched the platform (`requirements.txt` lists Linux x86_64, Linux aarch64, and macOS arm64). The plugin itself refuses to register against an older wheel and logs the required release instead of failing at the first model call. The plugin needs the recovery entry points added after Tokenless 0.7.14, so a package built before the next version bump points at a wheel without them: the plugin then installs, logs the required release, and stays disabled until that release is installed. The working directory is resolved like QwenPaw itself: `QWENPAW_WORKING_DIR`, else `COPAW_WORKING_DIR`, else an existing `~/.copaw`, else `~/.qwenpaw`. Without a `qwenpaw` command the install script prints a hint and exits 0 so `make setup` completes on hosts without QwenPaw.
+
+A running QwenPaw hot-loads the plugin; otherwise start QwenPaw. Schema compression and the `tokenless_retrieve` tool apply from the next model call, and command rewriting runs after QwenPaw's approval step, so an approved `execute_shell_command` executes the rewritten command. Only QwenPaw's built-in tools are classified: `execute_shell_command` is command output, `read_file`, `recall_history`, `view_image`, and `view_video` are file content, and the remaining built-ins are API responses; skills, MCP tools, and tools added by later QwenPaw releases pass through untouched. QwenPaw's own tool-result pruning runs after Tokenless and keeps the head of each result (50000 bytes for the two most recent tool results, 3000 bytes for older ones, overflow written to `tool_results/`), so a recovery instruction at the end of a compressed result survives only while the result fits that budget; the omitted content stays retrievable from the stash with `tokenless retrieve`. Records land under `<workspace>/.tokenless` for each QwenPaw workspace; point `tokenless stats list --data-dir` there.
 
 ## AgentScope framework integration
 

--- a/docs/user-guide/zh/token-saving/tokenless/QUICKSTART.md
+++ b/docs/user-guide/zh/token-saving/tokenless/QUICKSTART.md
@@ -119,6 +119,7 @@ anolisa adapter scan
 | DeepSeek Harness（dsh） | `anolisa adapter enable tokenless dsh --profile <profile>` |
 | OpenCode | `anolisa adapter enable tokenless opencode` |
 | Qwen Code | `anolisa adapter enable tokenless qwencode` |
+| QwenPaw | `anolisa adapter enable tokenless qwenpaw` |
 
 接入后重启对应的 Agent CLI 或 IDE。OpenClaw 还需要运行
 `openclaw gateway restart`；如果安全检查拒绝 Plugin，请按照

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -18,6 +18,7 @@ Python SDK 及其 AgentScope 专用子文档放在 [Python SDK 指南](sdk.md) �
 | DeepSeek Harness | `dsh` | 未注册 | 未注册 | 把已接受的单文本结果委托给 Core；支持 Marker 命令恢复 | 对可替换文本由 Core 选择 | 未注册 |
 | OpenCode | `opencode` | 已硬关闭 | 替换 Bash 输入 | 替换工具输出 | 对可替换文本由 Pipeline 选择 | ✅ |
 | Qwen Code | `qwencode` | 已硬关闭 | 输出改写后的 Shell 输入 | 宿主没有替换字段，因此透传 | — | — |
+| QwenPaw | `qwenpaw` | — | 替换 `execute_shell_command` 的输入 | 在 AgentScope 中间件链中替换工具结果的文本块 | 对可替换文本由 Core 选择 | ✅ |
 
 “—”表示该能力不可用：当前 Adapter 没有注册，或当前宿主版本不会运行；对应的 Tokenless CLI 命令仍可能可用。
 
@@ -176,6 +177,7 @@ anolisa adapter enable tokenless claude-code
 anolisa adapter enable tokenless codex
 anolisa adapter enable tokenless opencode
 anolisa adapter enable tokenless qwencode
+anolisa adapter enable tokenless qwenpaw
 anolisa adapter enable tokenless dsh \
   --profile web \
   --profile headless
@@ -230,7 +232,7 @@ npm 的 postinstall 脚本会尝试把 Adapter 资源复制到：
 
 应确认该目录确实存在。Adapter 复制属于补充步骤，失败时只输出警告，不会让二进制安装失败；因此可能出现命令可用但这里没有资源副本的情况。目录缺失时应检查 npm postinstall 警告，并优先改用 anolisa 管理的安装。
 
-npm 安装不会创建 anolisa 组件安装记录，因此不要假设 `anolisa adapter enable` 能管理这次安装。OpenClaw、Hermes、Qoder、Claude Code、Codex、OpenCode 和 Qwen Code 可以运行各自的安装脚本：
+npm 安装不会创建 anolisa 组件安装记录，因此不要假设 `anolisa adapter enable` 能管理这次安装。OpenClaw、Hermes、Qoder、Claude Code、Codex、OpenCode、Qwen Code 和 QwenPaw 可以运行各自的安装脚本：
 
 ```bash
 bash ~/.local/share/anolisa/adapters/tokenless/<framework>/scripts/install.sh
@@ -319,6 +321,29 @@ OpenCode 启动时会自动加载配置目录下的 Plugin。使用上述 Tokenl
 ### Qwen Code
 
 Extension 在新的 Qwen Code 会话中加载。重启后执行一次工具调用验证。
+
+### QwenPaw
+
+该 Adapter 是一个 QwenPaw Plugin：`anolisa adapter enable tokenless qwenpaw` 和自带的安装脚本都会执行
+`qwenpaw plugin install <bundle> --force`，由 QwenPaw 把插件复制到 `<工作目录>/plugins/tokenless/`，
+并把其 `requirements.txt` 安装进 QwenPaw 自己的 Python 环境。该依赖是对应 GitHub Release 中的
+`anolisa_tokenless` wheel，因此首次安装需要联网。QwenPaw 只在其解释器的包元数据里找不到 `anolisa_tokenless`
+时才运行 pip，所以离线主机可先用 `pip install` 把 wheel 装进 QwenPaw 的 Python 环境；同样的规则意味着已装过的旧版
+wheel 不会被 `plugin install` 升级。因此安装脚本会通过 `qwenpaw` 命令背后的解释器确认 `anolisa_tokenless`
+可导入且具备插件需要的 SDK 接口，没有 wheel 匹配当前平台（`requirements.txt` 列出 Linux x86_64、Linux aarch64
+和 macOS arm64）时安装失败。插件本身也会拒绝在旧版 wheel 上注册并在日志中给出所需的 release，而不是在第一次模型
+调用时报错。插件需要 Tokenless 0.7.14 之后新增的恢复入口，因此在下一次版本号提升之前构建的软件包会指向一个不含
+该接口的 wheel：此时插件可以安装，但只会记录所需的 release 并保持禁用，直到装上该 release。工作目录与 QwenPaw 本身的解析一致：`QWENPAW_WORKING_DIR`，否则 `COPAW_WORKING_DIR`，否则已存在的
+`~/.copaw`，否则 `~/.qwenpaw`。没有 `qwenpaw` 命令时安装脚本打印提示并以 0 退出，`make setup` 在未安装 QwenPaw
+的主机上可以完整跑完。
+
+正在运行的 QwenPaw 会热加载插件；否则启动 QwenPaw 即可。Schema 压缩和 `tokenless_retrieve` 工具从下一次
+模型调用开始生效；命令重写发生在 QwenPaw 的审批步骤之后，因此已批准的 `execute_shell_command` 会执行改写后的
+命令。只有 QwenPaw 内置工具会被分类：`execute_shell_command` 为命令输出，`read_file`、`recall_history`、`view_image`、
+`view_video` 为文件内容，其余内置工具为 API 响应；Skill、MCP 工具以及后续 QwenPaw 版本新增的工具原样
+透传。QwenPaw 自己的工具结果裁剪在 Tokenless 之后运行，且保留结果头部（最近两条工具结果 50000 字节，更早的 3000
+字节，溢出部分写入 `tool_results/`），因此压缩结果末尾的恢复指令只在结果未超出该预算时可见；被省略的内容仍可用
+`tokenless retrieve` 从 Stash 取回。统计记录按 QwenPaw 工作区写入 `<workspace>/.tokenless`，运行 `tokenless stats list --data-dir` 时指向该目录。
 
 ## AgentScope 框架集成
 

--- a/scripts/check-component-versions.py
+++ b/scripts/check-component-versions.py
@@ -43,6 +43,7 @@ VERSION_TEMPLATES = (
     ("src/tokenless/Cargo.toml", "src/tokenless/adapters/tokenless/claude-code/.claude-plugin/plugin.json.in"),
     ("src/tokenless/Cargo.toml", "src/tokenless/adapters/tokenless/codex/.codex-plugin/plugin.json.in"),
     ("src/tokenless/Cargo.toml", "src/tokenless/adapters/tokenless/qwencode/qwen-extension.json.in"),
+    ("src/tokenless/Cargo.toml", "src/tokenless/adapters/tokenless/qwenpaw/plugin.json.in"),
 )
 AGENT_MEMORY_JSON = (
     "src/agent-memory/adapters/agent-memory/manifest.json",

--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -509,6 +509,8 @@ build_tokenless() {
         --exclude='adapters/tokenless/claude-code/.claude-plugin/plugin.json' \
         --exclude='adapters/tokenless/codex/.codex-plugin/plugin.json' \
         --exclude='adapters/tokenless/qwencode/qwen-extension.json' \
+        --exclude='adapters/tokenless/qwenpaw/plugin.json' \
+        --exclude='adapters/tokenless/qwenpaw/requirements.txt' \
         . | tar -xf - -C "$pkg_dir"
 
     tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}-${version}"

--- a/src/anolisa/crates/anolisa-core/src/adapter.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter.rs
@@ -33,6 +33,7 @@ pub mod manager;
 pub mod openclaw;
 pub mod qoder;
 pub mod qwencode;
+pub mod qwenpaw;
 pub mod registry;
 mod util;
 

--- a/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
@@ -589,6 +589,9 @@ pub enum DriverPayload {
     /// Qwen Code driver payload.
     #[serde(rename = "qwencode")]
     QwenCode(QwenCodeClaim),
+    /// QwenPaw driver payload.
+    #[serde(rename = "qwenpaw")]
+    QwenPaw(QwenPawClaim),
     /// DeepSeek Harness (`dsh`) native plugin payload.
     #[serde(rename = "dsh")]
     Dsh(DshClaim),
@@ -732,6 +735,19 @@ pub struct QwenCodeClaim {
     pub extension_dir_resource: String,
     /// Resource id of the installed extension
     /// ([`ClaimResourceKind::FrameworkPlugin`]).
+    pub plugin_resource: String,
+}
+
+/// QwenPaw driver payload. QwenPaw copies, validates and hot-loads the
+/// plugin through its own CLI; the receipt references the working directory
+/// and the installed plugin directory the CLI populated.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct QwenPawClaim {
+    /// Resource id of the QwenPaw working directory
+    /// ([`ClaimResourceKind::ExternalPath`]).
+    pub home_resource: String,
+    /// Resource id of the installed plugin directory
+    /// ([`ClaimResourceKind::ExternalPath`]).
     pub plugin_resource: String,
 }
 
@@ -1612,6 +1628,69 @@ mod tests {
         let json = serde_json::to_string(&claim).expect("serialize Hermes JSON");
         let parsed: AdapterClaim = serde_json::from_str(&json).expect("parse Hermes JSON");
         assert_eq!(claim, parsed);
+    }
+
+    fn sample_qwenpaw_claim() -> AdapterClaim {
+        AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: "tokenless".to_string(),
+            framework: "qwenpaw".to_string(),
+            plugin_id: Some("tokenless".to_string()),
+            adapter_type: Some("plugin".to_string()),
+            enabled_at: "2026-09-04T10:30:45Z".to_string(),
+            resource_root: PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/qwenpaw"),
+            bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            notices: Vec::new(),
+            resources: vec![
+                ClaimResource {
+                    id: "qwenpaw_home".to_string(),
+                    purpose: "qwenpaw_home".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/alice/.qwenpaw"),
+                    },
+                },
+                ClaimResource {
+                    id: "qwenpaw_plugin".to_string(),
+                    purpose: "qwenpaw_plugin_dir".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/alice/.qwenpaw/plugins/tokenless"),
+                    },
+                },
+            ],
+            driver_payload: DriverPayload::QwenPaw(QwenPawClaim {
+                home_resource: "qwenpaw_home".to_string(),
+                plugin_resource: "qwenpaw_plugin".to_string(),
+            }),
+        }
+    }
+
+    #[test]
+    fn qwenpaw_claim_round_trips_and_validates() {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Wrapper {
+            adapter_claims: Vec<AdapterClaim>,
+        }
+        let claim = sample_qwenpaw_claim();
+        let wrapper = Wrapper {
+            adapter_claims: vec![claim.clone()],
+        };
+        let text = toml::to_string_pretty(&wrapper).expect("serialize QwenPaw to TOML");
+        let parsed: Wrapper = toml::from_str(&text).expect("parse QwenPaw from TOML");
+        assert_eq!(
+            wrapper, parsed,
+            "QwenPaw round-trip mismatch; TOML:\n{text}"
+        );
+        let json = serde_json::to_string(&claim).expect("serialize QwenPaw JSON");
+        let parsed: AdapterClaim = serde_json::from_str(&json).expect("parse QwenPaw JSON");
+        assert_eq!(claim, parsed);
+        let layout = FsLayout::system(None);
+        claim
+            .validate(&layout, &[PathBuf::from("/home/alice/.qwenpaw")])
+            .expect("QwenPaw claim validates under its working directory");
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
@@ -793,7 +793,7 @@ pub fn find_binary_in_path(name: &str) -> Option<PathBuf> {
 }
 
 #[cfg(unix)]
-fn is_executable(path: &Path) -> bool {
+pub(crate) fn is_executable(path: &Path) -> bool {
     use std::os::unix::fs::PermissionsExt;
     path.metadata()
         .map(|m| m.permissions().mode() & 0o111 != 0)
@@ -801,6 +801,6 @@ fn is_executable(path: &Path) -> bool {
 }
 
 #[cfg(not(unix))]
-fn is_executable(_path: &Path) -> bool {
+pub(crate) fn is_executable(_path: &Path) -> bool {
     true
 }

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -3668,6 +3668,8 @@ fn allowed_adapter_types(framework: &str) -> Option<&'static [&'static str]> {
         "qoder" => Some(&["plugin"]),
         // dsh bundles are native plugins registered per explicit profile.
         "dsh" => Some(&["plugin"]),
+        // QwenPaw installs a directory-named plugin through its own CLI.
+        "qwenpaw" => Some(&["plugin"]),
         // Extension frameworks require an explicit type. Qwen Code delegates
         // artifact and activation mutations to its native CLI.
         "cosh" | "qwencode" => Some(&["extension"]),
@@ -4018,12 +4020,13 @@ fn plan_disable_report(claim: &AdapterClaim) -> DisableReport {
 
     // Resource ids that a real disable actually acts on. Empty plugin ids
     // (skill-bundle receipts carry no plugin resource) are excluded.
-    // `hermes_plugin_id` is the plugin resource id for Hermes receipts:
-    // real Hermes disable first runs `hermes plugins disable <id>` before
-    // removing the plugin directory, so its dry-run plan needs the extra
-    // CLI-disable line that OpenClaw (registry-only) does not.
+    // `cli_step` names the plugin resource id and verb for receipts whose
+    // real disable first runs a framework CLI step (`hermes plugins disable
+    // <id>`, `qwenpaw plugin uninstall <id>`) before removing the plugin
+    // directory, so their dry-run plan needs the extra CLI line that
+    // OpenClaw (registry-only) does not.
     let mut cleanup_ids: Vec<&str> = Vec::new();
-    let hermes_plugin_id: Option<&str> = match &claim.driver_payload {
+    let cli_step: Option<(&str, &str)> = match &claim.driver_payload {
         DriverPayload::OpenClaw(oc) => {
             cleanup_ids.extend(oc.skill_resources.iter().map(String::as_str));
             if !oc.plugin_resource.is_empty() {
@@ -4037,7 +4040,7 @@ fn plan_disable_report(claim: &AdapterClaim) -> DisableReport {
                 None
             } else {
                 cleanup_ids.push(&h.plugin_resource);
-                Some(h.plugin_resource.as_str())
+                Some((h.plugin_resource.as_str(), "disable"))
             }
         }
         DriverPayload::Cosh(c) => {
@@ -4085,6 +4088,10 @@ fn plan_disable_report(claim: &AdapterClaim) -> DisableReport {
             }
             None
         }
+        DriverPayload::QwenPaw(q) => {
+            cleanup_ids.push(&q.plugin_resource);
+            Some((q.plugin_resource.as_str(), "uninstall"))
+        }
     };
 
     // Whether disable uninstalls (Claude Code / Qoder semantics) rather than
@@ -4127,12 +4134,17 @@ fn plan_disable_report(claim: &AdapterClaim) -> DisableReport {
                 messages.push(format!("would remove symlink {}", link.display()));
             }
             ClaimResourceKind::ExternalPath { path } => {
-                // Hermes stores its plugin as a directory (ExternalPath) but
-                // disable also runs a CLI step first — surface it.
-                if Some(resource.id.as_str()) == hermes_plugin_id
+                // Hermes and QwenPaw store the plugin as a directory
+                // (ExternalPath) but disable also runs a CLI step first —
+                // surface it.
+                if let Some((cli_resource, verb)) = cli_step
+                    && cli_resource == resource.id
                     && let Some(plugin_id) = claim.plugin_id.as_deref()
                 {
-                    messages.push(format!("would disable hermes plugin '{plugin_id}'"));
+                    messages.push(format!(
+                        "would {verb} {} plugin '{plugin_id}'",
+                        claim.framework
+                    ));
                 }
                 messages.push(format!("would remove {}", path.display()));
             }
@@ -4956,11 +4968,20 @@ mod tests {
         assert!(ok("dsh", Some("plugin")));
         assert!(ok("dsh", None), "dsh defaults to plugin");
         assert!(ok("qwencode", Some("extension")));
+        assert!(ok("qwenpaw", Some("plugin")));
+        assert!(ok("qwenpaw", None), "qwenpaw defaults to plugin");
     }
 
     #[test]
     fn framework_type_matrix_rejects_extension_on_plugin_frameworks() {
-        for fw in ["openclaw", "hermes", "codex", "claude-code", "qoder"] {
+        for fw in [
+            "openclaw",
+            "hermes",
+            "codex",
+            "claude-code",
+            "qoder",
+            "qwenpaw",
+        ] {
             let err = validate_adapter_type_for_framework("tokenless", fw, Some("extension"))
                 .expect_err(&format!("{fw} + extension must be rejected"));
             assert!(
@@ -8809,6 +8830,76 @@ dest = "{datadir}/skills"
                 .iter()
                 .any(|m| m == "would remove /home/user/.hermes"),
             "must NOT claim to remove the hermes home: {:#?}",
+            report.messages
+        );
+    }
+
+    #[test]
+    fn plan_disable_report_qwenpaw_plugin_adapter() {
+        use crate::adapter::claim::{
+            CLAIM_SCHEMA_VERSION, ClaimResource, ClaimResourceKind, ClaimStatus,
+            DRIVER_SCHEMA_VERSION, DriverPayload, QwenPawClaim,
+        };
+
+        let claim = AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: "test-comp".to_string(),
+            framework: "qwenpaw".to_string(),
+            plugin_id: Some("test-comp".to_string()),
+            adapter_type: Some("plugin".to_string()),
+            enabled_at: "2026-09-04T00:00:00Z".to_string(),
+            resource_root: PathBuf::from("/fake/adapters/test-comp/qwenpaw"),
+            bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            notices: Vec::new(),
+            resources: vec![
+                ClaimResource {
+                    id: "qwenpaw_home".to_string(),
+                    purpose: "qwenpaw_home".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/user/.qwenpaw"),
+                    },
+                },
+                ClaimResource {
+                    id: "qwenpaw_plugin".to_string(),
+                    purpose: "qwenpaw_plugin_dir".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/user/.qwenpaw/plugins/test-comp"),
+                    },
+                },
+            ],
+            driver_payload: DriverPayload::QwenPaw(QwenPawClaim {
+                home_resource: "qwenpaw_home".to_string(),
+                plugin_resource: "qwenpaw_plugin".to_string(),
+            }),
+        };
+
+        let report = plan_disable_report(&claim);
+        assert!(
+            report
+                .messages
+                .iter()
+                .any(|m| m == "would uninstall qwenpaw plugin 'test-comp'"),
+            "must describe the qwenpaw CLI uninstall step: {:#?}",
+            report.messages
+        );
+        assert!(
+            report
+                .messages
+                .iter()
+                .any(|m| m == "would remove /home/user/.qwenpaw/plugins/test-comp"),
+            "must describe the plugin directory removal: {:#?}",
+            report.messages
+        );
+        assert!(
+            !report
+                .messages
+                .iter()
+                .any(|m| m == "would remove /home/user/.qwenpaw"),
+            "must NOT claim to remove the qwenpaw working directory: {:#?}",
             report.messages
         );
     }

--- a/src/anolisa/crates/anolisa-core/src/adapter/qwenpaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/qwenpaw.rs
@@ -1,0 +1,910 @@
+//! QwenPaw framework driver.
+//!
+//! QwenPaw keeps plugins under `<working dir>/plugins/<plugin_id>/` and owns
+//! their lifecycle through its own CLI: `qwenpaw plugin install <dir>`
+//! copies the bundle, validates the entry module, installs the bundle's
+//! `requirements.txt` into QwenPaw's Python environment and hot-loads the
+//! plugin when a QwenPaw server is running. ANOLISA therefore never copies
+//! the bundle itself; it hands the resource root to the CLI and verifies the
+//! post-condition (the installed `plugin.json`), because the CLI reports
+//! failures on stdout and still exits 0.
+//!
+//! The working directory mirrors QwenPaw's own resolution:
+//! `QWENPAW_WORKING_DIR`, else `COPAW_WORKING_DIR`, else `~/.copaw` when it
+//! exists, else `~/.qwenpaw`. `QWENPAW_BIN` overrides the executable (used
+//! by tests to point at a fake CLI). The installer's `bin/qwenpaw` wrapper
+//! lives under `${QWENPAW_HOME:-~/.qwenpaw}/bin`, which is rarely on a
+//! non-login PATH, so detection also probes that directory.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use super::AdapterError;
+use super::claim::{
+    AdapterClaim, CLAIM_SCHEMA_VERSION, ClaimResource, ClaimResourceKind, ClaimStatus,
+    DRIVER_SCHEMA_VERSION, DriverPayload, QwenPawClaim, validate_plugin_id,
+};
+use super::driver::{
+    AdapterBundle, AdapterCondition, AdapterConditionKind, AdapterOps, AdapterStatusReport,
+    AdapterSummary, ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx,
+    DriverPlan, FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
+    is_executable,
+};
+use super::util::{bool_status, cli_failure_reason, display_command, now_iso8601};
+
+/// `plugin install` copies the bundle and pip-installs its requirements
+/// (QwenPaw allows 300s offline, 120s for a hot install over HTTP).
+const INSTALL_TIMEOUT: Duration = Duration::from_secs(420);
+/// Timeout for `plugin uninstall`.
+const CLI_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Resource ids used in QwenPaw receipts.
+const RES_HOME: &str = "qwenpaw_home";
+const RES_PLUGIN: &str = "qwenpaw_plugin";
+
+/// QwenPaw-native plugin manifest inside the bundle and the installed
+/// plugin directory.
+const MANIFEST: &str = "plugin.json";
+
+/// QwenPaw driver. Stateless; all per-operation context arrives via
+/// [`DriverCtx`].
+pub struct QwenPawDriver;
+
+impl QwenPawDriver {
+    /// Construct the driver.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for QwenPawDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FrameworkDriver for QwenPawDriver {
+    fn name(&self) -> &'static str {
+        "qwenpaw"
+    }
+
+    fn detect(&self, env: &HostEnv) -> DetectResult {
+        match locate_qwenpaw(env.user_home.as_deref()) {
+            Some(path) => DetectResult {
+                detected: true,
+                reason: format!("qwenpaw CLI found at {}", path.display()),
+            },
+            None => {
+                let home_note = qwenpaw_home(env.user_home.as_deref())
+                    .filter(|h| h.exists())
+                    .map(|h| {
+                        format!(
+                            " (working dir {} exists but CLI is not on PATH)",
+                            h.display()
+                        )
+                    })
+                    .unwrap_or_default();
+                DetectResult {
+                    detected: false,
+                    reason: format!("qwenpaw CLI not found on PATH{home_note}"),
+                }
+            }
+        }
+    }
+
+    fn probe_bundle(&self, resource_root: &Path, declared_entry: Option<&str>) -> bool {
+        resource_root
+            .join(declared_entry.unwrap_or(MANIFEST))
+            .is_file()
+    }
+
+    fn allowed_external_roots(&self, ctx: &DriverCtx) -> Vec<PathBuf> {
+        // The CLI writes only under the working directory. Also allow both
+        // default locations so a receipt stays verifiable after `~/.copaw`
+        // appears or disappears.
+        let mut roots: Vec<PathBuf> = qwenpaw_home(ctx.user_home.as_deref()).into_iter().collect();
+        if let Some(home) = ctx.user_home.as_deref() {
+            for default in [".qwenpaw", ".copaw"] {
+                let path = home.join(default);
+                if !roots.contains(&path) {
+                    roots.push(path);
+                }
+            }
+        }
+        roots
+    }
+
+    fn read_bundle(&self, ctx: &DriverCtx) -> Result<AdapterBundle, AdapterError> {
+        let root = &ctx.resource_root;
+        if !root.is_dir() {
+            return Err(AdapterError::BundleInvalid {
+                root: root.clone(),
+                reason: "resource root does not exist or is not a directory".to_string(),
+            });
+        }
+        // QwenPaw installs the plugin under the id written in plugin.json,
+        // so the receipt must carry that id — never a guessed one.
+        let manifest = root.join(ctx.declared_bundle_entry.as_deref().unwrap_or(MANIFEST));
+        let bytes = std::fs::read(&manifest).map_err(|source| AdapterError::Io {
+            path: manifest.clone(),
+            source,
+        })?;
+        let plugin_id = parse_manifest_id(&bytes).ok_or_else(|| AdapterError::BundleInvalid {
+            root: root.clone(),
+            reason: format!(
+                "{} is not a QwenPaw plugin manifest with a non-empty \"id\"",
+                manifest.display()
+            ),
+        })?;
+        if let Some(declared) = ctx
+            .declared_plugin_id
+            .as_deref()
+            .filter(|id| !id.is_empty())
+            && declared != plugin_id
+        {
+            return Err(AdapterError::BundleInvalid {
+                root: root.clone(),
+                reason: format!(
+                    "manifest declares plugin_id '{declared}' but {} has id '{plugin_id}'",
+                    manifest.display()
+                ),
+            });
+        }
+        Ok(AdapterBundle {
+            resource_root: root.clone(),
+            plugin_id: Some(plugin_id),
+        })
+    }
+
+    fn plan_enable(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<DriverPlan, AdapterError> {
+        let home = require_home(ctx)?;
+        let plugin_id = require_plugin_id(bundle)?;
+        validate_plugin_id(&plugin_id)?;
+        let install_cmd = build_install_cmd(&home, ctx.user_home.as_deref(), &bundle.resource_root);
+        Ok(DriverPlan {
+            framework: self.name().to_string(),
+            component: ctx.component.clone(),
+            actions: vec![format!(
+                "install qwenpaw plugin '{plugin_id}' from {} into {}/plugins/{plugin_id} via the qwenpaw CLI",
+                bundle.resource_root.display(),
+                home.display(),
+            )],
+            register_command: Some(display_command(&install_cmd)),
+        })
+    }
+
+    fn prepare_enable(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<(AdapterClaim, PreparedEnable), AdapterError> {
+        let home = require_home(ctx)?;
+        let plugin_id = require_plugin_id(bundle)?;
+        validate_plugin_id(&plugin_id)?;
+        let resources = vec![
+            ClaimResource {
+                id: RES_HOME.to_string(),
+                purpose: "qwenpaw_home".to_string(),
+                kind: ClaimResourceKind::ExternalPath { path: home.clone() },
+            },
+            ClaimResource {
+                id: RES_PLUGIN.to_string(),
+                purpose: "qwenpaw_plugin_dir".to_string(),
+                kind: ClaimResourceKind::ExternalPath {
+                    path: home.join("plugins").join(&plugin_id),
+                },
+            },
+        ];
+        Ok((
+            AdapterClaim {
+                claim_schema: CLAIM_SCHEMA_VERSION,
+                component: ctx.component.clone(),
+                framework: self.name().to_string(),
+                plugin_id: Some(plugin_id),
+                adapter_type: ctx.adapter_type.clone(),
+                enabled_at: now_iso8601(),
+                resource_root: bundle.resource_root.clone(),
+                bundle_digest: None,
+                source_revision: None,
+                materialized_files: Vec::new(),
+                driver_schema: DRIVER_SCHEMA_VERSION,
+                status: ClaimStatus::Enabled,
+                notices: Vec::new(),
+                resources,
+                driver_payload: DriverPayload::QwenPaw(QwenPawClaim {
+                    home_resource: RES_HOME.to_string(),
+                    plugin_resource: RES_PLUGIN.to_string(),
+                }),
+            },
+            PreparedEnable::None,
+        ))
+    }
+
+    fn apply_enable(
+        &self,
+        claim: &mut AdapterClaim,
+        _prepared: &PreparedEnable,
+        ctx: &DriverCtx,
+        _progress: &mut dyn super::driver::EnableProgress,
+    ) -> Result<(), AdapterError> {
+        let home = require_home(ctx)?;
+        let plugin_id = claim
+            .plugin_id
+            .clone()
+            .ok_or_else(|| AdapterError::BundleInvalid {
+                root: claim.resource_root.clone(),
+                reason: "qwenpaw receipt has no plugin id".to_string(),
+            })?;
+        validate_plugin_id(&plugin_id)?;
+
+        let install_cmd = build_install_cmd(&home, ctx.user_home.as_deref(), &claim.resource_root);
+        let program = install_cmd.program.clone();
+        let output = ctx.ops.run_framework_cli(install_cmd)?;
+        if !output.success() {
+            return Err(AdapterError::FrameworkCli {
+                program,
+                reason: cli_failure_reason("plugin install", &output),
+            });
+        }
+        // The CLI echoes failures and exits 0, and a failed reinstall leaves
+        // the previous bundle in place: only installed files that match the
+        // source bundle prove the install happened.
+        let installed_dir = home.join("plugins").join(&plugin_id);
+        if let Some(reason) =
+            installed_bundle_mismatch(ctx.ops, &claim.resource_root, &installed_dir, &plugin_id)?
+        {
+            let hint = output
+                .stderr
+                .lines()
+                .chain(output.stdout.lines())
+                .map(str::trim)
+                .rfind(|line| !line.is_empty())
+                .unwrap_or("no output")
+                .to_string();
+            return Err(AdapterError::FrameworkCli {
+                program,
+                reason: format!("'plugin install' exited 0 but {reason}: {hint}"),
+            });
+        }
+        Ok(())
+    }
+
+    fn status(
+        &self,
+        claim: &AdapterClaim,
+        ctx: &DriverCtx,
+    ) -> Result<AdapterStatusReport, AdapterError> {
+        let detect = self.detect(&HostEnv {
+            user_home: ctx.user_home.clone(),
+        });
+        let mut conditions = vec![AdapterCondition {
+            kind: AdapterConditionKind::FrameworkDetected,
+            status: bool_status(detect.detected),
+            reason: Some(detect.reason.clone()),
+            resource: None,
+        }];
+
+        let plugin_ref = Some(ClaimResourceRef {
+            id: RES_PLUGIN.to_string(),
+        });
+        // The installed manifest is the registry: QwenPaw scans
+        // <working dir>/plugins at startup and `plugin list` is the same
+        // directory scan, so status does not need the CLI.
+        let plugin_registered = match (claim.plugin_id.as_deref(), plugin_dir(claim)) {
+            (Some(plugin_id), Some(dir)) => match installed_id(ctx.ops, &dir.join(MANIFEST)) {
+                Ok(installed) => {
+                    let registered = installed.as_deref() == Some(plugin_id);
+                    conditions.push(AdapterCondition {
+                        kind: AdapterConditionKind::PluginRegistered,
+                        status: bool_status(registered),
+                        reason: (!registered).then(|| match installed {
+                            Some(other) => format!("{} belongs to plugin '{other}'", dir.display()),
+                            None => format!("{} has no plugin manifest", dir.display()),
+                        }),
+                        resource: plugin_ref,
+                    });
+                    conditions.push(AdapterCondition {
+                        kind: AdapterConditionKind::VerificationSupported,
+                        status: ConditionStatus::True,
+                        reason: None,
+                        resource: None,
+                    });
+                    bool_status(registered)
+                }
+                Err(err) => {
+                    conditions.push(AdapterCondition {
+                        kind: AdapterConditionKind::PluginRegistered,
+                        status: ConditionStatus::Unknown,
+                        reason: Some(format!("cannot read {}: {err}", dir.display())),
+                        resource: plugin_ref,
+                    });
+                    conditions.push(AdapterCondition {
+                        kind: AdapterConditionKind::VerificationSupported,
+                        status: ConditionStatus::False,
+                        reason: Some("installed plugin manifest unreadable".to_string()),
+                        resource: None,
+                    });
+                    ConditionStatus::Unknown
+                }
+            },
+            _ => {
+                conditions.push(AdapterCondition {
+                    kind: AdapterConditionKind::PluginRegistered,
+                    status: ConditionStatus::Unknown,
+                    reason: Some("receipt has no plugin id or plugin resource".to_string()),
+                    resource: None,
+                });
+                conditions.push(AdapterCondition {
+                    kind: AdapterConditionKind::VerificationSupported,
+                    status: ConditionStatus::False,
+                    reason: Some("receipt is incomplete".to_string()),
+                    resource: None,
+                });
+                ConditionStatus::Unknown
+            }
+        };
+
+        let summary = if claim.status == ClaimStatus::CleanupFailed {
+            AdapterSummary::CleanupFailed
+        } else if !detect.detected {
+            AdapterSummary::Degraded
+        } else {
+            match plugin_registered {
+                ConditionStatus::True => AdapterSummary::Healthy,
+                ConditionStatus::False => AdapterSummary::Degraded,
+                ConditionStatus::Unknown => AdapterSummary::Unknown,
+            }
+        };
+        Ok(AdapterStatusReport {
+            summary,
+            conditions,
+        })
+    }
+
+    fn disable(
+        &self,
+        claim: &AdapterClaim,
+        ctx: &DriverCtx,
+    ) -> Result<DisableReport, AdapterError> {
+        let Some(plugin_id) = claim.plugin_id.clone() else {
+            return Ok(DisableReport {
+                cleanup_complete: true,
+                messages: vec!["receipt records no plugin to uninstall".to_string()],
+            });
+        };
+        // prepare_enable records both paths, so a receipt without them is
+        // damaged: keep it rather than orphan an installed plugin.
+        let (Some(home), Some(dir)) = (claim_home(claim), plugin_dir(claim)) else {
+            return Ok(DisableReport {
+                cleanup_complete: false,
+                messages: vec![
+                    "receipt does not record the qwenpaw working and plugin directories; \
+                     receipt kept for inspection"
+                        .to_string(),
+                ],
+            });
+        };
+        validate_plugin_id(&plugin_id)?;
+        if locate_qwenpaw(ctx.user_home.as_deref()).is_none() {
+            // Deleting the directory under a running QwenPaw would leave the
+            // plugin loaded; keep the receipt so cleanup can be retried.
+            return Ok(DisableReport {
+                cleanup_complete: false,
+                messages: vec![
+                    "qwenpaw CLI not found on PATH; receipt kept so cleanup can be retried"
+                        .to_string(),
+                ],
+            });
+        }
+
+        let mut messages = Vec::new();
+        let uninstall_cmd = build_uninstall_cmd(&home, ctx.user_home.as_deref(), &plugin_id);
+        match ctx.ops.run_framework_cli(uninstall_cmd) {
+            Ok(output) if output.success() => {}
+            Ok(output) => messages.push(cli_failure_reason("plugin uninstall", &output)),
+            Err(err) => messages.push(format!("'plugin uninstall' could not run: {err}")),
+        }
+        // The CLI reports failures on stdout and still exits 0, so only the
+        // manifest being gone proves QwenPaw unloaded the plugin; otherwise a
+        // running QwenPaw may still have it loaded, so keep the directory and
+        // the receipt for a retry.
+        if installed_id(ctx.ops, &dir.join(MANIFEST))?.is_some() {
+            messages.push(format!(
+                "qwenpaw plugin directory {} kept; receipt kept so cleanup can be retried",
+                dir.display()
+            ));
+            return Ok(DisableReport {
+                cleanup_complete: false,
+                messages,
+            });
+        }
+        messages.push(format!("uninstalled qwenpaw plugin '{plugin_id}'"));
+        let mut cleanup_complete = true;
+        match ctx.ops.remove_tree(&dir) {
+            Ok(true) => messages.push(format!(
+                "removed qwenpaw plugin directory {}",
+                dir.display()
+            )),
+            Ok(false) => messages.push(format!(
+                "qwenpaw plugin directory {} already absent",
+                dir.display()
+            )),
+            Err(err) => {
+                cleanup_complete = false;
+                messages.push(format!(
+                    "failed to remove qwenpaw plugin directory {}: {err}",
+                    dir.display()
+                ));
+            }
+        }
+        Ok(DisableReport {
+            cleanup_complete,
+            messages,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (no spawning) — unit-testable
+// ---------------------------------------------------------------------------
+
+/// `QWENPAW_BIN` override, else `qwenpaw`.
+fn qwenpaw_bin() -> String {
+    std::env::var("QWENPAW_BIN")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "qwenpaw".to_string())
+}
+
+/// Non-empty value of an environment variable with trailing slashes trimmed.
+fn env_path(key: &str) -> Option<PathBuf> {
+    let value = std::env::var_os(key)?;
+    let value = value.to_string_lossy();
+    let trimmed = value.trim_end_matches('/');
+    (!trimmed.is_empty()).then(|| PathBuf::from(trimmed))
+}
+
+/// QwenPaw working directory, resolved exactly like QwenPaw's `constant.py`:
+/// `QWENPAW_WORKING_DIR`, else `COPAW_WORKING_DIR`, else `~/.copaw` when it
+/// is a directory, else `~/.qwenpaw`.
+fn qwenpaw_home(user_home: Option<&Path>) -> Option<PathBuf> {
+    if let Some(dir) = env_path("QWENPAW_WORKING_DIR").or_else(|| env_path("COPAW_WORKING_DIR")) {
+        return Some(dir);
+    }
+    let home = user_home?;
+    let copaw = home.join(".copaw");
+    Some(if copaw.is_dir() {
+        copaw
+    } else {
+        home.join(".qwenpaw")
+    })
+}
+
+/// Directories the installer's `bin/qwenpaw` wrapper commonly lives in.
+fn path_prepend(user_home: Option<&Path>) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(dir) = env_path("QWENPAW_HOME") {
+        dirs.push(dir.join("bin"));
+    } else if let Some(home) = user_home {
+        dirs.push(home.join(".qwenpaw").join("bin"));
+    }
+    if let Some(home) = user_home {
+        dirs.push(home.join(".local").join("bin"));
+    }
+    dirs.push(PathBuf::from("/usr/local/bin"));
+    dirs
+}
+
+/// Locate the CLI on `PATH` or in one of the [`path_prepend`] directories.
+fn locate_qwenpaw(user_home: Option<&Path>) -> Option<PathBuf> {
+    let bin = qwenpaw_bin();
+    find_binary_in_path(&bin).or_else(|| {
+        path_prepend(user_home)
+            .into_iter()
+            .map(|dir| dir.join(&bin))
+            .find(|candidate| candidate.is_file() && is_executable(candidate))
+    })
+}
+
+/// Build a `qwenpaw` command pinned to `home`. `COPAW_WORKING_DIR` is
+/// dropped so the child cannot resolve a different working directory than
+/// the one the receipt claims.
+fn base_cmd(
+    home: &Path,
+    user_home: Option<&Path>,
+    args: Vec<String>,
+    timeout: Duration,
+) -> FrameworkCommand {
+    FrameworkCommand {
+        program: qwenpaw_bin(),
+        args,
+        stdin: None,
+        env_set: vec![(
+            "QWENPAW_WORKING_DIR".to_string(),
+            home.to_string_lossy().into_owned(),
+        )],
+        env_remove: vec!["COPAW_WORKING_DIR".to_string()],
+        path_prepend: path_prepend(user_home),
+        timeout,
+    }
+}
+
+/// Build `qwenpaw plugin install <resource_root> --force`.
+fn build_install_cmd(
+    home: &Path,
+    user_home: Option<&Path>,
+    resource_root: &Path,
+) -> FrameworkCommand {
+    base_cmd(
+        home,
+        user_home,
+        vec![
+            "plugin".to_string(),
+            "install".to_string(),
+            resource_root.to_string_lossy().into_owned(),
+            "--force".to_string(),
+        ],
+        INSTALL_TIMEOUT,
+    )
+}
+
+/// Build `qwenpaw plugin uninstall <plugin_id>`, answering its confirmation
+/// prompt on stdin.
+fn build_uninstall_cmd(home: &Path, user_home: Option<&Path>, plugin_id: &str) -> FrameworkCommand {
+    let mut cmd = base_cmd(
+        home,
+        user_home,
+        vec![
+            "plugin".to_string(),
+            "uninstall".to_string(),
+            plugin_id.to_string(),
+        ],
+        CLI_TIMEOUT,
+    );
+    cmd.stdin = Some(b"y\n".to_vec());
+    cmd
+}
+
+/// Non-empty `id` of a QwenPaw `plugin.json`.
+fn parse_manifest_id(bytes: &[u8]) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct PluginManifest {
+        id: Option<String>,
+    }
+    serde_json::from_slice::<PluginManifest>(bytes)
+        .ok()?
+        .id
+        .filter(|id| !id.is_empty())
+}
+
+/// Plugin id recorded by an installed manifest, `None` when the manifest is
+/// absent or not a QwenPaw plugin manifest.
+fn installed_id(ops: &dyn AdapterOps, manifest: &Path) -> Result<Option<String>, AdapterError> {
+    Ok(ops
+        .read_file(manifest)?
+        .and_then(|bytes| parse_manifest_id(&bytes)))
+}
+
+/// Files `qwenpaw plugin install` copies verbatim from the bundle. Verified
+/// against QwenPaw 2.2.0, which copies the bundle directory as-is; re-verify
+/// when a QwenPaw release starts rewriting any of them. Subdirectories are
+/// not compared.
+const BUNDLE_FILES: [&str; 3] = [MANIFEST, "plugin.py", "requirements.txt"];
+
+/// Why the installed directory does not hold the source bundle, if it does not.
+fn installed_bundle_mismatch(
+    ops: &dyn AdapterOps,
+    source_root: &Path,
+    installed_dir: &Path,
+    plugin_id: &str,
+) -> Result<Option<String>, AdapterError> {
+    let manifest = installed_dir.join(MANIFEST);
+    if installed_id(ops, &manifest)?.as_deref() != Some(plugin_id) {
+        return Ok(Some(format!(
+            "{} does not describe plugin '{plugin_id}'",
+            manifest.display()
+        )));
+    }
+    for file in BUNDLE_FILES {
+        if ops.read_file(&source_root.join(file))? != ops.read_file(&installed_dir.join(file))? {
+            return Ok(Some(format!(
+                "{} does not match the source bundle",
+                installed_dir.join(file).display()
+            )));
+        }
+    }
+    Ok(None)
+}
+
+/// External path recorded in the receipt under `resource`.
+fn external_path(claim: &AdapterClaim, resource: &str) -> Option<PathBuf> {
+    match &claim.resource(resource)?.kind {
+        ClaimResourceKind::ExternalPath { path } => Some(path.clone()),
+        _ => None,
+    }
+}
+
+/// Installed plugin directory recorded in the receipt.
+fn plugin_dir(claim: &AdapterClaim) -> Option<PathBuf> {
+    let DriverPayload::QwenPaw(payload) = &claim.driver_payload else {
+        return None;
+    };
+    external_path(claim, &payload.plugin_resource)
+}
+
+/// Working directory recorded in the receipt. The ambient resolution follows
+/// the environment and whether `~/.copaw` exists, both of which may have
+/// changed since enable, so disable must not re-resolve it.
+fn claim_home(claim: &AdapterClaim) -> Option<PathBuf> {
+    let DriverPayload::QwenPaw(payload) = &claim.driver_payload else {
+        return None;
+    };
+    external_path(claim, &payload.home_resource)
+}
+
+/// Plugin id from a bundle, or [`AdapterError::BundleInvalid`] when none
+/// is resolvable.
+fn require_plugin_id(bundle: &AdapterBundle) -> Result<String, AdapterError> {
+    bundle
+        .plugin_id
+        .clone()
+        .ok_or_else(|| AdapterError::BundleInvalid {
+            root: bundle.resource_root.clone(),
+            reason: "no plugin id in plugin.json".to_string(),
+        })
+}
+
+/// QwenPaw working directory, or [`AdapterError::FrameworkCli`] when `$HOME`
+/// is unresolvable and no working-dir variable is set.
+fn require_home(ctx: &DriverCtx) -> Result<PathBuf, AdapterError> {
+    qwenpaw_home(ctx.user_home.as_deref()).ok_or_else(|| AdapterError::FrameworkCli {
+        program: qwenpaw_bin(),
+        reason: "cannot resolve QwenPaw working directory (no $HOME and no QWENPAW_WORKING_DIR)"
+            .to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::{OsStr, OsString};
+    use std::sync::{Mutex, MutexGuard};
+
+    const ENV_KEYS: [&str; 4] = [
+        "QWENPAW_BIN",
+        "QWENPAW_WORKING_DIR",
+        "COPAW_WORKING_DIR",
+        "QWENPAW_HOME",
+    ];
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        saved: [(&'static str, Option<OsString>); 4],
+    }
+
+    impl EnvGuard {
+        fn acquire() -> Self {
+            let lock = ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let saved = ENV_KEYS.map(|key| (key, std::env::var_os(key)));
+            // SAFETY: every QwenPaw unit test that reads or mutates these
+            // process-wide variables holds ENV_LOCK.
+            unsafe {
+                for key in ENV_KEYS {
+                    std::env::remove_var(key);
+                }
+            }
+            Self { _lock: lock, saved }
+        }
+
+        fn set(&self, key: &'static str, value: impl AsRef<OsStr>) {
+            assert!(ENV_KEYS.contains(&key));
+            // SAFETY: this guard holds ENV_LOCK.
+            unsafe { std::env::set_var(key, value) }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: the lock remains held while restoring the original
+            // process environment for the next test.
+            unsafe {
+                for (key, value) in &self.saved {
+                    match value {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn working_dir_resolution_matches_qwenpaw() {
+        let env = EnvGuard::acquire();
+        let home = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            qwenpaw_home(Some(home.path())),
+            Some(home.path().join(".qwenpaw"))
+        );
+        std::fs::create_dir(home.path().join(".copaw")).expect("mkdir");
+        assert_eq!(
+            qwenpaw_home(Some(home.path())),
+            Some(home.path().join(".copaw"))
+        );
+        env.set("COPAW_WORKING_DIR", "/opt/copaw/");
+        assert_eq!(
+            qwenpaw_home(Some(home.path())),
+            Some(PathBuf::from("/opt/copaw"))
+        );
+        env.set("QWENPAW_WORKING_DIR", "/opt/qwenpaw");
+        assert_eq!(
+            qwenpaw_home(Some(home.path())),
+            Some(PathBuf::from("/opt/qwenpaw"))
+        );
+        env.set("QWENPAW_WORKING_DIR", "");
+        assert_eq!(
+            qwenpaw_home(Some(home.path())),
+            Some(PathBuf::from("/opt/copaw"))
+        );
+        env.set("COPAW_WORKING_DIR", "");
+        assert_eq!(qwenpaw_home(None), None);
+    }
+
+    #[test]
+    fn install_cmd_pins_working_dir_and_forces_overwrite() {
+        let env = EnvGuard::acquire();
+        env.set("QWENPAW_HOME", "/opt/qwenpaw-venv");
+        let cmd = build_install_cmd(
+            Path::new("/home/alice/.qwenpaw"),
+            Some(Path::new("/home/alice")),
+            Path::new("/usr/share/anolisa/adapters/tokenless/qwenpaw"),
+        );
+        assert_eq!(cmd.program, "qwenpaw");
+        assert_eq!(
+            cmd.args,
+            vec![
+                "plugin",
+                "install",
+                "/usr/share/anolisa/adapters/tokenless/qwenpaw",
+                "--force"
+            ]
+        );
+        assert_eq!(
+            cmd.env_set,
+            vec![(
+                "QWENPAW_WORKING_DIR".to_string(),
+                "/home/alice/.qwenpaw".to_string()
+            )]
+        );
+        assert_eq!(cmd.env_remove, vec!["COPAW_WORKING_DIR"]);
+        assert_eq!(
+            cmd.path_prepend,
+            vec![
+                PathBuf::from("/opt/qwenpaw-venv/bin"),
+                PathBuf::from("/home/alice/.local/bin"),
+                PathBuf::from("/usr/local/bin"),
+            ]
+        );
+        assert_eq!(cmd.timeout, INSTALL_TIMEOUT);
+        assert!(cmd.stdin.is_none());
+    }
+
+    #[test]
+    fn uninstall_cmd_answers_confirmation() {
+        let env = EnvGuard::acquire();
+        env.set("QWENPAW_BIN", "/opt/bin/qwenpaw");
+        let cmd = build_uninstall_cmd(
+            Path::new("/home/alice/.qwenpaw"),
+            Some(Path::new("/home/alice")),
+            "tokenless",
+        );
+        assert_eq!(cmd.program, "/opt/bin/qwenpaw");
+        assert_eq!(cmd.args, vec!["plugin", "uninstall", "tokenless"]);
+        assert_eq!(cmd.stdin.as_deref(), Some(&b"y\n"[..]));
+        assert_eq!(
+            cmd.path_prepend[0],
+            PathBuf::from("/home/alice/.qwenpaw/bin")
+        );
+    }
+
+    #[test]
+    fn manifest_id_requires_non_empty_id() {
+        assert_eq!(
+            parse_manifest_id(br#"{"id":"tokenless","version":"1.0.0"}"#).as_deref(),
+            Some("tokenless")
+        );
+        assert_eq!(parse_manifest_id(br#"{"id":""}"#), None);
+        assert_eq!(parse_manifest_id(br#"{"name":"x"}"#), None);
+        assert_eq!(parse_manifest_id(b"not json"), None);
+    }
+
+    #[test]
+    fn read_bundle_rejects_declared_id_mismatch() {
+        use crate::adapter::driver::{AdapterOps, CliOutput};
+
+        struct StubOps;
+        impl AdapterOps for StubOps {
+            fn run_framework_cli(&self, _: FrameworkCommand) -> Result<CliOutput, AdapterError> {
+                unimplemented!()
+            }
+            fn copy_tree(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+            fn copy_file(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+            fn remove_tree(&self, _: &Path) -> Result<bool, AdapterError> {
+                unimplemented!()
+            }
+            fn write_file(&self, _: &Path, _: &[u8]) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+            fn create_symlink(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+            fn read_file(&self, _: &Path) -> Result<Option<Vec<u8>>, AdapterError> {
+                unimplemented!()
+            }
+        }
+
+        let _env = EnvGuard::acquire();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(MANIFEST), br#"{"id":"tokenless"}"#).expect("write");
+        let layout = anolisa_platform::fs_layout::FsLayout::user(dir.path().join("home"));
+        let ops = StubOps;
+        let mut ctx = DriverCtx {
+            component: "tokenless".to_string(),
+            framework: "qwenpaw".to_string(),
+            layout: &layout,
+            resource_root: dir.path().to_path_buf(),
+            user_home: Some(dir.path().join("home")),
+            declared_plugin_id: Some("other".to_string()),
+            requested_profiles: Vec::new(),
+            adapter_type: Some("plugin".to_string()),
+            declared_skills: Vec::new(),
+            declared_config: Vec::new(),
+            declared_bundle_entry: Some(MANIFEST.to_string()),
+            framework_version_req: None,
+            allow_unsafe_plugin_install: false,
+            dry_run: true,
+            ops: &ops,
+        };
+        let err = QwenPawDriver::new()
+            .read_bundle(&ctx)
+            .expect_err("mismatch must be rejected");
+        assert!(matches!(err, AdapterError::BundleInvalid { .. }), "{err:?}");
+
+        ctx.declared_plugin_id = Some("tokenless".to_string());
+        let bundle = QwenPawDriver::new().read_bundle(&ctx).expect("bundle");
+        assert_eq!(bundle.plugin_id.as_deref(), Some("tokenless"));
+        let plan = QwenPawDriver::new()
+            .plan_enable(&bundle, &ctx)
+            .expect("plan");
+        let expected_home = dir.path().join("home").join(".qwenpaw");
+        assert_eq!(
+            plan.register_command.as_deref(),
+            Some(
+                format!(
+                    "QWENPAW_WORKING_DIR={} qwenpaw plugin install {} --force",
+                    expected_home.display(),
+                    dir.path().display()
+                )
+                .as_str()
+            )
+        );
+        let (claim, _) = QwenPawDriver::new()
+            .prepare_enable(&bundle, &ctx)
+            .expect("claim");
+        assert_eq!(
+            plugin_dir(&claim),
+            Some(expected_home.join("plugins").join("tokenless"))
+        );
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/adapter/registry.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/registry.rs
@@ -13,6 +13,7 @@ use super::hermes::HermesDriver;
 use super::openclaw::OpenClawDriver;
 use super::qoder::QoderDriver;
 use super::qwencode::QwenCodeDriver;
+use super::qwenpaw::QwenPawDriver;
 
 /// Immutable collection of the built-in framework drivers.
 pub struct DriverRegistry {
@@ -32,6 +33,7 @@ impl DriverRegistry {
                 Box::new(ClaudeCodeDriver::new()),
                 Box::new(QoderDriver::new()),
                 Box::new(QwenCodeDriver::new()),
+                Box::new(QwenPawDriver::new()),
             ],
         }
     }
@@ -76,6 +78,7 @@ mod tests {
         assert!(reg.contains("claude-code"));
         assert!(reg.contains("qoder"));
         assert!(reg.contains("qwencode"));
+        assert!(reg.contains("qwenpaw"));
         assert_eq!(
             reg.names(),
             vec![
@@ -86,7 +89,8 @@ mod tests {
                 "codex",
                 "claude-code",
                 "qoder",
-                "qwencode"
+                "qwencode",
+                "qwenpaw"
             ]
         );
     }

--- a/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
@@ -57,6 +57,12 @@ const MANAGED_ENV: &[&str] = &[
     "FAKE_QODER_LARGE_INVENTORY",
     "FAKE_QODER_PLUGIN_ID",
     "FAKE_QODER_PROJECT_PLUGIN",
+    "QWENPAW_BIN",
+    "QWENPAW_WORKING_DIR",
+    "COPAW_WORKING_DIR",
+    "QWENPAW_HOME",
+    "FAKE_QWENPAW_LOG",
+    "FAKE_QWENPAW_FAIL",
 ];
 
 struct EnvGuard {
@@ -3824,4 +3830,424 @@ fn claude_code_external_rpm_root_needs_no_anchor_stays_v5() {
         "anchor-free state must stay at v5, got:\n{}",
         state_text.lines().take(3).collect::<Vec<_>>().join("\n")
     );
+}
+
+// ---------------------------------------------------------------------------
+// QwenPaw
+// ---------------------------------------------------------------------------
+
+fn stage_qwenpaw_bundle(root: &Path) {
+    std::fs::write(
+        root.join("plugin.json"),
+        br#"{"id":"tokenless","name":"Tokenless","version":"0.6.0","entry":{"backend":"plugin.py"}}"#,
+    )
+    .expect("plugin.json");
+    std::fs::write(root.join("plugin.py"), b"plugin = None\n").expect("plugin.py");
+    std::fs::write(root.join("requirements.txt"), b"anolisa-tokenless\n").expect("requirements");
+}
+
+/// Fake `qwenpaw` CLI. Like the real one it copies the bundle into
+/// `$QWENPAW_WORKING_DIR/plugins/<id>`, asks for confirmation on uninstall,
+/// and exits 0 even when an install or uninstall fails
+/// (`FAKE_QWENPAW_FAIL=install|uninstall`), leaving the installed tree in
+/// place.
+fn write_fake_qwenpaw(dir: &Path) -> PathBuf {
+    let path = dir.join("qwenpaw");
+    write_exec(
+        &path,
+        r#"#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_QWENPAW_LOG"
+printf 'WORKING_DIR=%s\n' "${QWENPAW_WORKING_DIR:-unset}" >> "$FAKE_QWENPAW_LOG"
+plugins="$QWENPAW_WORKING_DIR/plugins"
+if [ "$1" = plugin ] && [ "$2" = install ]; then
+  if [ "$FAKE_QWENPAW_FAIL" = install ]; then
+    echo "❌ Failed to install plugin: simulated"
+    exit 0
+  fi
+  id=$(sed -n 's/.*"id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$3/plugin.json" | head -n1)
+  dst="$plugins/$id"
+  if [ -d "$dst" ] && [ "$4" != "--force" ]; then
+    echo "❌ Plugin '$id' already installed. Use --force to overwrite."
+    exit 0
+  fi
+  rm -rf "$dst"
+  mkdir -p "$plugins"
+  cp -R "$3" "$dst"
+  exit 0
+fi
+if [ "$1" = plugin ] && [ "$2" = uninstall ]; then
+  read -r answer
+  [ "$answer" = y ] || exit 1
+  if [ "$FAKE_QWENPAW_FAIL" = uninstall ]; then
+    echo "❌ Failed to uninstall plugin: simulated"
+    exit 0
+  fi
+  rm -rf "$plugins/$3"
+  exit 0
+fi
+exit 0
+"#,
+    );
+    path
+}
+
+fn apply_qwenpaw_env(guard: &EnvGuard, world: &World, fake_bin: &Path) -> (PathBuf, PathBuf) {
+    let log = world.prefix.join("qwenpaw.log");
+    guard.set("QWENPAW_BIN", fake_bin);
+    guard.set("FAKE_QWENPAW_LOG", &log);
+    let plugin_dir = world.user_home.join(".qwenpaw/plugins/tokenless");
+    (log, plugin_dir)
+}
+
+fn stage_qwenpaw() -> World {
+    stage(
+        "qwenpaw",
+        "plugin",
+        "{datadir}/adapters/{component}/qwenpaw/",
+        stage_qwenpaw_bundle,
+    )
+}
+
+#[test]
+fn qwenpaw_enable_status_disable_delegates_to_cli() {
+    let guard = EnvGuard::acquire();
+    let world = stage_qwenpaw();
+    let fake = write_fake_qwenpaw(&world.prefix);
+    let (log, plugin_dir) = apply_qwenpaw_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    let claim = match manager
+        .enable(COMPONENT, Some("qwenpaw"), false)
+        .expect("enable")
+    {
+        EnableOutcome::Enabled(c) => *c,
+        EnableOutcome::Planned { .. } => panic!("expected enabled"),
+    };
+    assert_eq!(claim.plugin_id.as_deref(), Some("tokenless"));
+    assert!(matches!(claim.driver_payload, DriverPayload::QwenPaw(_)));
+    assert!(
+        claim.materialized_files.is_empty(),
+        "qwenpaw owns the copied tree; ANOLISA must not claim its files"
+    );
+
+    let log_text = std::fs::read_to_string(&log).expect("qwenpaw log");
+    assert!(
+        log_text
+            .lines()
+            .any(|l| l == format!("plugin install {} --force", world.resource_root.display())),
+        "must hand the bundle root to the CLI: {log_text}"
+    );
+    assert!(
+        log_text
+            .lines()
+            .any(|l| l == format!("WORKING_DIR={}", world.user_home.join(".qwenpaw").display())),
+        "must pin the working directory: {log_text}"
+    );
+    assert!(plugin_dir.join("plugin.json").is_file());
+    assert!(plugin_dir.join("requirements.txt").is_file());
+
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+    assert!(status.entries[0].report.conditions.iter().any(|c| {
+        c.kind == AdapterConditionKind::PluginRegistered && c.status == ConditionStatus::True
+    }));
+
+    let disabled = manager
+        .disable(COMPONENT, Some("qwenpaw"), false)
+        .expect("disable");
+    assert!(disabled.claim_removed);
+    assert!(disabled.report.cleanup_complete);
+    let log_text = std::fs::read_to_string(&log).expect("qwenpaw log");
+    assert!(
+        log_text.lines().any(|l| l == "plugin uninstall tokenless"),
+        "disable must uninstall through the CLI: {log_text}"
+    );
+    assert!(!plugin_dir.exists(), "plugin directory must be gone");
+    assert!(
+        world.user_home.join(".qwenpaw").is_dir(),
+        "working directory itself must survive"
+    );
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, "qwenpaw")
+            .is_none()
+    );
+}
+
+#[test]
+fn qwenpaw_enable_fails_closed_when_cli_exits_zero_without_installing() {
+    let guard = EnvGuard::acquire();
+    let world = stage_qwenpaw();
+    let fake = write_fake_qwenpaw(&world.prefix);
+    let (log, plugin_dir) = apply_qwenpaw_env(&guard, &world, &fake);
+    guard.set("FAKE_QWENPAW_FAIL", Path::new("install"));
+
+    let err = world
+        .manager()
+        .enable(COMPONENT, Some("qwenpaw"), false)
+        .expect_err("install that produced no plugin must fail");
+    assert!(
+        matches!(err, AdapterError::FrameworkCli { .. }),
+        "unexpected error: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("simulated"),
+        "failure must surface the CLI's message: {err}"
+    );
+    assert!(!plugin_dir.exists());
+    let claim = world
+        .load_state()
+        .find_adapter_claim(COMPONENT, "qwenpaw")
+        .cloned()
+        .expect("write-ahead receipt kept for retry");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+    let log_text = std::fs::read_to_string(&log).expect("qwenpaw log");
+    assert!(
+        !log_text.lines().any(|l| l.starts_with("plugin uninstall")),
+        "a failed install must not trigger an uninstall: {log_text}"
+    );
+}
+
+#[test]
+fn qwenpaw_reenable_reinstalls_with_force() {
+    let guard = EnvGuard::acquire();
+    let world = stage_qwenpaw();
+    let fake = write_fake_qwenpaw(&world.prefix);
+    let (log, plugin_dir) = apply_qwenpaw_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qwenpaw"), false)
+        .expect("first enable");
+    std::fs::write(plugin_dir.join("stale"), b"x").expect("stale marker");
+    manager
+        .enable(COMPONENT, Some("qwenpaw"), false)
+        .expect("second enable");
+
+    let log_text = std::fs::read_to_string(&log).expect("qwenpaw log");
+    let installs = log_text
+        .lines()
+        .filter(|l| l.starts_with("plugin install ") && l.ends_with(" --force"))
+        .count();
+    assert_eq!(
+        installs, 2,
+        "every enable reinstalls with --force: {log_text}"
+    );
+    assert!(
+        !plugin_dir.join("stale").exists(),
+        "re-enable replaces the installed tree"
+    );
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+}
+
+#[test]
+fn qwenpaw_reenable_fails_closed_when_stale_bundle_remains() {
+    let guard = EnvGuard::acquire();
+    let world = stage_qwenpaw();
+    let fake = write_fake_qwenpaw(&world.prefix);
+    let (_log, plugin_dir) = apply_qwenpaw_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qwenpaw"), false)
+        .expect("first enable");
+    // The installed tree no longer holds the source bundle (an older
+    // install), and the reinstall fails: the CLI exits 0 and leaves that
+    // tree, whose manifest still carries the expected id.
+    std::fs::write(plugin_dir.join("plugin.py"), b"plugin = 'previous'\n")
+        .expect("stale plugin.py");
+    guard.set("FAKE_QWENPAW_FAIL", Path::new("install"));
+
+    let err = manager
+        .enable(COMPONENT, Some("qwenpaw"), false)
+        .expect_err("a stale bundle must not pass as installed");
+    assert!(
+        matches!(err, AdapterError::FrameworkCli { .. }),
+        "unexpected error: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("does not match the source bundle"),
+        "failure must name the stale file: {err}"
+    );
+    assert!(
+        plugin_dir.join("plugin.json").is_file(),
+        "the previous tree is left for QwenPaw"
+    );
+    let claim = world
+        .load_state()
+        .find_adapter_claim(COMPONENT, "qwenpaw")
+        .cloned()
+        .expect("receipt kept for retry");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+}
+
+#[test]
+fn qwenpaw_disable_keeps_receipt_when_uninstall_fails() {
+    let guard = EnvGuard::acquire();
+    let world = stage_qwenpaw();
+    let fake = write_fake_qwenpaw(&world.prefix);
+    let (_log, plugin_dir) = apply_qwenpaw_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qwenpaw"), false)
+        .expect("enable");
+
+    guard.set("FAKE_QWENPAW_FAIL", Path::new("uninstall"));
+    let disabled = manager
+        .disable(COMPONENT, Some("qwenpaw"), false)
+        .expect("disable runs");
+    assert!(
+        !disabled.claim_removed,
+        "receipt kept when hot-unload fails"
+    );
+    assert!(!disabled.report.cleanup_complete);
+    assert!(
+        plugin_dir.is_dir(),
+        "a failed hot-unload must leave the directory for retry"
+    );
+    let claim = world
+        .load_state()
+        .find_adapter_claim(COMPONENT, "qwenpaw")
+        .cloned()
+        .expect("receipt kept");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+
+    guard.set("FAKE_QWENPAW_FAIL", Path::new("none"));
+    let disabled = manager
+        .disable(COMPONENT, Some("qwenpaw"), false)
+        .expect("retry runs");
+    assert!(disabled.claim_removed, "retry completes the cleanup");
+    assert!(disabled.report.cleanup_complete);
+    assert!(!plugin_dir.exists());
+}
+
+#[test]
+fn qwenpaw_disable_uses_working_directory_from_receipt() {
+    let guard = EnvGuard::acquire();
+    let world = stage_qwenpaw();
+    let fake = write_fake_qwenpaw(&world.prefix);
+    let (log, plugin_dir) = apply_qwenpaw_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qwenpaw"), false)
+        .expect("enable");
+    assert!(plugin_dir.is_dir());
+
+    // ~/.copaw appearing after enable moves the ambient resolution; the
+    // receipt still names ~/.qwenpaw and the CLI must be pointed there.
+    std::fs::create_dir_all(world.user_home.join(".copaw")).expect("mkdir ~/.copaw");
+    let disabled = manager
+        .disable(COMPONENT, Some("qwenpaw"), false)
+        .expect("disable");
+    assert!(
+        disabled.claim_removed,
+        "cleanup completes: {:?}",
+        disabled.report
+    );
+    assert!(disabled.report.cleanup_complete);
+    assert!(!plugin_dir.exists());
+    let log_text = std::fs::read_to_string(&log).expect("read fake CLI log");
+    let expected = format!("WORKING_DIR={}", world.user_home.join(".qwenpaw").display());
+    assert_eq!(
+        log_text.lines().rfind(|l| l.starts_with("WORKING_DIR=")),
+        Some(expected.as_str()),
+        "uninstall must use the receipt's working directory: {log_text}"
+    );
+}
+
+#[test]
+fn qwenpaw_disable_without_cli_keeps_receipt() {
+    let guard = EnvGuard::acquire();
+    let world = stage_qwenpaw();
+    let fake = write_fake_qwenpaw(&world.prefix);
+    let (_log, plugin_dir) = apply_qwenpaw_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qwenpaw"), false)
+        .expect("enable");
+
+    guard.set("QWENPAW_BIN", &world.prefix.join("no-such-qwenpaw"));
+    let disabled = manager
+        .disable(COMPONENT, Some("qwenpaw"), false)
+        .expect("disable runs");
+    assert!(!disabled.claim_removed, "receipt kept when CLI absent");
+    assert!(!disabled.report.cleanup_complete);
+    assert!(
+        plugin_dir.is_dir(),
+        "without the CLI the plugin directory must be left alone"
+    );
+    let claim = world
+        .load_state()
+        .find_adapter_claim(COMPONENT, "qwenpaw")
+        .cloned()
+        .expect("receipt kept");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(
+        status.entries[0].report.summary,
+        AdapterSummary::CleanupFailed
+    );
+}
+
+#[test]
+fn qwenpaw_dry_run_enable_writes_nothing() {
+    let guard = EnvGuard::acquire();
+    let world = stage_qwenpaw();
+    let fake = write_fake_qwenpaw(&world.prefix);
+    let (log, plugin_dir) = apply_qwenpaw_env(&guard, &world, &fake);
+
+    let outcome = world
+        .manager()
+        .enable(COMPONENT, Some("qwenpaw"), true)
+        .expect("dry-run enable");
+    let EnableOutcome::Planned { plan, .. } = outcome else {
+        panic!("dry run must only plan");
+    };
+    let register = plan.register_command.expect("install command in plan");
+    assert!(
+        register.ends_with(&format!(
+            "qwenpaw plugin install {} --force",
+            world.resource_root.display()
+        )),
+        "plan must show the CLI invocation: {register}"
+    );
+    assert!(!log.exists(), "dry run must not run the CLI");
+    assert!(!plugin_dir.exists());
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, "qwenpaw")
+            .is_none()
+    );
+}
+
+#[test]
+fn qwenpaw_status_degraded_when_plugin_removed_externally() {
+    let guard = EnvGuard::acquire();
+    let world = stage_qwenpaw();
+    let fake = write_fake_qwenpaw(&world.prefix);
+    let (_log, plugin_dir) = apply_qwenpaw_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qwenpaw"), false)
+        .expect("enable");
+    std::fs::remove_dir_all(&plugin_dir).expect("remove plugin dir");
+
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Degraded);
+    assert!(status.entries[0].report.conditions.iter().any(|c| {
+        c.kind == AdapterConditionKind::PluginRegistered && c.status == ConditionStatus::False
+    }));
+
+    // A different plugin occupying the directory is not ours either.
+    std::fs::create_dir_all(&plugin_dir).expect("recreate");
+    std::fs::write(plugin_dir.join("plugin.json"), br#"{"id":"someone-else"}"#).expect("other");
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Degraded);
 }

--- a/src/anolisa/manifests/components/tokenless/component.toml
+++ b/src/anolisa/manifests/components/tokenless/component.toml
@@ -93,6 +93,18 @@ detect = { binary = "hermes" }
 entry = "plugin.yaml"
 
 [[adapters]]
+framework = "qwenpaw"
+kind = "third-party"
+adapter_type = "plugin"
+plugin_id = "tokenless"
+source = "adapters/qwenpaw"
+dest = "{datadir}/adapters/{component}/qwenpaw/"
+detect = { binary = "qwenpaw" }
+
+[adapters.bundle]
+entry = "plugin.json"
+
+[[adapters]]
 framework = "qoder"
 adapter_type = "plugin"
 plugin_id = "tokenless"

--- a/src/tokenless/.anolisa/component.toml.in
+++ b/src/tokenless/.anolisa/component.toml.in
@@ -103,6 +103,20 @@ detect = { binary = "hermes" }
 entry = "plugin.yaml"
 
 [[adapters]]
+framework = "qwenpaw"
+adapter_type = "plugin"
+plugin_id = "tokenless"
+source = "adapters/qwenpaw"
+dest = "{datadir}/adapters/{component}/qwenpaw/"
+detect = { binary = "qwenpaw" }
+
+[adapters.bundle]
+# QwenPaw plugin manifest. The built-in qwenpaw driver hands the bundle to
+# `qwenpaw plugin install`, which copies it, validates plugin.py and installs
+# requirements.txt into QwenPaw's own Python environment.
+entry = "plugin.json"
+
+[[adapters]]
 framework = "qoder"
 adapter_type = "plugin"
 plugin_id = "tokenless"

--- a/src/tokenless/.gitignore
+++ b/src/tokenless/.gitignore
@@ -12,6 +12,8 @@ adapters/tokenless/qoder/.qoder-plugin/plugin.json
 adapters/tokenless/claude-code/.claude-plugin/plugin.json
 adapters/tokenless/codex/.codex-plugin/plugin.json
 adapters/tokenless/qwencode/qwen-extension.json
+adapters/tokenless/qwenpaw/plugin.json
+adapters/tokenless/qwenpaw/requirements.txt
 python/agentscope/pyproject.toml
 python/agentscope/build/
 python/agentscope/src/*.egg-info/

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -31,7 +31,9 @@ ADAPTER_TEMPLATES := \
     $(ADAPTER_SRC_DIR)/qoder/.qoder-plugin/plugin.json \
     $(ADAPTER_SRC_DIR)/claude-code/.claude-plugin/plugin.json \
     $(ADAPTER_SRC_DIR)/codex/.codex-plugin/plugin.json \
-    $(ADAPTER_SRC_DIR)/qwencode/qwen-extension.json
+    $(ADAPTER_SRC_DIR)/qwencode/qwen-extension.json \
+    $(ADAPTER_SRC_DIR)/qwenpaw/plugin.json \
+    $(ADAPTER_SRC_DIR)/qwenpaw/requirements.txt
 # Canonical RPM/raw component contract — kept separate from the adapter
 # payload tree and stamped from the workspace version before packaging.
 # Shipped to %{_datadir}/anolisa/components/tokenless/component.toml and
@@ -62,6 +64,7 @@ PYPROJECT_BUILD ?= uvx --from 'build>=1,<2' pyproject-build
         codex-install codex-uninstall \
         opencode-install opencode-uninstall \
         qwencode-install qwencode-uninstall \
+        qwenpaw-install qwenpaw-uninstall \
         setup help \
         npm-package npm-package-all npm-publish prepare-npm-native-binaries \
         python-wheel test-python-runtime agentscope-wheel \
@@ -128,6 +131,14 @@ $(ADAPTER_SRC_DIR)/codex/.codex-plugin/plugin.json: $(ADAPTER_SRC_DIR)/codex/.co
 $(ADAPTER_SRC_DIR)/qwencode/qwen-extension.json: \
     $(ADAPTER_SRC_DIR)/qwencode/qwen-extension.json.in Cargo.toml
 	@echo "==> Generating qwencode/qwen-extension.json (version=$(VERSION))..."
+	sed 's/@VERSION@/$(VERSION)/g' $< > $@
+
+$(ADAPTER_SRC_DIR)/qwenpaw/plugin.json: $(ADAPTER_SRC_DIR)/qwenpaw/plugin.json.in Cargo.toml
+	@echo "==> Generating qwenpaw/plugin.json (version=$(VERSION))..."
+	sed 's/@VERSION@/$(VERSION)/g' $< > $@
+
+$(ADAPTER_SRC_DIR)/qwenpaw/requirements.txt: $(ADAPTER_SRC_DIR)/qwenpaw/requirements.txt.in Cargo.toml
+	@echo "==> Generating qwenpaw/requirements.txt (version=$(VERSION))..."
 	sed 's/@VERSION@/$(VERSION)/g' $< > $@
 
 $(AGENTSCOPE_PACKAGE_DIR)/pyproject.toml: \
@@ -260,6 +271,7 @@ test-integration:
 	python3 tests/test_cosh_extension_matcher.py
 	python3 tests/test_resolve_agent_id.py
 	python3 tests/test_release_regression_probe.py
+	python3 tests/test_qwenpaw_plugin.py
 
 # Protocol v2 Common Hook parity: replay the contract corpus through the
 # current hooks and real debug binary, then compare with the v2 goldens.
@@ -278,6 +290,8 @@ test-adapters: build-openclaw-plugin build-dsh-plugin
 	@echo "==> Testing OpenCode adapter..."
 	bash tests/test-opencode-adapter-install.sh
 	node tests/test-opencode-plugin.mjs
+	@echo "==> Testing QwenPaw adapter installer..."
+	bash tests/test-qwenpaw-adapter-install.sh
 
 # Build the abi3 extension with unwind semantics so a Rust panic cannot abort
 # the embedding Python interpreter. The wheel remains platform-specific, but
@@ -389,9 +403,9 @@ ADAPTER_ENV = ANOLISA_PREFIX=$(HOME)/.local \
               ANOLISA_COMPONENT=tokenless \
               ANOLISA_VERSION=$(VERSION)
 
-adapter-install: cosh-extension-install openclaw-install hermes-install qoder-install claude-code-install codex-install opencode-install qwencode-install
+adapter-install: cosh-extension-install openclaw-install hermes-install qoder-install claude-code-install codex-install opencode-install qwencode-install qwenpaw-install
 
-adapter-uninstall: cosh-extension-uninstall openclaw-uninstall hermes-uninstall qoder-uninstall claude-code-uninstall codex-uninstall opencode-uninstall qwencode-uninstall
+adapter-uninstall: cosh-extension-uninstall openclaw-uninstall hermes-uninstall qoder-uninstall claude-code-uninstall codex-uninstall opencode-uninstall qwencode-uninstall qwenpaw-uninstall
 
 adapter-scan:
 	@echo "=== Tokenless Adapter Manifest ==="
@@ -506,6 +520,18 @@ qwencode-uninstall:
 	@echo "==> Uninstalling Qwen Code plugin..."
 	@$(ADAPTER_ENV) ANOLISA_TARGET=qwencode bash $(QWENCODE_ADAPTER_DIR)/scripts/uninstall.sh
 
+# --- QwenPaw ---
+QWENPAW_ADAPTER_DIR = $(SHARE_DIR)/qwenpaw
+
+qwenpaw-install:
+	@echo "==> Installing QwenPaw plugin..."
+	@$(ADAPTER_ENV) ANOLISA_TARGET=qwenpaw bash $(QWENPAW_ADAPTER_DIR)/scripts/detect.sh || true
+	@$(ADAPTER_ENV) ANOLISA_TARGET=qwenpaw bash $(QWENPAW_ADAPTER_DIR)/scripts/install.sh
+
+qwenpaw-uninstall:
+	@echo "==> Uninstalling QwenPaw plugin..."
+	@$(ADAPTER_ENV) ANOLISA_TARGET=qwenpaw bash $(QWENPAW_ADAPTER_DIR)/scripts/uninstall.sh
+
 # One-step setup: build + install + all adapters
 setup: install adapter-install
 	@echo ""
@@ -520,7 +546,7 @@ setup: install adapter-install
 	@echo "  Adapter (FHS):"
 	@echo "    $(SHARE_DIR)/"
 	@echo "  Registered:"
-	@echo "    cosh, openclaw, hermes, qoder, claude-code, codex, opencode, qwencode"
+	@echo "    cosh, openclaw, hermes, qoder, claude-code, codex, opencode, qwencode, qwenpaw"
 	@echo ""
 	@echo "Verify:"
 	@echo "  tokenless --version"
@@ -593,7 +619,7 @@ help:
 	@echo "  agentscope-wheel  Build the AgentScope integration wheel"
 	@echo "  test-agentscope-integration  Test the integration with supported AgentScope versions"
 	@echo "  adapter-scan      List registered adapter capabilities"
-	@echo "  adapter-install   Register all adapters (cosh+openclaw+hermes+qoder+claude-code+codex+opencode+qwencode)"
+	@echo "  adapter-install   Register all adapters (cosh+openclaw+hermes+qoder+claude-code+codex+opencode+qwencode+qwenpaw)"
 	@echo "  adapter-uninstall Unregister all adapters"
 	@echo "  cosh-extension-install  Install cosh extension"
 	@echo "  cosh-extension-uninstall Uninstall cosh extension"
@@ -611,6 +637,8 @@ help:
 	@echo "  opencode-uninstall Unregister OpenCode local plugin"
 	@echo "  qwencode-install  Register Qwen Code plugin via qwen CLI"
 	@echo "  qwencode-uninstall Unregister Qwen Code plugin"
+	@echo "  qwenpaw-install   Install QwenPaw plugin via qwenpaw CLI"
+	@echo "  qwenpaw-uninstall Uninstall QwenPaw plugin"
 	@echo "  setup             Full setup: build + install + register adapters"
 	@echo "  npm-package       Build and package the current host"
 	@echo "  npm-package-all   Package target/npm-prebuilt target directories"

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -21,6 +21,7 @@ Agent adapters are available for:
 - **Codex plugin** — RTK command rewriting, environment-failure diagnostics, and registered but hard-disabled Tool Ready via Codex's native hook system.
 - **OpenCode plugin** — schema/response/TOON compression, Marker-directed recovery, registered but hard-disabled Tool Ready, and command rewriting via OpenCode's local plugin API.
 - **Qwen Code extension** — command rewriting and registered but hard-disabled Tool Ready; current host releases cannot replace post-tool output and skip the declared schema event.
+- **QwenPaw plugin** — schema compression, RTK command rewriting, response/TOON compression, and static-tool recovery through an AgentScope middleware registered by QwenPaw's plugin system; the plugin embeds the `anolisa_tokenless` wheel in-process.
 - **DeepSeek Harness plugin** — native response compression, Marker-directed recovery, and environment-error attribution through DSH's `tools/post-execute` seam.
 
 For framework developers, the Python SDK has a framework-neutral layer and an **AgentScope-specific
@@ -46,6 +47,7 @@ retrieval, and attribution.
 | Codex plugin | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Environment diagnostics ✅, Response compression — protocol-blocked |
 | OpenCode plugin | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Schema compression ✅, Response compression ✅, TOON ✅, Marker-command recovery ✅ |
 | Qwen Code extension | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Response/Schema replacement unavailable in current host |
+| QwenPaw plugin | — | Schema compression ✅, Command rewriting ✅, Response compression ✅, TOON ✅, Retrieve Tool recovery ✅ |
 | DeepSeek Harness plugin | — | Response compression ✅, Marker-command recovery ✅, Environment-error attribution ✅ |
 | AgentScope framework integration | — | Schema ✅, RTK ✅, Response ✅, TOON ✅, Retrieval ✅ |
 | Zero runtime deps | — | Pure Rust, single static binary |
@@ -130,6 +132,7 @@ Token-Less/
 │   ├── claude-code/             # Claude Code plugin + marketplace + hooks
 │   ├── codex/                   # Codex plugin + scripts
 │   ├── opencode/                # OpenCode local plugin + scripts
+│   ├── qwenpaw/                 # QwenPaw plugin (AgentScope middleware) + scripts
 │   └── dsh/                     # Native DeepSeek Harness bundle
 ├── third_party/rtk/           # RTK vendored source (justfile clone+patch from GitHub)
 ├── third_party/patches/      # Patches for vendored third_party sources
@@ -674,6 +677,30 @@ If a response contains a Retrieve Marker, OpenCode can run the embedded
 `tokenless retrieve` command through its existing shell tool. The adapter sends
 the successful recovery result through the Core bypass without recompressing it.
 
+## QwenPaw Plugin
+
+The QwenPaw adapter is a native QwenPaw plugin. Its `plugin.py` registers an
+AgentScope middleware through `api.register_middleware` and a
+`tokenless_retrieve` tool through `api.register_tool`, and calls the in-process
+`anolisa_tokenless.TokenlessSdk` directly:
+
+| Feature | Middleware hook | Behavior | Status |
+|---|---|---|---|
+| Schema compression | `on_model_call` | Compresses tool schemas and appends the retrieve tool | ✅ Active |
+| Command rewriting | `on_acting` | Rewrites `execute_shell_command` input via RTK after QwenPaw's approval step | ✅ Active |
+| Response + TOON compression | `on_acting` | Replaces text blocks of the tool result for QwenPaw's built-in tools; file readers and tools outside the built-in table pass through untouched | ✅ Active |
+| Recovery | `tokenless_retrieve` tool | Restores omitted content from the hash in a visible recovery instruction | ✅ Active |
+
+```bash
+make qwenpaw-install
+```
+
+The installer runs `qwenpaw plugin install <bundle> --force`; QwenPaw copies the
+bundle into `<working dir>/plugins/tokenless/` (`QWENPAW_WORKING_DIR`, else
+`COPAW_WORKING_DIR`, else an existing `~/.copaw`, else `~/.qwenpaw`) and installs
+the `anolisa_tokenless` wheel listed in `requirements.txt` from the matching
+GitHub Release. Records are written under `<workspace>/.tokenless`.
+
 ## DeepSeek Harness Plugin
 
 The native DSH bundle sends replaceable single-text tool results through
@@ -868,6 +895,8 @@ tool-output savings and retrieval overhead separately.
 | `make codex-uninstall` | Remove Codex plugin |
 | `make opencode-install` | Install OpenCode local plugin |
 | `make opencode-uninstall` | Remove OpenCode local plugin |
+| `make qwenpaw-install` | Install QwenPaw plugin via the qwenpaw CLI |
+| `make qwenpaw-uninstall` | Remove QwenPaw plugin |
 | `make setup` | Full setup: build + install + all adapters |
 
 Override install paths:
@@ -926,6 +955,7 @@ layout and single-target interface.
 | `adapters/tokenless/claude-code/` | Claude Code adapter — marketplace + plugin + hooks dispatcher |
 | `adapters/tokenless/codex/` | Codex adapter — plugin + Python hook scripts |
 | `adapters/tokenless/opencode/` | OpenCode adapter — local JavaScript plugin + lifecycle scripts |
+| `adapters/tokenless/qwenpaw/` | QwenPaw adapter — plugin manifest, AgentScope middleware, wheel requirements + lifecycle scripts |
 | `third_party/rtk/` | RTK vendored source — command rewriting engine (justfile clone+patch) |
 | `third_party/patches/` | Patches for vendored third_party sources |
 | `packaging/raw/` | Component-owned ANOLISA raw packer and target validation |

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -86,6 +86,7 @@ tokenless 优化进入 LLM 上下文前、由它实际处理的工具相关内�
 - **OpenCode 插件** — Tool Ready（已硬关闭）+ 命令重写 + Schema/响应压缩 + TOON + Marker 命令恢复
 - **DeepSeek Harness 插件** — 通过 DSH 原生 `tools/post-execute` 接入响应压缩、Marker 命令恢复和环境错误归因
 - **Qwen Code Extension** — Tool Ready（已硬关闭）+ 命令重写；当前宿主不支持工具后输出替换，并跳过声明的 Schema 事件
+- **QwenPaw 插件** — 通过 QwenPaw 插件系统注册 AgentScope 中间件，进程内调用 `anolisa_tokenless` wheel，提供 Schema 压缩、RTK 命令重写、响应/TOON 压缩和 `tokenless_retrieve` 静态工具恢复
 
 OpenClaw Plugin 只保留宿主事件转换与逐调用状态：`before_tool_call` 把 `exec` 参数交给
 `tokenless compress`，`tool_result_persist` 把 OpenClaw 自己持久化的 Tool Result 交给同一
@@ -284,6 +285,22 @@ make opencode-install
 不会覆盖同名的非托管文件。配置目录支持 `OPENCODE_CONFIG_DIR`、
 `XDG_CONFIG_HOME` 和显式的 `TOKENLESS_OPENCODE_CONFIG_DIR` 覆盖。
 安装后重启 OpenCode 即可加载插件。
+
+### QwenPaw 安装
+
+QwenPaw 适配器是一个原生 QwenPaw 插件：`plugin.py` 通过 `api.register_middleware` 注册
+AgentScope 中间件，通过 `api.register_tool` 注册 `tokenless_retrieve` 工具，并直接调用进程内的
+`anolisa_tokenless.TokenlessSdk`。`on_model_call` 压缩工具 Schema，`on_acting` 在 QwenPaw 审批之后
+用 RTK 改写 `execute_shell_command` 的输入，并替换 QwenPaw 内置工具结果中的文本块（文件读取类工具和内置表之外的工具原样透传）。
+
+```bash
+make qwenpaw-install
+```
+
+安装器执行 `qwenpaw plugin install <bundle> --force`，由 QwenPaw 把 Bundle 复制到
+`<工作目录>/plugins/tokenless/`（`QWENPAW_WORKING_DIR`，否则 `COPAW_WORKING_DIR`，否则已存在的
+`~/.copaw`，否则 `~/.qwenpaw`），并按 `requirements.txt` 从对应 GitHub Release
+安装 `anolisa_tokenless` wheel。统计记录写入 `<workspace>/.tokenless`。
 
 ### DeepSeek Harness 插件
 

--- a/src/tokenless/adapters/tokenless/manifest.json.in
+++ b/src/tokenless/adapters/tokenless/manifest.json.in
@@ -141,6 +141,22 @@
         "install":   "qwencode/scripts/install.sh",
         "uninstall": "qwencode/scripts/uninstall.sh"
       }
+    },
+    "qwenpaw": {
+      "compatibleVersions": ">=2.0.0 <3.0.0",
+      "capabilities": {
+        "hooks": [
+          "compress-schema",
+          "rewrite",
+          "compress-response",
+          "compress-toon"
+        ]
+      },
+      "actions": {
+        "detect":    "qwenpaw/scripts/detect.sh",
+        "install":   "qwenpaw/scripts/install.sh",
+        "uninstall": "qwenpaw/scripts/uninstall.sh"
+      }
     }
   }
 }

--- a/src/tokenless/adapters/tokenless/qwenpaw/plugin.json.in
+++ b/src/tokenless/adapters/tokenless/qwenpaw/plugin.json.in
@@ -1,0 +1,17 @@
+{
+  "id": "tokenless",
+  "name": "Tokenless",
+  "version": "@VERSION@",
+  "type": "general",
+  "description": "ANOLISA Tokenless: compress tool schemas and tool results before they reach the model",
+  "author": "ANOLISA",
+  "entry": {
+    "backend": "plugin.py"
+  },
+  "dependencies": [],
+  "qwenpaw_version": {
+    "min": "2.0.0",
+    "max": "3.0.0"
+  },
+  "meta": {}
+}

--- a/src/tokenless/adapters/tokenless/qwenpaw/plugin.py
+++ b/src/tokenless/adapters/tokenless/qwenpaw/plugin.py
@@ -1,0 +1,390 @@
+"""Tokenless plugin for QwenPaw.
+
+Registers one AgentScope middleware that runs the complete Tokenless lifecycle
+in-process through ``anolisa_tokenless.TokenlessSdk``: tool schema compression
+before each model call, RTK command rewriting before ``execute_shell_command``,
+tool result compression after every tool call, and a marker-authorized
+``tokenless_retrieve`` tool.
+
+QwenPaw imports this file once at install time before the plugin's
+``requirements.txt`` is installed, so ``anolisa_tokenless`` is imported inside
+``register`` rather than at module level. Tools outside the built-in contract
+table are passed through untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncGenerator, Callable
+from pathlib import Path
+from typing import Any
+
+from agentscope.message import TextBlock, ToolResultState
+from agentscope.middleware import MiddlewareBase
+from agentscope.tool import ToolChunk, ToolResponse
+
+logger = logging.getLogger(__name__)
+
+AGENT_ID = "qwenpaw"
+STATE_KEY = "anolisa_tokenless"
+RETRIEVE_TOOL = "tokenless_retrieve"
+RETRIEVE_DECLARATION = {
+    "type": "function",
+    "function": {
+        "name": RETRIEVE_TOOL,
+        "description": (
+            "Restore omitted content when needed. Pass only the 24-character hash "
+            "from a visible Tokenless recovery instruction, not the whole instruction."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "hash_or_marker": {
+                    "type": "string",
+                    "description": (
+                        "The 24-character hash from a visible recovery instruction; "
+                        "historical Tokenless markers are also accepted"
+                    ),
+                }
+            },
+            "required": ["hash_or_marker"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+# tool name -> (content_origin wire value, RTK command field) for QwenPaw
+# 2.2.0's built-in tools. Core passes `file_content` through untouched, so a
+# tool absent from this table (skills, MCP servers, newer built-ins) falls
+# back to it and is never compressed or rewritten.
+_CONTRACTS: dict[str, tuple[str, str | None]] = {
+    "execute_shell_command": ("command_output", "command"),
+    **{
+        name: ("file_content", None)
+        for name in ("read_file", "recall_history", "view_image", "view_video")
+    },
+    **{
+        name: ("api_response", None)
+        for name in (
+            "glob_search",
+            "grep_search",
+            "ast_search",
+            "web_fetch",
+            "web_search",
+            "memory_search",
+            "get_current_time",
+            "get_token_usage",
+            "list_agents",
+            "check_agent_task",
+            "chat_with_agent",
+            "submit_to_agent",
+            "spawn_subagent",
+            "delegate_external_agent",
+            "browser",
+            "desktop_screenshot",
+            "run_tool_batch",
+            "send_file_to_user",
+            "set_user_timezone",
+            "activate_f1_exploration_mode",
+            "edit_file",
+            "write_file",
+            "append_file",
+            "materialize_skill",
+        )
+    },
+}
+_DEFAULT_CONTRACT: tuple[str, str | None] = ("file_content", None)
+
+# Every name the middleware and the retrieve tool import from
+# anolisa_tokenless. A released wheel that predates one of them imports fine
+# at registration and would fail at the first model call instead, so the
+# plugin refuses to register against such a wheel.
+_REQUIRED_SDK_NAMES = (
+    "Attribution",
+    "BeforeModelCapabilities",
+    "BeforeModelRequest",
+    "ContentOrigin",
+    "OutputOptimization",
+    "PostToolCapabilities",
+    "PostToolRequest",
+    "PreToolAction",
+    "PreToolCapabilities",
+    "PreToolRequest",
+    "RecoveryMethod",
+    "ResultKind",
+    "RetrieveRequest",
+    "TokenlessConfig",
+    "TokenlessError",
+    "TokenlessSdk",
+    "ToolResultStatus",
+)
+
+_SDKS: dict[str, Any] = {}
+
+
+def _sdk_for(data_dir: str) -> Any:
+    sdk = _SDKS.get(data_dir)
+    if sdk is None:
+        from anolisa_tokenless import TokenlessConfig, TokenlessSdk
+
+        sdk = TokenlessSdk(
+            TokenlessConfig(
+                data_dir=data_dir, rtk_enabled=True, retrieve_tool_name=RETRIEVE_TOOL
+            )
+        )
+        _SDKS[data_dir] = sdk
+    return sdk
+
+
+class TokenlessMiddleware(MiddlewareBase):
+    """Apply the Tokenless lifecycle to one QwenPaw agent request."""
+
+    def __init__(self, sdk: Any, data_dir: str) -> None:
+        self.sdk = sdk
+        self.data_dir = data_dir
+
+    async def on_model_call(
+        self,
+        agent: Any,
+        input_kwargs: dict[str, Any],
+        next_handler: Callable[..., Any],
+    ) -> Any:
+        from anolisa_tokenless import (
+            Attribution,
+            BeforeModelCapabilities,
+            BeforeModelRequest,
+            RecoveryMethod,
+        )
+
+        tools = [
+            tool
+            for tool in input_kwargs["tools"]
+            if tool.get("function", {}).get("name") != RETRIEVE_TOOL
+        ]
+        transformed = await self.sdk.before_model(
+            BeforeModelRequest(
+                tools=tuple(tools),
+                visible_context=json.dumps(
+                    input_kwargs["messages"], ensure_ascii=False, default=str
+                ),
+                capabilities=BeforeModelCapabilities(
+                    replace_tools=True, recovery=RecoveryMethod.tool(RETRIEVE_TOOL)
+                ),
+                attribution=Attribution(AGENT_ID, agent.state.session_id),
+            )
+        )
+        agent.state.middle_context[STATE_KEY] = {
+            "visible_markers": sorted(transformed.visible_markers),
+            "agent_id": AGENT_ID,
+            "data_dir": self.data_dir,
+        }
+        tools = list(transformed.tools)
+        tools.append(RETRIEVE_DECLARATION)
+        return await next_handler(**{**input_kwargs, "tools": tools})
+
+    async def on_acting(
+        self,
+        agent: Any,
+        input_kwargs: dict[str, Any],
+        next_handler: Callable[..., AsyncGenerator[Any, None]],
+    ) -> AsyncGenerator[Any, None]:
+        from anolisa_tokenless import (
+            Attribution,
+            OutputOptimization,
+            PreToolAction,
+            PreToolCapabilities,
+            PreToolRequest,
+        )
+
+        source = input_kwargs["tool_call"]
+        if source.name == RETRIEVE_TOOL:
+            async for item in next_handler(**input_kwargs):
+                yield item
+            return
+
+        origin, command_field = _CONTRACTS.get(source.name, _DEFAULT_CONTRACT)
+        attribution = Attribution(AGENT_ID, agent.state.session_id, source.id)
+        optimization = OutputOptimization.NONE
+        forwarded = source
+        if command_field is not None:
+            arguments = json.loads(source.input)
+            if not isinstance(arguments, dict):
+                raise TypeError(f"{source.name} arguments must be a JSON object")
+            transformed = await self.sdk.pre_tool(
+                PreToolRequest(
+                    tool_name=source.name,
+                    arguments=arguments,
+                    command_field=command_field,
+                    capabilities=PreToolCapabilities(
+                        replace_arguments=True, block_and_suggest=False
+                    ),
+                    attribution=attribution,
+                )
+            )
+            if transformed.action is PreToolAction.BLOCK_AND_SUGGEST:
+                raise RuntimeError(
+                    "Core returned block_and_suggest without host capability"
+                )
+            optimization = transformed.output_optimization
+            forwarded = source.model_copy(
+                update={
+                    "input": json.dumps(
+                        transformed.arguments,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    )
+                }
+            )
+        async for item in next_handler(**{**input_kwargs, "tool_call": forwarded}):
+            if isinstance(item, ToolResponse):
+                yield await self._after_response(
+                    item, source.name, origin, optimization, attribution
+                )
+            else:
+                yield item
+
+    async def _after_response(
+        self,
+        response: ToolResponse,
+        tool_name: str,
+        origin: str,
+        optimization: Any,
+        attribution: Any,
+    ) -> ToolResponse:
+        from anolisa_tokenless import (
+            ContentOrigin,
+            OutputOptimization,
+            PostToolCapabilities,
+            PostToolRequest,
+            RecoveryMethod,
+            ResultKind,
+            ToolResultStatus,
+        )
+
+        status = {
+            ToolResultState.SUCCESS: ToolResultStatus.SUCCESS,
+            ToolResultState.ERROR: ToolResultStatus.ERROR,
+            ToolResultState.INTERRUPTED: ToolResultStatus.INTERRUPTED,
+            ToolResultState.DENIED: ToolResultStatus.DENIED,
+        }[response.state]
+        # Recoverable compression needs the static retrieve tool; RTK output
+        # and failed results stay lossless-only, as in tokenless_agentscope.
+        recovery = (
+            RecoveryMethod.tool(RETRIEVE_TOOL)
+            if status is ToolResultStatus.SUCCESS
+            and optimization == OutputOptimization.NONE
+            else RecoveryMethod()
+        )
+        content = list(response.content)
+        extra_context: str | None = None
+        for index, block in enumerate(content):
+            if not isinstance(block, TextBlock):
+                continue
+            transformed = await self.sdk.post_tool(
+                PostToolRequest(
+                    result_kind=ResultKind.TOOL,
+                    tool_name=tool_name,
+                    content=block.text,
+                    status=status,
+                    content_origin=ContentOrigin(origin),
+                    output_optimization=optimization,
+                    capabilities=PostToolCapabilities(
+                        replace_output=True,
+                        recovery=recovery,
+                        replace_with_text=True,
+                    ),
+                    attribution=attribution,
+                )
+            )
+            extra_context = extra_context or transformed.additional_context
+            if transformed.output != block.text:
+                content[index] = block.model_copy(update={"text": transformed.output})
+        if extra_context is not None:
+            content.append(TextBlock(text=extra_context))
+        if content == response.content:
+            return response
+        return response.model_copy(update={"content": content})
+
+
+def _factory(ctx: Any, agent_config: Any) -> TokenlessMiddleware:
+    del agent_config
+    # TokenlessConfig rejects relative data directories.
+    data_dir = str(Path(ctx.workspace.workspace_dir).expanduser().resolve() / ".tokenless")
+    return TokenlessMiddleware(_sdk_for(data_dir), data_dir)
+
+
+async def tokenless_retrieve(hash_or_marker: str) -> ToolChunk:
+    """Restore omitted content behind a visible Tokenless recovery instruction.
+
+    Args:
+        hash_or_marker: The 24-character hash from a visible recovery
+            instruction; historical <<tokenless:HASH>> markers are accepted.
+    """
+    from anolisa_tokenless import Attribution, RetrieveRequest, TokenlessError
+    from qwenpaw.config.context import get_current_agent_state
+
+    state = get_current_agent_state()
+    saved = getattr(state, "middle_context", {}).get(STATE_KEY) if state else None
+    if not saved:
+        return ToolChunk(
+            content=[TextBlock(text="Tokenless has no marker state for this session")],
+            state=ToolResultState.ERROR,
+        )
+    try:
+        response = await _sdk_for(saved["data_dir"]).retrieve(
+            RetrieveRequest(
+                hash_or_marker,
+                frozenset(saved["visible_markers"]),
+                Attribution(saved["agent_id"], state.session_id),
+            )
+        )
+    except TokenlessError as error:
+        return ToolChunk(
+            content=[TextBlock(text=str(error))], state=ToolResultState.ERROR
+        )
+    return ToolChunk(
+        content=[TextBlock(text=response.payload)], state=ToolResultState.SUCCESS
+    )
+
+
+class TokenlessPlugin:
+    """QwenPaw plugin entry point."""
+
+    def register(self, api: Any) -> None:
+        import anolisa_tokenless
+
+        manifest = json.loads(
+            (Path(__file__).parent / "plugin.json").read_text(encoding="utf-8")
+        )
+        missing = [
+            name for name in _REQUIRED_SDK_NAMES if not hasattr(anolisa_tokenless, name)
+        ]
+        if missing:
+            logger.error(
+                "tokenless: anolisa_tokenless %s lacks %s required by plugin %s; "
+                "install the anolisa_tokenless wheel from the tokenless/v%s release "
+                "into QwenPaw's Python environment. Tokenless stays disabled.",
+                anolisa_tokenless.__version__,
+                ", ".join(missing),
+                manifest["version"],
+                manifest["version"],
+            )
+            return
+        if anolisa_tokenless.__version__ != manifest["version"]:
+            logger.warning(
+                "tokenless: plugin %s runs against anolisa_tokenless %s",
+                manifest["version"],
+                anolisa_tokenless.__version__,
+            )
+        api.register_middleware(_factory, priority=100)
+        api.register_tool(
+            tool_name=RETRIEVE_TOOL,
+            tool_func=tokenless_retrieve,
+            description="Restore content behind a Tokenless marker",
+            enabled=True,
+            tool_type="internal",
+        )
+
+
+plugin = TokenlessPlugin()

--- a/src/tokenless/adapters/tokenless/qwenpaw/requirements.txt.in
+++ b/src/tokenless/adapters/tokenless/qwenpaw/requirements.txt.in
@@ -1,0 +1,6 @@
+# Installed by QwenPaw's plugin loader into QwenPaw's own Python environment.
+# The native wheel is published only as a Tokenless GitHub Release asset; pip
+# picks the single line whose environment marker matches this host.
+anolisa-tokenless @ https://github.com/alibaba/anolisa/releases/download/tokenless/v@VERSION@/anolisa_tokenless-@VERSION@-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == "linux" and platform_machine == "x86_64"
+anolisa-tokenless @ https://github.com/alibaba/anolisa/releases/download/tokenless/v@VERSION@/anolisa_tokenless-@VERSION@-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl ; sys_platform == "linux" and platform_machine == "aarch64"
+anolisa-tokenless @ https://github.com/alibaba/anolisa/releases/download/tokenless/v@VERSION@/anolisa_tokenless-@VERSION@-cp311-abi3-macosx_11_0_arm64.whl ; sys_platform == "darwin" and platform_machine == "arm64"

--- a/src/tokenless/adapters/tokenless/qwenpaw/scripts/detect.sh
+++ b/src/tokenless/adapters/tokenless/qwenpaw/scripts/detect.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# detect.sh — Inspect tokenless QwenPaw integration. Read-only.
+#
+# Reports qwenpaw CLI, QwenPaw working directory, tokenless plugin install
+# state, and adapter resource availability. Exit codes:
+#   0 = installed and ready
+#   1 = not installed but installable
+#   2 = missing prerequisites
+set -euo pipefail
+
+AGENT="${ANOLISA_TARGET:-qwenpaw}"
+COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
+ADAPTER_DIR="${ANOLISA_ADAPTER_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# Resolve the working directory like QwenPaw: QWENPAW_WORKING_DIR, else
+# COPAW_WORKING_DIR, else a legacy ~/.copaw, else ~/.qwenpaw.
+PLUGIN_ID="tokenless"
+QWENPAW_WORKING_DIR="${QWENPAW_WORKING_DIR:-${COPAW_WORKING_DIR:-}}"
+if [ -z "$QWENPAW_WORKING_DIR" ]; then
+    if [ -d "$HOME/.copaw" ]; then QWENPAW_WORKING_DIR="$HOME/.copaw"; other="$HOME/.qwenpaw"; else QWENPAW_WORKING_DIR="$HOME/.qwenpaw"; other="$HOME/.copaw"; fi
+    # ~/.copaw may have appeared or vanished since the plugin was installed:
+    # prefer the default location that actually holds it.
+    if [ ! -d "$QWENPAW_WORKING_DIR/plugins/$PLUGIN_ID" ] && [ -d "$other/plugins/$PLUGIN_ID" ]; then
+        QWENPAW_WORKING_DIR="$other"
+    fi
+fi
+QWENPAW_BIN="${QWENPAW_BIN:-}"
+export PATH="${QWENPAW_HOME:-$HOME/.qwenpaw}/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
+
+PLUGIN_SRC="$ADAPTER_DIR/qwenpaw"
+
+# QwenPaw installs requirements.txt with its own interpreter (the CLI's
+# shebang). On a platform without a matching wheel pip installs nothing and
+# still exits 0, and a released wheel may predate the SDK surface the plugin
+# imports, so prove the SDK imports there. QWENPAW_PYTHON overrides the
+# interpreter; a CLI without a Python shebang (frozen build) is left unverified.
+check_sdk() {
+    local python="${QWENPAW_PYTHON:-}"
+    if [ -z "$python" ]; then
+        python="$(sed -n '1s/^#![[:space:]]*//p' "$QWENPAW_BIN")"
+        case "$python" in
+            /usr/bin/env\ *) python="$(command -v "${python#/usr/bin/env }" 2>/dev/null || true)" ;;
+        esac
+    fi
+    if [ -z "$python" ] || [ ! -x "$python" ] || ! "$python" --version 2>&1 | grep -q '^Python '; then
+        return 2
+    fi
+    "$python" - <<'PY'
+import sys
+try:
+    import anolisa_tokenless as sdk
+except ImportError as error:
+    sys.exit(f"anolisa_tokenless is not importable by {sys.executable}: {error}")
+if not hasattr(sdk, "RecoveryMethod"):
+    sys.exit(f"anolisa_tokenless {sdk.__version__} predates the SDK surface the plugin needs")
+print(sdk.__version__)
+PY
+}
+
+line()  { printf '[%s] %s\n' "$COMPONENT" "$*"; }
+field() { printf '[%s]   %-26s %s\n' "$COMPONENT" "$1" "$2"; }
+
+PREREQ_MISSING=()
+INSTALL_MISSING=()
+note_prereq_missing() { PREREQ_MISSING+=("$1"); }
+note_install_missing() { INSTALL_MISSING+=("$1"); }
+
+if [ -z "$QWENPAW_BIN" ]; then
+    QWENPAW_BIN="$(command -v qwenpaw 2>/dev/null || true)"
+fi
+
+line "${AGENT} detect"
+if [ -n "$QWENPAW_BIN" ] && [ -x "$QWENPAW_BIN" ]; then
+    field "qwenpaw CLI" "present (${QWENPAW_BIN})"
+else
+    field "qwenpaw CLI" "missing"
+    note_prereq_missing "qwenpaw CLI"
+fi
+
+if [ -d "$QWENPAW_WORKING_DIR" ]; then
+    field "qwenpaw working dir" "present (${QWENPAW_WORKING_DIR})"
+else
+    field "qwenpaw working dir" "not initialized (${QWENPAW_WORKING_DIR})"
+    note_install_missing "qwenpaw working dir"
+fi
+
+if [ -f "$PLUGIN_SRC/plugin.json" ] && [ -f "$PLUGIN_SRC/plugin.py" ] && [ -f "$PLUGIN_SRC/requirements.txt" ]; then
+    field "plugin resource" "present (${PLUGIN_SRC})"
+else
+    field "plugin resource" "missing (${PLUGIN_SRC})"
+    note_prereq_missing "plugin resource"
+fi
+
+plugin_dst="${QWENPAW_WORKING_DIR%/}/plugins/${PLUGIN_ID}"
+if [ -f "$plugin_dst/plugin.json" ]; then
+    stale=""
+    for file in plugin.json plugin.py requirements.txt; do
+        cmp -s "$PLUGIN_SRC/$file" "$plugin_dst/$file" || stale="$file"
+    done
+    if [ -n "$stale" ]; then
+        field "${PLUGIN_ID} plugin" "stale (${plugin_dst}/${stale} differs from ${PLUGIN_SRC})"
+        note_install_missing "${PLUGIN_ID} plugin"
+    else
+        field "${PLUGIN_ID} plugin" "installed (${plugin_dst})"
+    fi
+else
+    field "${PLUGIN_ID} plugin" "missing (${plugin_dst})"
+    note_install_missing "${PLUGIN_ID} plugin"
+fi
+
+if [ -n "$QWENPAW_BIN" ] && [ -x "$QWENPAW_BIN" ]; then
+    sdk_version="$(check_sdk 2>/dev/null)" && sdk_status=0 || sdk_status=$?
+    case "$sdk_status" in
+        0) field "anolisa_tokenless SDK" "importable (${sdk_version})" ;;
+        2) field "anolisa_tokenless SDK" "unverified (no Python shebang in ${QWENPAW_BIN})" ;;
+        *)
+            field "anolisa_tokenless SDK" "not importable by QwenPaw's Python (${sdk_version})"
+            note_install_missing "anolisa_tokenless SDK"
+            ;;
+    esac
+fi
+
+if [ ${#PREREQ_MISSING[@]} -gt 0 ]; then
+    line "${AGENT}: missing prerequisites (${PREREQ_MISSING[*]})"
+    exit 2
+fi
+if [ ${#INSTALL_MISSING[@]} -gt 0 ]; then
+    line "${AGENT}: not installed (ready to install)"
+    exit 1
+fi
+line "${AGENT}: ready"
+exit 0

--- a/src/tokenless/adapters/tokenless/qwenpaw/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/qwenpaw/scripts/install.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# install.sh — Install the tokenless plugin into QwenPaw through its own CLI.
+#
+# `qwenpaw plugin install` copies the bundle into the QwenPaw working
+# directory, validates plugin.py, installs requirements.txt into QwenPaw's
+# Python environment, and hot-loads when QwenPaw is running. It exits 0 even
+# when it fails, so the installed files are compared with the source afterwards.
+set -euo pipefail
+
+AGENT="${ANOLISA_TARGET:-qwenpaw}"
+COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
+ADAPTER_DIR="${ANOLISA_ADAPTER_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# Resolve the working directory like QwenPaw: QWENPAW_WORKING_DIR, else
+# COPAW_WORKING_DIR, else a legacy ~/.copaw, else ~/.qwenpaw.
+QWENPAW_WORKING_DIR="${QWENPAW_WORKING_DIR:-${COPAW_WORKING_DIR:-}}"
+if [ -z "$QWENPAW_WORKING_DIR" ]; then
+    if [ -d "$HOME/.copaw" ]; then QWENPAW_WORKING_DIR="$HOME/.copaw"; else QWENPAW_WORKING_DIR="$HOME/.qwenpaw"; fi
+fi
+QWENPAW_BIN="${QWENPAW_BIN:-}"
+DRY_RUN="${ANOLISA_DRY_RUN:-0}"
+export PATH="${QWENPAW_HOME:-$HOME/.qwenpaw}/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
+
+PLUGIN_ID="tokenless"
+PLUGIN_SRC="$ADAPTER_DIR/qwenpaw"
+PLUGIN_DST="${QWENPAW_WORKING_DIR%/}/plugins/${PLUGIN_ID}"
+
+# QwenPaw installs requirements.txt with its own interpreter (the CLI's
+# shebang). On a platform without a matching wheel pip installs nothing and
+# still exits 0, and a released wheel may predate the SDK surface the plugin
+# imports, so prove the SDK imports there. QWENPAW_PYTHON overrides the
+# interpreter; a CLI without a Python shebang (frozen build) is left unverified.
+check_sdk() {
+    local python="${QWENPAW_PYTHON:-}"
+    if [ -z "$python" ]; then
+        python="$(sed -n '1s/^#![[:space:]]*//p' "$QWENPAW_BIN")"
+        case "$python" in
+            /usr/bin/env\ *) python="$(command -v "${python#/usr/bin/env }" 2>/dev/null || true)" ;;
+        esac
+    fi
+    if [ -z "$python" ] || [ ! -x "$python" ] || ! "$python" --version 2>&1 | grep -q '^Python '; then
+        return 2
+    fi
+    "$python" - <<'PY'
+import sys
+try:
+    import anolisa_tokenless as sdk
+except ImportError as error:
+    sys.exit(f"anolisa_tokenless is not importable by {sys.executable}: {error}")
+if not hasattr(sdk, "RecoveryMethod"):
+    sys.exit(f"anolisa_tokenless {sdk.__version__} predates the SDK surface the plugin needs")
+print(sdk.__version__)
+PY
+}
+
+echo "[${COMPONENT}] Installing ${AGENT} plugin..."
+
+if [ ! -f "$PLUGIN_SRC/plugin.json" ] || [ ! -f "$PLUGIN_SRC/plugin.py" ] || [ ! -f "$PLUGIN_SRC/requirements.txt" ]; then
+    echo "[${COMPONENT}] Missing plugin.json, plugin.py or requirements.txt in $PLUGIN_SRC" >&2
+    exit 1
+fi
+
+if [ -z "$QWENPAW_BIN" ]; then
+    QWENPAW_BIN="$(command -v qwenpaw 2>/dev/null || true)"
+fi
+if [ -z "$QWENPAW_BIN" ] || [ ! -x "$QWENPAW_BIN" ]; then
+    echo "[${COMPONENT}] qwenpaw CLI not found — skipping plugin installation."
+    echo "[${COMPONENT}] Install QwenPaw first (https://qwenpaw.agentscope.io/), then run this script again."
+    exit 0
+fi
+
+if [ "$DRY_RUN" = "1" ]; then
+    echo "DRY-RUN: QWENPAW_WORKING_DIR=${QWENPAW_WORKING_DIR%/} $QWENPAW_BIN plugin install $PLUGIN_SRC --force"
+    exit 0
+fi
+
+QWENPAW_WORKING_DIR="${QWENPAW_WORKING_DIR%/}" "$QWENPAW_BIN" plugin install "$PLUGIN_SRC" --force
+
+# A failed install may leave the previous bundle in place, so the installed
+# files must match the source bundle, not merely exist.
+for file in plugin.json plugin.py requirements.txt; do
+    if ! cmp -s "$PLUGIN_SRC/$file" "$PLUGIN_DST/$file"; then
+        echo "[${COMPONENT}] qwenpaw plugin install did not install $PLUGIN_SRC/$file into $PLUGIN_DST — see the output above." >&2
+        exit 1
+    fi
+done
+
+sdk_version="$(check_sdk)" && sdk_status=0 || sdk_status=$?
+case "$sdk_status" in
+    0) echo "[${COMPONENT}] anolisa_tokenless ${sdk_version} is importable by QwenPaw's Python." ;;
+    2) echo "[${COMPONENT}] Could not find QwenPaw's Python interpreter; anolisa_tokenless import left unverified." >&2 ;;
+    *)
+        echo "[${COMPONENT}] ${sdk_version}" >&2
+        echo "[${COMPONENT}] The plugin is copied but cannot run; install a matching anolisa_tokenless wheel into QwenPaw's Python environment (see $PLUGIN_SRC/requirements.txt for the supported platforms)." >&2
+        exit 1
+        ;;
+esac
+
+echo "[${COMPONENT}] ${AGENT} plugin installed to $PLUGIN_DST (from $PLUGIN_SRC)."

--- a/src/tokenless/adapters/tokenless/qwenpaw/scripts/uninstall.sh
+++ b/src/tokenless/adapters/tokenless/qwenpaw/scripts/uninstall.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# uninstall.sh — Remove the tokenless plugin from QwenPaw.
+set -euo pipefail
+
+AGENT="${ANOLISA_TARGET:-qwenpaw}"
+COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
+# Resolve the working directory like QwenPaw: QWENPAW_WORKING_DIR, else
+# COPAW_WORKING_DIR, else a legacy ~/.copaw, else ~/.qwenpaw.
+PLUGIN_ID="tokenless"
+QWENPAW_WORKING_DIR="${QWENPAW_WORKING_DIR:-${COPAW_WORKING_DIR:-}}"
+if [ -z "$QWENPAW_WORKING_DIR" ]; then
+    if [ -d "$HOME/.copaw" ]; then QWENPAW_WORKING_DIR="$HOME/.copaw"; other="$HOME/.qwenpaw"; else QWENPAW_WORKING_DIR="$HOME/.qwenpaw"; other="$HOME/.copaw"; fi
+    # ~/.copaw may have appeared or vanished since the plugin was installed:
+    # prefer the default location that actually holds it.
+    if [ ! -d "$QWENPAW_WORKING_DIR/plugins/$PLUGIN_ID" ] && [ -d "$other/plugins/$PLUGIN_ID" ]; then
+        QWENPAW_WORKING_DIR="$other"
+    fi
+fi
+QWENPAW_BIN="${QWENPAW_BIN:-}"
+DRY_RUN="${ANOLISA_DRY_RUN:-0}"
+export PATH="${QWENPAW_HOME:-$HOME/.qwenpaw}/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
+
+PLUGIN_DST="${QWENPAW_WORKING_DIR%/}/plugins/${PLUGIN_ID}"
+
+echo "[${COMPONENT}] Uninstalling ${AGENT} plugin..."
+
+if [ -z "$QWENPAW_BIN" ]; then
+    QWENPAW_BIN="$(command -v qwenpaw 2>/dev/null || true)"
+fi
+
+if [ "$DRY_RUN" = "1" ]; then
+    if [ -n "$QWENPAW_BIN" ] && [ -x "$QWENPAW_BIN" ]; then
+        echo "DRY-RUN: QWENPAW_WORKING_DIR=${QWENPAW_WORKING_DIR%/} $QWENPAW_BIN plugin uninstall ${PLUGIN_ID}"
+    else
+        echo "DRY-RUN: qwenpaw CLI not found; skip CLI uninstall"
+    fi
+    echo "DRY-RUN: rm -rf $PLUGIN_DST"
+    exit 0
+fi
+
+if [ ! -d "$PLUGIN_DST" ]; then
+    echo "[${COMPONENT}] no ${PLUGIN_ID} plugin is installed in $PLUGIN_DST; set QWENPAW_WORKING_DIR if QwenPaw uses another working directory."
+    exit 0
+fi
+
+# The CLI hot-unloads a running QwenPaw, prompts for confirmation, removes
+# the plugin directory, and exits 0 even when it fails: the directory still
+# being there means the plugin may still be loaded in a running QwenPaw.
+if [ -n "$QWENPAW_BIN" ] && [ -x "$QWENPAW_BIN" ]; then
+    printf 'y\n' | QWENPAW_WORKING_DIR="${QWENPAW_WORKING_DIR%/}" "$QWENPAW_BIN" plugin uninstall "$PLUGIN_ID" || true
+    if [ -f "$PLUGIN_DST/plugin.json" ]; then
+        echo "[${COMPONENT}] qwenpaw plugin uninstall did not remove $PLUGIN_DST; a running QwenPaw may still have the plugin loaded. Restart QwenPaw and run this script again." >&2
+        exit 1
+    fi
+else
+    echo "[${COMPONENT}] qwenpaw CLI not found; removing $PLUGIN_DST without hot-unloading. Restart QwenPaw if it is running." >&2
+fi
+
+rm -rf "$PLUGIN_DST"
+
+echo "[${COMPONENT}] ${AGENT} plugin uninstalled."

--- a/src/tokenless/packaging/raw/package.sh
+++ b/src/tokenless/packaging/raw/package.sh
@@ -101,6 +101,9 @@ stage_payload() {
         codex/.codex-plugin/plugin.json \
         qwencode/qwen-extension.json \
         qwencode/hooks/run-hook.sh \
+        qwenpaw/plugin.json \
+        qwenpaw/plugin.py \
+        qwenpaw/requirements.txt \
         common/cosh-extension.json \
         common/tool-ready-spec.json \
         common/tokenless-env-fix.sh; do

--- a/src/tokenless/packaging/raw/verify-release.py
+++ b/src/tokenless/packaging/raw/verify-release.py
@@ -85,6 +85,7 @@ def verify_versions(root: Path, contract: Path) -> str:
         adapters / "claude-code" / ".claude-plugin" / "plugin.json",
         adapters / "codex" / ".codex-plugin" / "plugin.json",
         adapters / "qwencode" / "qwen-extension.json",
+        adapters / "qwenpaw" / "plugin.json",
     )
     versions = {str(path.relative_to(root)): read_json_version(path) for path in json_manifests}
     hermes = adapters / "hermes" / "plugin.yaml"
@@ -94,6 +95,18 @@ def verify_versions(root: Path, contract: Path) -> str:
         raise SystemExit(
             f"ERROR: generated adapter versions do not match {expected}: "
             + ", ".join(drift)
+        )
+    # The QwenPaw requirements file is stamped too, but as wheel URLs: a
+    # stale or unstamped version there only fails inside `qwenpaw plugin install`.
+    requirements = adapters / "qwenpaw" / "requirements.txt"
+    text = requirements.read_text(encoding="utf-8")
+    referenced = set(re.findall(r"/tokenless/v([^/]+)/", text)) | set(
+        re.findall(r"anolisa_tokenless-([^-]+)-", text)
+    )
+    if "@VERSION@" in text or referenced != {expected}:
+        raise SystemExit(
+            f"ERROR: {requirements.relative_to(root)} does not reference "
+            f"tokenless {expected}: {sorted(referenced) or 'no wheel URL'}"
         )
     return expected
 

--- a/src/tokenless/tests/test-package-raw.sh
+++ b/src/tokenless/tests/test-package-raw.sh
@@ -24,7 +24,8 @@ mkdir -p \
     "$ADAPTERS/codex/.codex-plugin" \
     "$ADAPTERS/agentscope/build/lib/tokenless_agentscope" \
     "$ADAPTERS/agentscope/src/anolisa_tokenless_agentscope.egg-info" \
-    "$ADAPTERS/qwencode/hooks"
+    "$ADAPTERS/qwencode/hooks" \
+    "$ADAPTERS/qwenpaw"
 
 cat > "$SOURCE/Cargo.toml" <<EOF
 [workspace]
@@ -51,6 +52,10 @@ write_json_version "$ADAPTERS/qoder/.qoder-plugin/plugin.json"
 write_json_version "$ADAPTERS/claude-code/.claude-plugin/plugin.json"
 write_json_version "$ADAPTERS/codex/.codex-plugin/plugin.json"
 write_json_version "$ADAPTERS/qwencode/qwen-extension.json"
+write_json_version "$ADAPTERS/qwenpaw/plugin.json"
+printf 'plugin = None\n' > "$ADAPTERS/qwenpaw/plugin.py"
+printf 'anolisa-tokenless @ https://github.com/alibaba/anolisa/releases/download/tokenless/v%s/anolisa_tokenless-%s-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == "linux"\n' \
+    "$VERSION" "$VERSION" > "$ADAPTERS/qwenpaw/requirements.txt"
 printf '{"name":"anolisa-tokenless"}\n' \
     > "$ADAPTERS/claude-code/.claude-plugin/marketplace.json"
 printf 'version: "%s"\n' "$VERSION" > "$ADAPTERS/hermes/plugin.yaml"

--- a/src/tokenless/tests/test-qwenpaw-adapter-install.sh
+++ b/src/tokenless/tests/test-qwenpaw-adapter-install.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# Regression tests for the QwenPaw plugin install scripts.
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1" >&2; FAIL=$((FAIL + 1)); }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_ADAPTER_DIR="$SCRIPT_DIR/../adapters/tokenless"
+SANDBOX="$(mktemp -d -t tokenless-qwenpaw-install-test.XXXXXX)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+FAKE_HOME="$SANDBOX/home"
+ADAPTER_DIR="$SANDBOX/adapter root"
+QWENPAW_STUB="$FAKE_HOME/.qwenpaw/bin/qwenpaw"
+STUB_LOG="$FAKE_HOME/.qwenpaw/stub.log"
+PLUGIN_DST="$FAKE_HOME/.qwenpaw/plugins/tokenless"
+mkdir -p "$FAKE_HOME/.qwenpaw/bin" "$ADAPTER_DIR" "$SANDBOX/emptybin"
+cp -R "$SOURCE_ADAPTER_DIR"/. "$ADAPTER_DIR"/
+
+# Source checkouts contain the version templates; packages contain the
+# stamped files. Stamp only the sandbox copy so this test never modifies the tree.
+for template in plugin.json requirements.txt; do
+    sed 's/@VERSION@/0.0.0-test/g' "$ADAPTER_DIR/qwenpaw/$template.in" > "$ADAPTER_DIR/qwenpaw/$template"
+done
+
+cat > "$QWENPAW_STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+# Mimics `qwenpaw plugin ...`: copies the bundle, prompts on uninstall, and
+# exits 0 even on failure, exactly like the real CLI.
+set -euo pipefail
+log="$HOME/.qwenpaw/stub.log"
+printf '%s\n' "$*" >> "$log"
+printf 'WORKING_DIR=%s\n' "${QWENPAW_WORKING_DIR:-unset}" >> "$log"
+plugins="${QWENPAW_WORKING_DIR:-$HOME/.qwenpaw}/plugins"
+
+if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "install" ]; then
+    src="${3:?plugin path required}"
+    if [ "${QWENPAW_STUB_FAIL_INSTALL:-0}" = "1" ]; then
+        echo "❌ Failed to install plugin: simulated" >&2
+        exit 0
+    fi
+    dst="$plugins/tokenless"
+    if [ -d "$dst" ] && [ "${4:-}" != "--force" ]; then
+        echo "❌ Plugin 'tokenless' already installed. Use --force to overwrite." >&2
+        exit 0
+    fi
+    rm -rf "$dst"
+    mkdir -p "$plugins"
+    cp -R "$src" "$dst"
+    exit 0
+fi
+
+if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "uninstall" ]; then
+    [ "${3:-}" = "tokenless" ]
+    read -r answer || answer=""
+    [ "$answer" = "y" ] || exit 1
+    if [ "${QWENPAW_STUB_FAIL_UNINSTALL:-0}" = "1" ]; then
+        echo "❌ Failed to uninstall plugin: simulated" >&2
+        exit 0
+    fi
+    rm -rf "$plugins/tokenless"
+    exit 0
+fi
+
+echo "unsupported qwenpaw invocation: $*" >&2
+exit 2
+STUBEOF
+chmod +x "$QWENPAW_STUB"
+
+DETECT_SH="$ADAPTER_DIR/qwenpaw/scripts/detect.sh"
+INSTALL_SH="$ADAPTER_DIR/qwenpaw/scripts/install.sh"
+UNINSTALL_SH="$ADAPTER_DIR/qwenpaw/scripts/uninstall.sh"
+
+run() { HOME="$FAKE_HOME" ANOLISA_ADAPTER_DIR="$ADAPTER_DIR" "$@"; }
+
+run bash "$DETECT_SH" >/dev/null 2>&1
+if [ "$?" -eq 1 ]; then
+    pass "detect reports installable before installation"
+else
+    fail "detect did not report installable before installation"
+fi
+
+if run bash "$INSTALL_SH" >/dev/null; then
+    pass "plugin installation succeeds"
+else
+    fail "plugin installation failed"
+fi
+
+if [ -f "$PLUGIN_DST/plugin.json" ] && [ -f "$PLUGIN_DST/requirements.txt" ]; then
+    pass "qwenpaw copied the stamped bundle into its plugins directory"
+else
+    fail "installed bundle is missing plugin.json or requirements.txt"
+fi
+
+if grep -Fqx "plugin install $ADAPTER_DIR/qwenpaw --force" "$STUB_LOG" && \
+        grep -Fqx "WORKING_DIR=$FAKE_HOME/.qwenpaw" "$STUB_LOG"; then
+    pass "installer hands the bundle root to qwenpaw with the working directory set"
+else
+    fail "installer used an unexpected qwenpaw invocation"
+fi
+
+if run bash "$DETECT_SH" >/dev/null; then
+    pass "detect reports ready after installation"
+else
+    fail "detect did not report ready after installation"
+fi
+
+if run bash "$INSTALL_SH" >/dev/null; then
+    pass "plugin reinstallation is idempotent"
+else
+    fail "plugin reinstallation failed"
+fi
+
+rm -rf "$PLUGIN_DST"
+if run env QWENPAW_STUB_FAIL_INSTALL=1 bash "$INSTALL_SH" >/dev/null 2>&1; then
+    fail "installer trusted a zero exit status without an installed plugin"
+else
+    pass "installer fails when qwenpaw exits 0 without installing"
+fi
+
+if run env ANOLISA_DRY_RUN=1 bash "$INSTALL_SH" | grep -q '^DRY-RUN: ' && [ ! -d "$PLUGIN_DST" ]; then
+    pass "dry-run install prints the command and changes nothing"
+else
+    fail "dry-run install misbehaved"
+fi
+
+run bash "$INSTALL_SH" >/dev/null || fail "failed to reinstall plugin for uninstall coverage"
+
+if run bash "$UNINSTALL_SH" >/dev/null && [ ! -d "$PLUGIN_DST" ] && \
+        grep -Fqx "plugin uninstall tokenless" "$STUB_LOG"; then
+    pass "uninstaller confirms through qwenpaw and removes the plugin directory"
+else
+    fail "uninstaller did not remove the plugin through qwenpaw"
+fi
+
+if run bash "$UNINSTALL_SH" >/dev/null; then
+    pass "repeated uninstallation succeeds"
+else
+    fail "repeated uninstallation failed"
+fi
+
+run bash "$INSTALL_SH" >/dev/null || fail "failed to reinstall plugin for stale-bundle coverage"
+printf 'plugin = "previous"\n' > "$PLUGIN_DST/plugin.py"
+if run env QWENPAW_STUB_FAIL_INSTALL=1 bash "$INSTALL_SH" >/dev/null 2>&1; then
+    fail "installer accepted the previous bundle left behind by a failed reinstall"
+else
+    pass "installer fails when a failed reinstall leaves the previous bundle in place"
+fi
+run bash "$UNINSTALL_SH" >/dev/null || fail "failed to uninstall plugin before working-directory coverage"
+
+COPAW_ENV_DIR="$SANDBOX/copaw-env"
+if run env COPAW_WORKING_DIR="$COPAW_ENV_DIR" bash "$INSTALL_SH" >/dev/null && \
+        [ -f "$COPAW_ENV_DIR/plugins/tokenless/plugin.json" ] && [ ! -d "$PLUGIN_DST" ]; then
+    pass "installer honors COPAW_WORKING_DIR"
+else
+    fail "installer ignored COPAW_WORKING_DIR"
+fi
+if run env COPAW_WORKING_DIR="$COPAW_ENV_DIR" bash "$DETECT_SH" >/dev/null; then
+    pass "detect honors COPAW_WORKING_DIR"
+else
+    fail "detect ignored COPAW_WORKING_DIR"
+fi
+if run env COPAW_WORKING_DIR="$COPAW_ENV_DIR" bash "$UNINSTALL_SH" >/dev/null && \
+        [ ! -d "$COPAW_ENV_DIR/plugins/tokenless" ]; then
+    pass "uninstaller honors COPAW_WORKING_DIR"
+else
+    fail "uninstaller ignored COPAW_WORKING_DIR"
+fi
+
+mkdir -p "$FAKE_HOME/.copaw"
+if run bash "$INSTALL_SH" >/dev/null && \
+        [ -f "$FAKE_HOME/.copaw/plugins/tokenless/plugin.json" ] && [ ! -d "$PLUGIN_DST" ]; then
+    pass "installer uses a legacy ~/.copaw working directory"
+else
+    fail "installer ignored a legacy ~/.copaw working directory"
+fi
+if run bash "$DETECT_SH" >/dev/null; then
+    pass "detect uses a legacy ~/.copaw working directory"
+else
+    fail "detect ignored a legacy ~/.copaw working directory"
+fi
+if run bash "$UNINSTALL_SH" >/dev/null && [ ! -d "$FAKE_HOME/.copaw/plugins/tokenless" ]; then
+    pass "uninstaller uses a legacy ~/.copaw working directory"
+else
+    fail "uninstaller ignored a legacy ~/.copaw working directory"
+fi
+rm -rf "$FAKE_HOME/.copaw"
+
+QP_ENV_DIR="$SANDBOX/qwenpaw-env"
+if run env QWENPAW_WORKING_DIR="$QP_ENV_DIR" COPAW_WORKING_DIR="$COPAW_ENV_DIR" bash "$INSTALL_SH" >/dev/null && \
+        [ -f "$QP_ENV_DIR/plugins/tokenless/plugin.json" ] && [ ! -d "$COPAW_ENV_DIR/plugins/tokenless" ]; then
+    pass "QWENPAW_WORKING_DIR takes precedence over COPAW_WORKING_DIR"
+else
+    fail "COPAW_WORKING_DIR overrode QWENPAW_WORKING_DIR"
+fi
+run env QWENPAW_WORKING_DIR="$QP_ENV_DIR" bash "$UNINSTALL_SH" >/dev/null || fail "failed to uninstall plugin from QWENPAW_WORKING_DIR"
+mkdir -p "$FAKE_HOME/.copaw"
+if run env QWENPAW_WORKING_DIR="$QP_ENV_DIR" bash "$INSTALL_SH" >/dev/null && \
+        [ -f "$QP_ENV_DIR/plugins/tokenless/plugin.json" ] && [ ! -d "$FAKE_HOME/.copaw/plugins/tokenless" ]; then
+    pass "QWENPAW_WORKING_DIR takes precedence over a legacy ~/.copaw"
+else
+    fail "a legacy ~/.copaw overrode QWENPAW_WORKING_DIR"
+fi
+run env QWENPAW_WORKING_DIR="$QP_ENV_DIR" bash "$UNINSTALL_SH" >/dev/null || fail "failed to uninstall plugin from QWENPAW_WORKING_DIR"
+rm -rf "$FAKE_HOME/.copaw"
+
+# ~/.copaw appearing after installation must not hide the plugin in ~/.qwenpaw.
+run bash "$INSTALL_SH" >/dev/null || fail "failed to reinstall plugin for working-directory drift coverage"
+mkdir -p "$FAKE_HOME/.copaw"
+run bash "$DETECT_SH" >"$SANDBOX/detect-drift.out" 2>&1
+if grep -q "installed ($PLUGIN_DST)" "$SANDBOX/detect-drift.out"; then
+    pass "detect finds the plugin in ~/.qwenpaw after ~/.copaw appears"
+else
+    fail "detect lost the plugin in ~/.qwenpaw after ~/.copaw appeared"
+fi
+if run bash "$UNINSTALL_SH" >/dev/null && [ ! -d "$PLUGIN_DST" ] && \
+        [ "$(grep '^WORKING_DIR=' "$STUB_LOG" | tail -n1)" = "WORKING_DIR=$FAKE_HOME/.qwenpaw" ]; then
+    pass "uninstaller removes the plugin from ~/.qwenpaw after ~/.copaw appears"
+else
+    fail "uninstaller missed the plugin in ~/.qwenpaw after ~/.copaw appeared"
+fi
+if run bash "$UNINSTALL_SH" | grep -q 'no tokenless plugin is installed'; then
+    pass "uninstaller reports where it looked when nothing is installed"
+else
+    fail "uninstaller claimed success although nothing was installed"
+fi
+rm -rf "$FAKE_HOME/.copaw"
+
+run bash "$INSTALL_SH" >/dev/null || fail "failed to reinstall plugin for stale-detect coverage"
+printf 'plugin = "previous"\n' > "$PLUGIN_DST/plugin.py"
+run bash "$DETECT_SH" >"$SANDBOX/detect-stale.out" 2>&1
+if [ "$?" -eq 1 ] && grep -q 'stale (' "$SANDBOX/detect-stale.out"; then
+    pass "detect reports an installed bundle that differs from the source as stale"
+else
+    fail "detect did not report the stale bundle"
+fi
+run bash "$UNINSTALL_SH" >/dev/null || fail "failed to uninstall plugin after stale-detect coverage"
+
+run bash "$INSTALL_SH" >/dev/null || fail "failed to reinstall plugin for uninstall-failure coverage"
+if run env QWENPAW_STUB_FAIL_UNINSTALL=1 bash "$UNINSTALL_SH" >/dev/null 2>&1; then
+    fail "uninstaller reported success although qwenpaw left the plugin installed"
+else
+    [ -f "$PLUGIN_DST/plugin.json" ] && pass "uninstaller fails and keeps the directory when qwenpaw does not unload the plugin" \
+        || fail "uninstaller removed the directory although qwenpaw did not unload the plugin"
+fi
+run bash "$UNINSTALL_SH" >/dev/null || fail "failed to uninstall plugin after uninstall-failure coverage"
+
+# The stub CLI has a bash shebang, so the installer cannot find QwenPaw's
+# Python and leaves the SDK unverified; QWENPAW_PYTHON plus a fake package
+# exercises both verdicts.
+mkdir -p "$SANDBOX/sdk-ok/anolisa_tokenless" "$SANDBOX/sdk-old/anolisa_tokenless"
+printf '__version__ = "0.0.0-test"\nRecoveryMethod = object\n' > "$SANDBOX/sdk-ok/anolisa_tokenless/__init__.py"
+printf '__version__ = "0.0.0-old"\n' > "$SANDBOX/sdk-old/anolisa_tokenless/__init__.py"
+PYTHON3="$(command -v python3)"
+if run bash "$INSTALL_SH" 2>&1 | grep -q 'import left unverified'; then
+    pass "installer reports an unverified SDK when the CLI has no Python shebang"
+else
+    fail "installer did not report the unverified SDK"
+fi
+if run env QWENPAW_PYTHON="$PYTHON3" PYTHONPATH="$SANDBOX/sdk-ok" bash "$INSTALL_SH" | grep -q 'anolisa_tokenless 0.0.0-test is importable'; then
+    pass "installer verifies the SDK through QwenPaw's Python"
+else
+    fail "installer did not verify the SDK through QwenPaw's Python"
+fi
+if run env QWENPAW_PYTHON="$PYTHON3" PYTHONPATH="$SANDBOX/sdk-old" bash "$INSTALL_SH" >/dev/null 2>&1; then
+    fail "installer accepted a wheel without the required SDK surface"
+else
+    pass "installer fails when the installed SDK predates the plugin"
+fi
+if run env QWENPAW_PYTHON="$PYTHON3" PYTHONPATH="$SANDBOX/emptybin" bash "$INSTALL_SH" >/dev/null 2>&1; then
+    fail "installer accepted a QwenPaw environment without anolisa_tokenless"
+else
+    pass "installer fails when anolisa_tokenless is not importable"
+fi
+run env QWENPAW_PYTHON="$PYTHON3" PYTHONPATH="$SANDBOX/sdk-old" bash "$DETECT_SH" >"$SANDBOX/detect-old.out" 2>&1
+if [ "$?" -eq 1 ] && grep -q 'not importable' "$SANDBOX/detect-old.out"; then
+    pass "detect reports an SDK that predates the plugin as not ready"
+else
+    fail "detect did not report the outdated SDK"
+fi
+if run env QWENPAW_PYTHON="$PYTHON3" PYTHONPATH="$SANDBOX/sdk-ok" bash "$DETECT_SH" | grep -q 'importable (0.0.0-test)'; then
+    pass "detect reports the importable SDK version"
+else
+    fail "detect did not report the importable SDK version"
+fi
+run bash "$UNINSTALL_SH" >/dev/null || fail "failed to uninstall plugin after SDK coverage"
+
+if run env PATH="$SANDBOX/emptybin:/usr/bin:/bin" QWENPAW_HOME="$SANDBOX/nowhere" \
+        bash "$INSTALL_SH" 2>/dev/null | grep -q 'skipping plugin installation' && [ ! -d "$PLUGIN_DST" ]; then
+    pass "installer skips without a qwenpaw CLI"
+else
+    fail "installer did not skip cleanly without a qwenpaw CLI"
+fi
+
+run env PATH="$SANDBOX/emptybin:/usr/bin:/bin" QWENPAW_HOME="$SANDBOX/nowhere" \
+    bash "$DETECT_SH" >/dev/null 2>&1
+if [ "$?" -eq 2 ]; then
+    pass "detect reports missing prerequisites without a qwenpaw CLI"
+else
+    fail "detect did not report missing prerequisites without a qwenpaw CLI"
+fi
+
+echo ""
+echo "QwenPaw adapter tests: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/src/tokenless/tests/test_qwenpaw_plugin.py
+++ b/src/tokenless/tests/test_qwenpaw_plugin.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""Unit tests for the QwenPaw plugin lifecycle (no QwenPaw, AgentScope or wheel)."""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import importlib.util
+import json
+import shutil
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_PLUGIN_SRC = _ROOT / "adapters" / "tokenless" / "qwenpaw"
+sys.path.insert(0, str(_ROOT / "python" / "tokenless" / "python"))
+
+
+class _NativeError(Exception):
+    pass
+
+
+@dataclass
+class _CompressionResult:
+    output: str
+    applied: bool
+
+
+class _Runtime:
+    def __init__(self, data_dir=None, **_kwargs):
+        self.data_dir = str(data_dir or "/tmp/tokenless-test")
+
+
+class _ResultState(StrEnum):
+    RUNNING = "running"
+    SUCCESS = "success"
+    ERROR = "error"
+    DENIED = "denied"
+    INTERRUPTED = "interrupted"
+
+
+def _model_copy(self, *, update=None, deep=False):
+    result = copy.deepcopy(self) if deep else copy.copy(self)
+    for key, value in (update or {}).items():
+        setattr(result, key, value)
+    return result
+
+
+@dataclass
+class _TextBlock:
+    text: str
+
+    model_copy = _model_copy
+
+
+@dataclass
+class _DataBlock:
+    data: bytes
+
+
+@dataclass
+class _ToolResponse:
+    content: list
+    state: _ResultState = _ResultState.SUCCESS
+
+    model_copy = _model_copy
+
+
+@dataclass
+class _ToolChunk:
+    content: list
+    state: _ResultState = _ResultState.RUNNING
+
+
+class _MiddlewareBase:
+    pass
+
+
+@dataclass
+class _Call:
+    id: str
+    name: str
+    input: str
+
+    model_copy = _model_copy
+
+
+@dataclass
+class _State:
+    session_id: str
+    middle_context: dict = field(default_factory=dict)
+
+
+@dataclass
+class _Agent:
+    name: str
+    state: _State
+
+
+_CURRENT_STATE: list = [None]
+
+
+def _install_stubs() -> None:
+    native = types.ModuleType("anolisa_tokenless._native")
+    native._StatsQuery = object
+    native.CompressionResult = _CompressionResult
+    native.TokenlessError = _NativeError
+    native.TokenlessRuntime = _Runtime
+    native.__version__ = "0.0.0-test"
+    agentscope = types.ModuleType("agentscope")
+    agentscope.__path__ = []
+    message = types.ModuleType("agentscope.message")
+    message.TextBlock = _TextBlock
+    message.ToolResultState = _ResultState
+    middleware = types.ModuleType("agentscope.middleware")
+    middleware.MiddlewareBase = _MiddlewareBase
+    tool = types.ModuleType("agentscope.tool")
+    tool.ToolChunk = _ToolChunk
+    tool.ToolResponse = _ToolResponse
+    qwenpaw = types.ModuleType("qwenpaw")
+    qwenpaw.__path__ = []
+    config = types.ModuleType("qwenpaw.config")
+    config.__path__ = []
+    context = types.ModuleType("qwenpaw.config.context")
+    context.get_current_agent_state = lambda: _CURRENT_STATE[0]
+    sys.modules.update(
+        {
+            "anolisa_tokenless._native": native,
+            "agentscope": agentscope,
+            "agentscope.message": message,
+            "agentscope.middleware": middleware,
+            "agentscope.tool": tool,
+            "qwenpaw": qwenpaw,
+            "qwenpaw.config": config,
+            "qwenpaw.config.context": context,
+        }
+    )
+
+
+_install_stubs()
+core = importlib.import_module("anolisa_tokenless")
+
+# QwenPaw loads the installed bundle, whose plugin.json is stamped; stamp a
+# sandbox copy so the source tree stays untouched.
+_SANDBOX = Path(tempfile.mkdtemp(prefix="tokenless-qwenpaw-test-"))
+shutil.copy(_PLUGIN_SRC / "plugin.py", _SANDBOX / "plugin.py")
+(_SANDBOX / "plugin.json").write_text(
+    (_PLUGIN_SRC / "plugin.json.in")
+    .read_text(encoding="utf-8")
+    .replace("@VERSION@", "0.0.0-test"),
+    encoding="utf-8",
+)
+_spec = importlib.util.spec_from_file_location("qwenpaw_tokenless_plugin", _SANDBOX / "plugin.py")
+plugin = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(plugin)
+
+DATA_DIR = "/tmp/tokenless-qwenpaw-test-data"
+
+
+async def _collect(generator):
+    return [item async for item in generator]
+
+
+def _post_response(output: str, additional_context: str | None = None):
+    return core.PostToolResponse(
+        output=output,
+        disposition=core.Disposition.PASSTHROUGH,
+        content_type=core.ContentType.PLAIN_TEXT,
+        applied_operations=(),
+        recoverability=core.Recoverability.LOSSLESS,
+        before_tokens=1,
+        after_tokens=1,
+        stash_keys=(),
+        tokenizer_id="heuristic-v1",
+        additional_context=additional_context,
+    )
+
+
+class _FakeApi:
+    def __init__(self) -> None:
+        self.middlewares: list = []
+        self.tools: list = []
+
+    def register_middleware(self, factory, *, priority):
+        self.middlewares.append((factory, priority))
+
+    def register_tool(self, **kwargs):
+        self.tools.append(kwargs)
+
+
+class PluginTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.sdk = core.TokenlessSdk(core.TokenlessConfig(data_dir=DATA_DIR, rtk_enabled=False))
+        plugin._SDKS.clear()
+        plugin._SDKS[DATA_DIR] = self.sdk
+        self.middleware = plugin.TokenlessMiddleware(self.sdk, DATA_DIR)
+        self.agent = _Agent(name="Paw", state=_State(session_id="session-1"))
+        _CURRENT_STATE[0] = None
+
+        async def pre_tool(_request):
+            raise AssertionError("pre_tool must not run for this tool")
+
+        self.sdk.pre_tool = pre_tool
+
+    def test_register_wires_middleware_and_retrieve_tool(self) -> None:
+        api = _FakeApi()
+        with self.assertNoLogs(plugin.logger, level="WARNING"):
+            plugin.plugin.register(api)
+        self.assertEqual(api.middlewares, [(plugin._factory, 100)])
+        self.assertEqual(len(api.tools), 1)
+        self.assertEqual(api.tools[0]["tool_name"], "tokenless_retrieve")
+        self.assertIs(api.tools[0]["tool_func"], plugin.tokenless_retrieve)
+        self.assertTrue(api.tools[0]["enabled"])
+        self.assertEqual(api.tools[0]["tool_type"], "internal")
+
+    def test_register_warns_on_wheel_version_mismatch(self) -> None:
+        stamped = json.loads((_SANDBOX / "plugin.json").read_text(encoding="utf-8"))
+        stamped["version"] = "9.9.9"
+        (_SANDBOX / "plugin.json").write_text(json.dumps(stamped), encoding="utf-8")
+        try:
+            with self.assertLogs(plugin.logger, level="WARNING") as logs:
+                plugin.plugin.register(_FakeApi())
+        finally:
+            stamped["version"] = "0.0.0-test"
+            (_SANDBOX / "plugin.json").write_text(json.dumps(stamped), encoding="utf-8")
+        self.assertIn("plugin 9.9.9 runs against anolisa_tokenless 0.0.0-test", logs.output[0])
+
+    def test_factory_uses_workspace_data_dir_and_caches_sdk(self) -> None:
+        ctx = types.SimpleNamespace(
+            workspace=types.SimpleNamespace(workspace_dir="/tmp/tokenless-qwenpaw-test-data/..")
+        )
+        plugin._SDKS["/tmp/.tokenless"] = self.sdk
+        middleware = plugin._factory(ctx, agent_config=None)
+        self.assertIs(middleware.sdk, self.sdk)
+        self.assertEqual(middleware.data_dir, "/tmp/.tokenless")
+
+    def test_factory_resolves_relative_workspace_dirs(self) -> None:
+        ctx = types.SimpleNamespace(workspace=types.SimpleNamespace(workspace_dir="relative/ws"))
+        expected = str(Path("relative/ws").resolve() / ".tokenless")
+        plugin._SDKS[expected] = self.sdk
+        self.assertEqual(plugin._factory(ctx, agent_config=None).data_dir, expected)
+
+    def test_sdk_is_configured_with_the_registered_retrieve_tool(self) -> None:
+        fake_sdk = lambda config: types.SimpleNamespace(config=config)  # noqa: E731
+        with mock.patch.object(core, "TokenlessSdk", side_effect=fake_sdk):
+            sdk = plugin._sdk_for("/tmp/tokenless-qwenpaw-test-config")
+        self.assertEqual(sdk.config.retrieve_tool_name, "tokenless_retrieve")
+        self.assertTrue(sdk.config.rtk_enabled)
+
+    def test_register_refuses_a_wheel_without_the_required_sdk_surface(self) -> None:
+        api = _FakeApi()
+        with mock.patch.dict(core.__dict__):
+            del core.RecoveryMethod
+            with self.assertLogs(plugin.logger, level="ERROR") as logs:
+                plugin.plugin.register(api)
+        self.assertIn("lacks RecoveryMethod", logs.output[0])
+        self.assertEqual(api.middlewares, [])
+        self.assertEqual(api.tools, [])
+
+    async def test_model_call_compresses_schemas_and_records_markers(self) -> None:
+        seen = {}
+
+        async def before_model(request):
+            seen["request"] = request
+            return core.BeforeModelResponse(
+                tools=({"type": "function", "function": {"name": "read_file", "description": "short"}},),
+                visible_markers=frozenset({"<<tokenless:b>>", "<<tokenless:a>>"}),
+            )
+
+        self.sdk.before_model = before_model
+        tools = [
+            {"type": "function", "function": {"name": "read_file", "description": "long"}},
+            plugin.RETRIEVE_DECLARATION,
+        ]
+        input_kwargs = {"messages": [{"role": "user", "content": "hi"}], "tools": tools, "tool_choice": "auto"}
+        snapshot = copy.deepcopy(input_kwargs)
+
+        async def next_handler(**kwargs):
+            return kwargs
+
+        result = await self.middleware.on_model_call(self.agent, input_kwargs, next_handler)
+
+        self.assertEqual(seen["request"].tools, (tools[0],))
+        self.assertEqual(seen["request"].attribution, core.Attribution("qwenpaw", "session-1"))
+        self.assertEqual(seen["request"].capabilities.recovery, core.RecoveryMethod.tool("tokenless_retrieve"))
+        self.assertEqual(json.loads(seen["request"].visible_context), snapshot["messages"])
+        self.assertEqual(
+            result["tools"],
+            [
+                {"type": "function", "function": {"name": "read_file", "description": "short"}},
+                plugin.RETRIEVE_DECLARATION,
+            ],
+        )
+        self.assertEqual(result["tool_choice"], "auto")
+        self.assertEqual(input_kwargs, snapshot)
+        self.assertEqual(
+            self.agent.state.middle_context["anolisa_tokenless"],
+            {
+                "visible_markers": ["<<tokenless:a>>", "<<tokenless:b>>"],
+                "agent_id": "qwenpaw",
+                "data_dir": DATA_DIR,
+            },
+        )
+
+    async def test_shell_call_is_rewritten_on_a_copy_and_result_replaced(self) -> None:
+        seen = {}
+
+        async def pre_tool(request):
+            seen["pre"] = request
+            return core.PreToolResponse(
+                arguments={"command": "/rtk ls"},
+                action=core.PreToolAction.REPLACE_ARGUMENTS,
+                output_optimization=core.OutputOptimization.RTK,
+            )
+
+        async def post_tool(request):
+            seen["post"] = request
+            return _post_response("small")
+
+        self.sdk.pre_tool = pre_tool
+        self.sdk.post_tool = post_tool
+        call = _Call(id="call-1", name="execute_shell_command", input='{"command": "ls"}')
+        forwarded = {}
+
+        async def next_handler(**kwargs):
+            forwarded.update(kwargs)
+            yield "stream-chunk"
+            yield _ToolResponse(content=[_TextBlock(text="big output")])
+
+        items = await _collect(self.middleware.on_acting(self.agent, {"tool_call": call}, next_handler))
+
+        self.assertEqual(seen["pre"].tool_name, "execute_shell_command")
+        self.assertEqual(seen["pre"].arguments, {"command": "ls"})
+        self.assertEqual(seen["pre"].command_field, "command")
+        self.assertEqual(seen["pre"].attribution, core.Attribution("qwenpaw", "session-1", "call-1"))
+        self.assertTrue(seen["pre"].capabilities.replace_arguments)
+        self.assertFalse(seen["pre"].capabilities.block_and_suggest)
+        self.assertEqual(forwarded["tool_call"].input, '{"command":"/rtk ls"}')
+        self.assertEqual(call.input, '{"command": "ls"}')
+        self.assertEqual(seen["post"].content_origin, core.ContentOrigin.COMMAND_OUTPUT)
+        self.assertEqual(seen["post"].output_optimization, core.OutputOptimization.RTK)
+        self.assertEqual(seen["post"].capabilities.recovery, core.RecoveryMethod())
+        self.assertEqual(seen["post"].status, core.ToolResultStatus.SUCCESS)
+        self.assertEqual(seen["post"].result_kind, core.ResultKind.TOOL)
+        self.assertEqual(seen["post"].tool_name, "execute_shell_command")
+        self.assertEqual(items[0], "stream-chunk")
+        self.assertEqual(items[1].content, [_TextBlock(text="small")])
+
+    async def test_non_object_shell_arguments_are_rejected(self) -> None:
+        call = _Call(id="call-1", name="execute_shell_command", input='["ls"]')
+
+        async def next_handler(**_kwargs):
+            yield _ToolResponse(content=[])
+
+        with self.assertRaises(TypeError):
+            await _collect(self.middleware.on_acting(self.agent, {"tool_call": call}, next_handler))
+
+    async def test_block_and_suggest_is_rejected(self) -> None:
+        async def pre_tool(_request):
+            return core.PreToolResponse(
+                arguments={}, action=core.PreToolAction.BLOCK_AND_SUGGEST,
+                output_optimization=core.OutputOptimization.RTK,
+            )
+
+        self.sdk.pre_tool = pre_tool
+        call = _Call(id="call-1", name="execute_shell_command", input='{"command": "ls"}')
+
+        async def next_handler(**_kwargs):
+            yield _ToolResponse(content=[])
+
+        with self.assertRaises(RuntimeError):
+            await _collect(self.middleware.on_acting(self.agent, {"tool_call": call}, next_handler))
+
+    async def test_registered_origins_and_unregistered_tools_pass_through(self) -> None:
+        origins = {}
+        recoveries = set()
+
+        async def post_tool(request):
+            origins[request.tool_name] = request.content_origin
+            recoveries.add(request.capabilities.recovery)
+            return _post_response(request.content)
+
+        self.sdk.post_tool = post_tool
+
+        for name in ("read_file", "grep_search", "mcp__weather__lookup"):
+            call = _Call(id=f"call-{name}", name=name, input="{}")
+
+            async def next_handler(**kwargs):
+                self.assertIs(kwargs["tool_call"], call)
+                yield _ToolResponse(content=[_TextBlock(text="payload")])
+
+            items = await _collect(self.middleware.on_acting(self.agent, {"tool_call": call}, next_handler))
+            self.assertEqual(items[0].content, [_TextBlock(text="payload")])
+
+        self.assertEqual(origins["read_file"], core.ContentOrigin.FILE_CONTENT)
+        self.assertEqual(origins["grep_search"], core.ContentOrigin.API_RESPONSE)
+        # Unregistered tools take the passthrough origin, never a compressible one.
+        self.assertEqual(origins["mcp__weather__lookup"], core.ContentOrigin.FILE_CONTENT)
+        self.assertEqual(recoveries, {core.RecoveryMethod.tool("tokenless_retrieve")})
+
+    async def test_error_status_maps_and_additional_context_is_appended(self) -> None:
+        seen = []
+
+        async def post_tool(request):
+            seen.append(request)
+            return _post_response(request.content, additional_context="hint" if len(seen) == 1 else "ignored")
+
+        self.sdk.post_tool = post_tool
+        call = _Call(id="call-1", name="web_fetch", input="{}")
+        original = _ToolResponse(
+            content=[_TextBlock(text="one"), _DataBlock(data=b"x"), _TextBlock(text="two")],
+            state=_ResultState.ERROR,
+        )
+
+        async def next_handler(**_kwargs):
+            yield original
+
+        items = await _collect(self.middleware.on_acting(self.agent, {"tool_call": call}, next_handler))
+
+        self.assertEqual([request.status for request in seen], [core.ToolResultStatus.ERROR] * 2)
+        self.assertEqual([request.capabilities.recovery for request in seen], [core.RecoveryMethod()] * 2)
+        self.assertEqual(
+            items[0].content,
+            [_TextBlock(text="one"), _DataBlock(data=b"x"), _TextBlock(text="two"), _TextBlock(text="hint")],
+        )
+        self.assertEqual(items[0].state, _ResultState.ERROR)
+        self.assertEqual(len(original.content), 3)
+
+    async def test_unchanged_response_is_returned_as_is(self) -> None:
+        async def post_tool(request):
+            return _post_response(request.content)
+
+        self.sdk.post_tool = post_tool
+        call = _Call(id="call-1", name="web_fetch", input="{}")
+        original = _ToolResponse(content=[_TextBlock(text="same")])
+
+        async def next_handler(**_kwargs):
+            yield original
+
+        items = await _collect(self.middleware.on_acting(self.agent, {"tool_call": call}, next_handler))
+        self.assertIs(items[0], original)
+
+    async def test_retrieve_tool_call_bypasses_post_tool(self) -> None:
+        async def post_tool(_request):
+            raise AssertionError("retrieve results must not be compressed")
+
+        self.sdk.post_tool = post_tool
+        call = _Call(id="call-1", name="tokenless_retrieve", input='{"hash_or_marker": "abc"}')
+        response = _ToolResponse(content=[_TextBlock(text="restored")])
+
+        async def next_handler(**kwargs):
+            self.assertIs(kwargs["tool_call"], call)
+            yield response
+
+        items = await _collect(self.middleware.on_acting(self.agent, {"tool_call": call}, next_handler))
+        self.assertIs(items[0], response)
+
+    async def test_retrieve_tool_uses_session_state(self) -> None:
+        seen = {}
+
+        async def retrieve(request):
+            seen["request"] = request
+            return core.RetrieveResponse(hash="abc", payload="full payload")
+
+        self.sdk.retrieve = retrieve
+        _CURRENT_STATE[0] = _State(
+            session_id="session-1",
+            middle_context={
+                "anolisa_tokenless": {
+                    "visible_markers": ["<<tokenless:abc>>"],
+                    "agent_id": "qwenpaw",
+                    "data_dir": DATA_DIR,
+                }
+            },
+        )
+
+        chunk = await plugin.tokenless_retrieve("<<tokenless:abc>>")
+
+        self.assertEqual(
+            seen["request"],
+            core.RetrieveRequest(
+                "<<tokenless:abc>>",
+                frozenset({"<<tokenless:abc>>"}),
+                core.Attribution("qwenpaw", "session-1"),
+            ),
+        )
+        self.assertEqual(
+            chunk,
+            _ToolChunk(content=[_TextBlock(text="full payload")], state=_ResultState.SUCCESS),
+        )
+
+    async def test_retrieve_tool_reports_errors_as_tool_errors(self) -> None:
+        async def retrieve(_request):
+            raise core.TokenlessError("marker not authorized")
+
+        self.sdk.retrieve = retrieve
+        _CURRENT_STATE[0] = _State(
+            session_id="session-1",
+            middle_context={
+                "anolisa_tokenless": {"visible_markers": [], "agent_id": "qwenpaw", "data_dir": DATA_DIR}
+            },
+        )
+        chunk = await plugin.tokenless_retrieve("zzz")
+        self.assertEqual(chunk.state, _ResultState.ERROR)
+        self.assertEqual(chunk.content, [_TextBlock(text="marker not authorized")])
+
+        _CURRENT_STATE[0] = _State(session_id="session-2")
+        chunk = await plugin.tokenless_retrieve("zzz")
+        self.assertEqual(chunk.state, _ResultState.ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -60,6 +60,9 @@ Copilot-shell extension is auto-discovered from /usr/share/anolisa/extensions/to
 Hermes Agent plugin (response compression, TOON encoding, command rewriting via RTK,
 and Tool Ready) is available under /usr/share/anolisa/adapters/tokenless/hermes/.
 Run the install script to register with Hermes: hermes/scripts/install.sh
+QwenPaw plugin (schema compression, response/TOON compression, command rewriting via RTK)
+is available under /usr/share/anolisa/adapters/tokenless/qwenpaw/.
+Run the install script to register with QwenPaw: qwenpaw/scripts/install.sh
 Claude Code plugin (RTK command rewriting, response/TOON compression, and Tool Ready
 environment pre-check) is available under /usr/share/anolisa/adapters/tokenless/claude-code/.
 Register it with the official `claude plugin marketplace add` / `claude plugin install`
@@ -101,6 +104,7 @@ mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/scripts
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/openclaw/dist
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/dsh/dist
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/hermes/scripts
+mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qwenpaw/scripts
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/.qoder-plugin
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/scripts
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qoder/commands
@@ -165,6 +169,15 @@ install -m 0644 adapters/tokenless/hermes/plugin.yaml %{buildroot}%{_datadir}/an
 install -m 0755 adapters/tokenless/hermes/scripts/detect.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/hermes/scripts/
 install -m 0755 adapters/tokenless/hermes/scripts/install.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/hermes/scripts/
 install -m 0755 adapters/tokenless/hermes/scripts/uninstall.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/hermes/scripts/
+
+# Install QwenPaw plugin (AgentScope middleware + install scripts). The
+# anolisa_tokenless wheel is pulled by QwenPaw from requirements.txt.
+install -m 0755 adapters/tokenless/qwenpaw/plugin.py %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qwenpaw/
+install -m 0644 adapters/tokenless/qwenpaw/plugin.json %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qwenpaw/
+install -m 0644 adapters/tokenless/qwenpaw/requirements.txt %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qwenpaw/
+install -m 0755 adapters/tokenless/qwenpaw/scripts/detect.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qwenpaw/scripts/
+install -m 0755 adapters/tokenless/qwenpaw/scripts/install.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qwenpaw/scripts/
+install -m 0755 adapters/tokenless/qwenpaw/scripts/uninstall.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qwenpaw/scripts/
 
 # Install the native Qoder CLI plugin. The wrapper resolves implementation
 # scripts from common/hooks/ so the hook logic remains shared.
@@ -248,6 +261,8 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 %dir %{_datadir}/anolisa/adapters/tokenless/dsh/dist
 %dir %{_datadir}/anolisa/adapters/tokenless/hermes
 %dir %{_datadir}/anolisa/adapters/tokenless/hermes/scripts
+%dir %{_datadir}/anolisa/adapters/tokenless/qwenpaw
+%dir %{_datadir}/anolisa/adapters/tokenless/qwenpaw/scripts
 %dir %{_datadir}/anolisa/adapters/tokenless/qoder
 %dir %{_datadir}/anolisa/adapters/tokenless/qoder/.qoder-plugin
 %dir %{_datadir}/anolisa/adapters/tokenless/qoder/scripts
@@ -289,6 +304,12 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/hermes/scripts/detect.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/hermes/scripts/install.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/hermes/scripts/uninstall.sh
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/qwenpaw/plugin.py
+%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/qwenpaw/plugin.json
+%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/qwenpaw/requirements.txt
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/qwenpaw/scripts/detect.sh
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/qwenpaw/scripts/install.sh
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/qwenpaw/scripts/uninstall.sh
 # Qoder CLI plugin — native hook wrapper resolves scripts from common/hooks/.
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/qoder/.qoder-plugin/plugin.json
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/qoder/hooks/hooks.json
@@ -456,6 +477,19 @@ if [ $1 -eq 0 ]; then
         bash "$HERMES_SCRIPT" || true
     elif [ -d "$HOME/.hermes/plugins/tokenless" ]; then
         rm -rf "$HOME/.hermes/plugins/tokenless" 2>/dev/null || true
+    fi
+    # Uninstall qwenpaw plugin (via qwenpaw CLI or manual cleanup)
+    QWENPAW_SCRIPT="%{_datadir}/anolisa/adapters/tokenless/qwenpaw/scripts/uninstall.sh"
+    if [ -f "$QWENPAW_SCRIPT" ]; then
+        bash "$QWENPAW_SCRIPT" || true
+    else
+        # Same resolution as uninstall.sh: QWENPAW_WORKING_DIR, COPAW_WORKING_DIR,
+        # an existing ~/.copaw, else ~/.qwenpaw.
+        QWENPAW_WD="${QWENPAW_WORKING_DIR:-${COPAW_WORKING_DIR:-}}"
+        if [ -z "$QWENPAW_WD" ]; then
+            if [ -d "$HOME/.copaw" ]; then QWENPAW_WD="$HOME/.copaw"; else QWENPAW_WD="$HOME/.qwenpaw"; fi
+        fi
+        rm -rf "$QWENPAW_WD/plugins/tokenless" 2>/dev/null || true
     fi
     # Uninstall claude-code plugin (remove via claude CLI or strip settings.json).
     # Note: %preun runs as root so this only touches root's ~/.claude — per-user


### PR DESCRIPTION
## Why

QwenPaw (formerly CoPaw) is an AgentScope-based personal agent with its own plugin system, and it had no Tokenless integration. Its tool schemas (27 built-in tools, ~32K characters per model call) and shell/tool results reach the model uncompressed, so QwenPaw users get none of the schema, RTK, response/TOON, or recovery savings the other adapters provide.

## What changed

- `src/tokenless/adapters/tokenless/qwenpaw/`: a native QwenPaw plugin. `plugin.py` registers an AgentScope middleware through `api.register_middleware` and a static `tokenless_retrieve` tool through `api.register_tool`, and calls the in-process `anolisa_tokenless.TokenlessSdk` directly with the `RecoveryMethod` capabilities introduced in #3068. `on_model_call` compresses schemas; `on_acting` rewrites `execute_shell_command` through RTK after QwenPaw's approval step and replaces tool-result text blocks through the response/TOON pipeline for QwenPaw's built-in tools; tools outside that table pass through untouched. Records land under `<workspace>/.tokenless`.
- Wheel delivery: `requirements.txt.in` points at the matching GitHub Release wheel URLs with platform markers, so `qwenpaw plugin install` installs `anolisa_tokenless` into QwenPaw's own Python environment; the Makefile, scripts, and anolisa never run pip.
- `crates/anolisa-core/src/adapter/qwenpaw.rs`: a framework driver that delegates enable/disable to `qwenpaw plugin install --force` / `plugin uninstall` and verifies the installed bundle after enable and the removed manifest after disable, because the CLI reports failures on stdout and still exits 0. Disable uses the working directory recorded in the receipt, not the ambient resolution. The tokenless component manifest registers the adapter.
- Detect/install/uninstall scripts, `make qwenpaw-install`/`qwenpaw-uninstall`, version stamping, raw/RPM packaging, user-guide docs (en/zh), and tests.

## Related issue

no-issue: new framework adapter following the existing adapter pattern (DSH, Hermes, Qoder); no tracking issue was filed for QwenPaw.

## User / Agent impact

New opt-in integration: `anolisa adapter enable tokenless qwenpaw` or `make qwenpaw-install`. Existing adapters and the SDK are unchanged. Note that the plugin needs a released `anolisa_tokenless` wheel with the `RecoveryMethod` SDK surface; the current 0.7.14 release wheel predates it, so a package stamped 0.7.14 points at a wheel without it. The plugin then refuses to register and logs the required release (Tokenless stays disabled, QwenPaw keeps working), and the install script fails when the wheel is not importable from QwenPaw's interpreter. Packages built after the next version bump pick up the matching wheel.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

`anolisa adapter enable/disable/status tokenless qwenpaw` gains a new framework target. Shared anolisa surfaces change additively: `DriverPayload` gains a `qwenpaw` variant (no `DRIVER_SCHEMA_VERSION` bump, since existing payloads keep their shape), `plan_disable_report` takes the CLI step from the driver instead of hard-coding hermes, `allowed_adapter_types` and the driver registry gain the qwenpaw entries, and `rpm-build.sh` / `check-component-versions.py` list the new stamped files. The generic SDK layer and `tokenless_agentscope` are not modified; the plugin is a separate consumer of `TokenlessSdk`.

## Validation

- `python3 tests/test_qwenpaw_plugin.py` (16 tests), `bash tests/test-qwenpaw-adapter-install.sh` (32 checks with a stubbed CLI), `bash tests/test-package-raw.sh`, `make test-integration`, `cargo test -p anolisa-core --test adapter_frameworks` (66 tests), `scripts/check-component-versions.py`.
- Install/detect/uninstall scripts also run against the real QwenPaw 2.2.0 CLI in a venv: `plugin install` copies the three bundle files verbatim (the byte comparison passes), `detect` reports the importable SDK, `plugin uninstall` exits 0 even for an absent plugin.
- Live against QwenPaw 2.2.0 from PyPI in a clean sandbox with a locally built wheel: real `qwenpaw plugin install/uninstall`, then console chats through `qwenpaw app` with a logging proxy in front of the model. Schema compression 31818 → 20733 chars per call with 49 recovery instructions, RTK rewrite of `ls -la` 11480 → 4490 chars, TOON on a 1000-record JSON output 51313 → 24332 chars (lossless), and `tokenless_retrieve` hits on a bare hash. Verified with both a scripted fake model and Bailian Token Plan `qwen3.8-flash`, which followed the recovery instruction unprompted when asked for the truncated description.
- Observed interaction: QwenPaw's own tool-result pruning middleware runs after Tokenless (50000 bytes for recent results, 3000 for older ones, overflow spilled to `tool_results/`), so it prunes the already-compressed text.

## Documentation and rollback

Docs: `docs/user-guide/{en,zh}/token-saving/tokenless/{QUICKSTART,framework-integration}.md`, `src/tokenless/README{,_zh}.md`; the CHANGELOG entry belongs to the release bump PR. Rollback: run `anolisa adapter disable tokenless qwenpaw` (or `make qwenpaw-uninstall`) **before** downgrading anolisa or reverting these commits. `claims.toml` is shared by all components and parsed as a whole, and `DriverPayload` has no fallback variant, so an older anolisa binary cannot read a state file that still holds a `qwenpaw` receipt; with the receipt removed, reverting the two commits removes the adapter entirely with no data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PF9EPWwcbiAgv6a9jqjhvg

