### PR TITLE
chore(anolisa): bump version to 0.3.10

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.10] - 2026-09-06
+
+### Added
+
+- QwenPaw plugin adapters can now be discovered, enabled, inspected, and
+  disabled through `anolisa adapter`. For Tokenless packages that include the
+  QwenPaw bundle, use `anolisa adapter enable tokenless qwenpaw`. Installation
+  and removal use QwenPaw's CLI and verify the resulting plugin files; failed
+  removal preserves the plugin directory and receipt for a retry, and cleanup
+  uses the working directory recorded at enable time
+  ([#3075](https://github.com/alibaba/anolisa/pull/3075)).
+
+### Fixed
+
+- `anolisa logs --limit N` now returns the most recent N matching records in
+  append order, with the oldest record in that window first, instead of
+  returning the earliest matches. The default limit of 50 therefore shows
+  recent activity as logs grow, and scanning existing logs no longer blocks
+  new records from being appended
+  ([#2618](https://github.com/alibaba/anolisa/pull/2618)).
+
 ## [0.3.9] - 2026-09-02
 
 ### Added

--- a/src/anolisa/CHANGELOG_zh.md
+++ b/src/anolisa/CHANGELOG_zh.md
@@ -9,6 +9,24 @@
 
 ## [未发布]
 
+## [0.3.10] - 2026-09-06
+
+### 新增
+
+- 现在可通过 `anolisa adapter` 发现、启用、查看和禁用 QwenPaw 插件适配器。
+  安装包含 QwenPaw 适配器包的 Tokenless 后，可使用
+  `anolisa adapter enable tokenless qwenpaw` 启用。安装和移除均调用 QwenPaw
+  CLI，并校验操作后的插件文件；移除失败时保留插件目录和操作凭据以便重试，
+  清理时使用启用时记录的工作目录
+  ([#3075](https://github.com/alibaba/anolisa/pull/3075))。
+
+### 修复
+
+- `anolisa logs --limit N` 现在按追加顺序选取最近 N 条匹配记录，并在结果中
+  将较早的记录排在前面，不再返回最早的匹配记录。因此，默认 50 条的限制在日志
+  增长后仍会显示近期活动；扫描已有日志时也不再阻塞新记录的追加
+  ([#2618](https://github.com/alibaba/anolisa/pull/2618))。
+
 ## [0.3.9] - 2026-09-02
 
 ### 新增

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "chrono",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.9"
+version = "0.3.10"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.93"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,11 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Wed Sep 02 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Sun Sep 06 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Manage QwenPaw plugin adapters through the framework CLI with verified cleanup.
+- Log limits now return recent matches without blocking new log appends during scans.
+
+* Wed Sep 02 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.3.9-1
 - Dry-runs now preview supported commands and reject unsupported requests before effects.
 - Self-updates now write redacted central operation-log records.
 - Raw repository defaults no longer advertise inactive cache settings.

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.3.9",
-    "@anolisa/cli-linux-arm64": "0.3.9",
-    "@anolisa/cli-darwin-arm64": "0.3.9"
+    "@anolisa/cli-linux-x64": "0.3.10",
+    "@anolisa/cli-linux-arm64": "0.3.10",
+    "@anolisa/cli-darwin-arm64": "0.3.10"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

ANOLISA still reports 0.3.9 after QwenPaw adapter support and the recent-log fix merged. Prepare 0.3.10 so distribution metadata and bilingual release notes describe the same release boundary, starting after `144ef2cb8e917db269aa7f07362579ea0b5dc59e`.

## What changed

- Synchronize the Cargo workspace and its five lockfile entries, npm root and three native package templates, and the RPM changelog boundary.
- Add matching English and Chinese 0.3.10 changelog entries for #3075 and #2618. The provisioning dependency-injection refactor preserves behavior and is omitted from the notes.
- Keep all nine release files in one atomic version-bump commit; third-party dependencies are unchanged.

## Related issue

no-issue: routine component version bump aggregating already-merged changes from #3075 and #2618.

## User / Agent impact

- QwenPaw plugin adapters can be discovered, enabled, inspected, and disabled through ANOLISA. Tokenless integration requires an installed package containing its QwenPaw adapter bundle.
- `anolisa logs --limit N` returns the most recent matching records in append order, oldest first within that window. Scanning existing logs no longer holds up new log appends.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The bump changes release metadata and documentation only; the summarized runtime changes are already on main. The release adds a QwenPaw driver/receipt type and Tokenless adapter declaration, while log limits intentionally change from earliest to most recent matches. Before downgrading to 0.3.9, successfully disable any QwenPaw adapters using 0.3.10 so the older CLI does not encounter unsupported QwenPaw receipts.

## Validation

Linux x86_64; Rust/Cargo 1.93.1, Node.js 24.15.0, npm 11.12.1. Rust compiler wrappers were unset for validation.

- `cargo fmt --all` and `cargo fmt --all -- --check`
- `cargo check --workspace` (regenerated only the five workspace package versions in `Cargo.lock`)
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`: 2436 passed, 0 failed, 1 ignored, including documentation tests and QwenPaw fake-CLI integration tests for failed installs/uninstalls, retries, recorded working directories, dry-runs, and status.
- `cargo doc --workspace --no-deps --locked`
- `node npm/tests/platforms.test.js` and `node npm/scripts/package-npm.js --validate`
- `bash tests/test-package-prebuilt.sh`, `bash ../../.github/actions/build-anolisa-prebuilt/test.sh`, and `python3 ../../.github/actions/prebuilt-rust-common/test_plan_matrix.py`
- `node npm/scripts/package-npm.js --target linux-x64`; local root/native tarball installation and the installed CLI's `--version` report 0.3.10.
- RPM rendering with `sed 's/@VERSION@/0.3.10/g' anolisa.spec.in | rpmspec -P /dev/stdin`; current and historical changelog versions verified.
- Bundled `check_release.py` audit against the 0.3.9 content commit; bilingual commands and PR links match, and `git diff --check` passes.
- From the repository root: `bash scripts/docs-lint.sh`, `python3 scripts/docs-link-check.py`, `npm ci --prefix website`, and website `build`, `typecheck`, and `check:links` scripts; 190 generated HTML files pass link/ID validation.

Linux arm64 and macOS arm64 were validated through metadata, templates, and prebuilt packer tests, not native execution. No full RPM build or live QwenPaw server test was performed. Website dependency installation reports 33 audit findings (9 moderate, 24 high); its dependency files are unchanged.

## Documentation and rollback

Updated `src/anolisa/CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM changelog with the same user-visible release scope. Revert the single bump commit to undo the release metadata change. For an installed downgrade, disable QwenPaw adapters successfully before returning to 0.3.9 as described above; no automatic migration is introduced by this bump.
