### PR TITLE
refactor(anolisa): inject doctor dependency probes

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
@@ -14,13 +14,14 @@ use anolisa_core::domain::{
     Installation, InstallationScope, LifecycleStatus, ManagementRelation, ProviderBinding,
 };
 use anolisa_core::facts::{FactsError, JournalEvidence, JournalInventory};
+use anolisa_core::manifest::RuntimeDependency;
 use anolisa_core::{
     CheckEnv, CheckOutcome, CheckSpec, CheckStatus, ComponentManifest, ComponentSnapshot,
     DependencyKind, DependencyResolution, DependencyResolver, DependencyStatus, HealthEntry,
     IntegrityStatus, ManifestHealthProvenance, ManifestHealthSnapshot, NativePackageProvenance,
-    NativePackageSnapshot, ProbeEvidence, ResolverEnv, ServiceManager, ServiceRef, ServiceScope,
-    ServiceState, StateRootScope, StateSnapshot, check_owned_file, run_check,
-    service_for_install_mode, user_service_for_install_mode,
+    NativePackageSnapshot, ProbeEvidence, ResolutionPlan, ResolverEnv, ResolverError,
+    ServiceManager, ServiceRef, ServiceScope, ServiceState, StateRootScope, StateSnapshot,
+    check_owned_file, run_check, service_for_install_mode, user_service_for_install_mode,
 };
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::PackageQuery;
@@ -197,9 +198,21 @@ struct FixSuggestion {
     automatic: bool,
 }
 
+type ResolveRuntimeDependencies<'a> =
+    dyn Fn(&[RuntimeDependency], &ResolverEnv) -> Result<ResolutionPlan, ResolverError> + 'a;
+
+#[cfg(test)]
+fn unexpected_runtime_dependencies(
+    _: &[RuntimeDependency],
+    _: &ResolverEnv,
+) -> Result<ResolutionPlan, ResolverError> {
+    panic!("runtime dependency resolution must not run for this fixture")
+}
+
 struct DoctorProbeContext<'a> {
     layout: &'a FsLayout,
     resolver_env: &'a ResolverEnv,
+    resolve_runtime_dependencies: &'a ResolveRuntimeDependencies<'a>,
     rpm_query: &'a dyn PackageQuery,
     system_service: &'a dyn ServiceManager,
     user_service: &'a dyn ServiceManager,
@@ -208,6 +221,7 @@ struct DoctorProbeContext<'a> {
 
 struct DoctorViewContext<'a> {
     resolver_env: &'a ResolverEnv,
+    resolve_runtime_dependencies: &'a ResolveRuntimeDependencies<'a>,
     rpm_query: &'a dyn PackageQuery,
     current_system_service: &'a dyn ServiceManager,
     system_scope_service: &'a dyn ServiceManager,
@@ -282,11 +296,15 @@ fn diagnose(component: Option<&str>, ctx: &CliContext) -> Result<DoctorPayload, 
         .transpose()?;
     let env = anolisa_env::EnvService::detect();
     let resolver_env = resolver_env_from_facts(&env);
+    let resolver = DependencyResolver::system();
+    let resolve_runtime_dependencies =
+        |deps: &[RuntimeDependency], env: &ResolverEnv| resolver.resolve(deps, env);
     let current_system_service = service_for_install_mode(ctx.install_mode.as_str(), &env);
     let system_scope_service = service_for_install_mode(InstallMode::System.as_str(), &env);
     let user_service = user_service_for_install_mode(ctx.install_mode.as_str(), &env);
     let view_ctx = DoctorViewContext {
         resolver_env: &resolver_env,
+        resolve_runtime_dependencies: &resolve_runtime_dependencies,
         rpm_query: &rpm_query,
         current_system_service: current_system_service.as_ref(),
         system_scope_service: system_scope_service.as_ref(),
@@ -321,6 +339,7 @@ fn diagnose_from_view(
         let probe_ctx = DoctorProbeContext {
             layout,
             resolver_env: view_ctx.resolver_env,
+            resolve_runtime_dependencies: view_ctx.resolve_runtime_dependencies,
             rpm_query: view_ctx.rpm_query,
             system_service: view_ctx.system_service_for_root(Some(root)),
             user_service: view_ctx.user_service,
@@ -360,6 +379,7 @@ fn diagnose_from_view(
         let probe_ctx = DoctorProbeContext {
             layout: &view.writable.layout,
             resolver_env: view_ctx.resolver_env,
+            resolve_runtime_dependencies: view_ctx.resolve_runtime_dependencies,
             rpm_query: view_ctx.rpm_query,
             system_service: view_ctx.system_service_for_root(None),
             user_service: view_ctx.user_service,
@@ -440,6 +460,7 @@ pub(super) fn snapshot_for_conformance(
     let probe_ctx = DoctorProbeContext {
         layout: &record.root.layout,
         resolver_env: &resolver_env,
+        resolve_runtime_dependencies: &unexpected_runtime_dependencies,
         rpm_query,
         system_service: &service,
         user_service: &service,
@@ -461,6 +482,7 @@ pub(super) fn projection_for_conformance(
     let probe_ctx = DoctorProbeContext {
         layout,
         resolver_env: &resolver_env,
+        resolve_runtime_dependencies: &unexpected_runtime_dependencies,
         rpm_query,
         system_service: &service,
         user_service: &service,
@@ -672,6 +694,7 @@ fn diagnose_component(
         manifest,
         object,
         probe_ctx.resolver_env,
+        probe_ctx.resolve_runtime_dependencies,
         probe_ctx.dry_run,
         &mut out,
     );
@@ -1413,6 +1436,7 @@ fn add_runtime_dependencies(
     manifest: Option<&ComponentManifest>,
     object: Option<&Installation>,
     resolver_env: &ResolverEnv,
+    resolve_runtime_dependencies: &ResolveRuntimeDependencies<'_>,
     dry_run: bool,
     out: &mut DoctorComponent,
 ) {
@@ -1450,7 +1474,7 @@ fn add_runtime_dependencies(
         return;
     }
 
-    match DependencyResolver::system().resolve(&manifest.runtime_deps, resolver_env) {
+    match resolve_runtime_dependencies(&manifest.runtime_deps, resolver_env) {
         Ok(plan) => {
             for warning in plan.warnings {
                 out.findings.push(finding(
@@ -2644,6 +2668,7 @@ mod tests {
         DoctorProbeContext {
             layout,
             resolver_env,
+            resolve_runtime_dependencies: &unexpected_runtime_dependencies,
             rpm_query,
             system_service,
             user_service,
@@ -2663,6 +2688,7 @@ mod tests {
         let user_service = FakeServiceManager::with_scope(ServiceScope::User);
         let view_ctx = DoctorViewContext {
             resolver_env: &resolver_env,
+            resolve_runtime_dependencies: &unexpected_runtime_dependencies,
             rpm_query: &query,
             current_system_service: &system_service,
             system_scope_service: &system_service,
@@ -2685,6 +2711,7 @@ mod tests {
         let user_service = FakeServiceManager::with_scope(ServiceScope::User);
         let view_ctx = DoctorViewContext {
             resolver_env: &resolver_env,
+            resolve_runtime_dependencies: &unexpected_runtime_dependencies,
             rpm_query: &rpm_query,
             current_system_service: &system_service,
             system_scope_service: &system_service,
@@ -2835,6 +2862,7 @@ mod tests {
         let user_service = FakeServiceManager::with_scope(ServiceScope::User);
         let view_ctx = DoctorViewContext {
             resolver_env: &resolver_env,
+            resolve_runtime_dependencies: &unexpected_runtime_dependencies,
             rpm_query: &rpm_query,
             current_system_service: &system_service,
             system_scope_service: &system_service,
@@ -2967,6 +2995,7 @@ mod tests {
         let user_service = FakeServiceManager::with_scope(ServiceScope::User);
         let view_ctx = DoctorViewContext {
             resolver_env: &resolver_env,
+            resolve_runtime_dependencies: &unexpected_runtime_dependencies,
             rpm_query: &query,
             current_system_service: &system_service,
             system_scope_service: &system_service,
@@ -3075,6 +3104,7 @@ mod tests {
         let user_service = FakeServiceManager::with_scope(ServiceScope::User);
         let view_ctx = DoctorViewContext {
             resolver_env: &resolver_env,
+            resolve_runtime_dependencies: &unexpected_runtime_dependencies,
             rpm_query: &rpm_query,
             current_system_service: &invocation_system_service,
             system_scope_service: &system_scope_service,
@@ -3114,6 +3144,7 @@ mod tests {
         user_service.set_state(ServiceState::Active);
         let view_ctx = DoctorViewContext {
             resolver_env: &resolver_env,
+            resolve_runtime_dependencies: &unexpected_runtime_dependencies,
             rpm_query: &rpm_query,
             current_system_service: &invocation_system_service,
             system_scope_service: &system_scope_service,
@@ -3175,6 +3206,7 @@ mod tests {
         let user_service = FakeServiceManager::with_scope(ServiceScope::User);
         let view_ctx = DoctorViewContext {
             resolver_env: &resolver_env,
+            resolve_runtime_dependencies: &unexpected_runtime_dependencies,
             rpm_query: &rpm_query,
             current_system_service: &system_service,
             system_scope_service: &system_service,
@@ -3237,6 +3269,7 @@ mod tests {
         let user_service = FakeServiceManager::with_scope(ServiceScope::User);
         let view_ctx = DoctorViewContext {
             resolver_env: &resolver_env,
+            resolve_runtime_dependencies: &unexpected_runtime_dependencies,
             rpm_query: &rpm_query,
             current_system_service: &system_service,
             system_scope_service: &system_service,
@@ -4430,5 +4463,488 @@ mod tests {
             None,
         ));
         assert_eq!(component_status(&component), "failed");
+    }
+
+    const RUNTIME_DEPS: &str = r#"
+        [[component.dependencies]]
+        name = "libfoo"
+        kind = "system-package"
+        [[component.dependencies]]
+        name = "node"
+        kind = "language-runtime"
+        version = ">=20"
+        [[component.dependencies]]
+        name = "kernel-btrfs"
+        kind = "platform-capability"
+        check = "btrfs"
+    "#;
+
+    struct RuntimeRunner {
+        calls: std::cell::RefCell<Vec<String>>,
+        outputs: std::cell::RefCell<
+            std::collections::VecDeque<std::io::Result<anolisa_platform::command::CommandOutput>>,
+        >,
+    }
+
+    impl RuntimeRunner {
+        fn new(outputs: Vec<std::io::Result<anolisa_platform::command::CommandOutput>>) -> Self {
+            Self {
+                calls: Default::default(),
+                outputs: std::cell::RefCell::new(outputs.into()),
+            }
+        }
+    }
+
+    impl anolisa_platform::command::CommandRunner for &RuntimeRunner {
+        fn run(
+            &self,
+            program: &str,
+            args: &[&str],
+        ) -> std::io::Result<anolisa_platform::command::CommandOutput> {
+            self.calls
+                .borrow_mut()
+                .push(format!("{program} {}", args.join(" ")));
+            self.outputs
+                .borrow_mut()
+                .pop_front()
+                .expect("unexpected runtime probe")
+        }
+    }
+
+    fn runtime_output(
+        code: Option<i32>,
+        stdout: &str,
+    ) -> std::io::Result<anolisa_platform::command::CommandOutput> {
+        Ok(anolisa_platform::command::CommandOutput {
+            code,
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+        })
+    }
+
+    fn diagnose_runtime_fixture(
+        layout: &FsLayout,
+        object: Option<Installation>,
+        deps: Option<&str>,
+        dry_run: bool,
+        resolve: &ResolveRuntimeDependencies<'_>,
+    ) -> DoctorPayload {
+        if let Some(deps) = deps {
+            write_manifest_snapshot(
+                layout,
+                "runtime-tool",
+                &format!("[component]\nname = \"runtime-tool\"\nversion = \"1.0.0\"\n{deps}"),
+            );
+        }
+        let view = system_view_with_layout(
+            layout.clone(),
+            object
+                .map(state_with_component)
+                .unwrap_or_else(StateStore::empty),
+        );
+        let env = ResolverEnv {
+            pkg_base: Some("rpm".to_string()),
+            ..Default::default()
+        };
+        let service = FakeServiceManager::new();
+        let user_service = FakeServiceManager::with_scope(ServiceScope::User);
+        let ctx = DoctorViewContext {
+            resolver_env: &env,
+            resolve_runtime_dependencies: resolve,
+            rpm_query: &MissingPackageQuery,
+            current_system_service: &service,
+            system_scope_service: &service,
+            user_service: &user_service,
+            dry_run,
+        };
+        let payload = diagnose_from_view(&view, Some("runtime-tool"), &ctx)
+            .expect("diagnose runtime fixture");
+        assert!(service.calls().is_empty());
+        assert!(user_service.calls().is_empty());
+        payload
+    }
+
+    #[test]
+    fn doctor_runtime_dependencies_use_real_resolver_exactly_once() {
+        for healthy in [true, false] {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let layout = FsLayout::system(Some(temp.path().to_path_buf()));
+            let runner = RuntimeRunner::new(vec![
+                runtime_output(Some(if healthy { 0 } else { 1 }), ""),
+                runtime_output(Some(0), if healthy { "v20.0.0" } else { "v18.0.0" }),
+            ]);
+            let reads = Cell::new(0);
+            let resolutions = Cell::new(0);
+            let resolver = DependencyResolver::with_probes(&runner, || {
+                reads.set(reads.get() + 1);
+                Ok(if healthy { "btrfs\n" } else { "ext4\n" }.to_string())
+            });
+            let resolve = |deps: &[RuntimeDependency], env: &ResolverEnv| {
+                resolutions.set(resolutions.get() + 1);
+                resolver.resolve(deps, env)
+            };
+            let payload = diagnose_runtime_fixture(
+                &layout,
+                Some(owned_object("runtime-tool", LifecycleStatus::Installed)),
+                Some(RUNTIME_DEPS),
+                false,
+                &resolve,
+            );
+            assert_eq!(resolutions.get(), 1);
+            assert_eq!(reads.get(), 1);
+            assert_eq!(*runner.calls.borrow(), ["rpm -q libfoo", "node --version"]);
+            assert!(runner.outputs.borrow().is_empty());
+            let component = &payload.components[0];
+            assert_eq!(
+                component
+                    .dependencies
+                    .iter()
+                    .map(|dep| dep.name.as_str())
+                    .collect::<Vec<_>>(),
+                ["libfoo", "node", "kernel-btrfs"]
+            );
+            assert_eq!(payload_has_issues(&payload), !healthy);
+            assert_eq!(component.status, if healthy { "ok" } else { "failed" });
+            if healthy {
+                assert!(
+                    component
+                        .dependencies
+                        .iter()
+                        .all(|dep| dep.status == DoctorDependencyStatus::Resolved)
+                );
+                assert!(component.findings.is_empty());
+                assert!(component.fix_plan.is_empty());
+                assert_eq!(payload.summary.ok, 1);
+            } else {
+                assert_eq!(
+                    component
+                        .dependencies
+                        .iter()
+                        .map(|dep| dep.status)
+                        .collect::<Vec<_>>(),
+                    [
+                        DoctorDependencyStatus::Unresolved,
+                        DoctorDependencyStatus::Unresolved,
+                        DoctorDependencyStatus::Unresolvable
+                    ]
+                );
+                assert_eq!(
+                    component.dependencies[1].detail.as_deref(),
+                    Some("found 18.0.0, need >=20")
+                );
+                assert_eq!(
+                    component
+                        .findings
+                        .iter()
+                        .map(|finding| finding.code.as_str())
+                        .collect::<Vec<_>>(),
+                    [
+                        "dependency_unresolved",
+                        "dependency_unresolved",
+                        "dependency_unresolvable"
+                    ]
+                );
+                assert_eq!(component.fix_plan.len(), 3);
+                assert_eq!(
+                    component.fix_plan[0].command.as_deref(),
+                    Some("sudo dnf install libfoo")
+                );
+                assert_eq!(component.fix_plan[2].action, "satisfy_platform_requirement");
+                assert_eq!(payload.summary.failed, 1);
+                assert_eq!(
+                    CliError::DiagnosticsFound {
+                        command: COMMAND.to_string()
+                    }
+                    .exit_code(),
+                    2
+                );
+            }
+            let json = serde_json::to_value(&payload).expect("serialize report");
+            assert_eq!(json["dry_run"], false);
+            assert_eq!(
+                json["components"][0]["dependencies"][0]["status"],
+                if healthy { "resolved" } else { "unresolved" }
+            );
+        }
+    }
+
+    #[test]
+    fn doctor_runtime_probe_errors_keep_existing_diagnostics() {
+        for kind in [
+            std::io::ErrorKind::NotFound,
+            std::io::ErrorKind::PermissionDenied,
+        ] {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let layout = FsLayout::system(Some(temp.path().to_path_buf()));
+            let runner = RuntimeRunner::new(vec![
+                Err(std::io::Error::new(kind, "scripted spawn failure")),
+                runtime_output(None, ""),
+            ]);
+            let resolver = DependencyResolver::with_probes(&runner, || {
+                Err(std::io::Error::new(kind, "scripted read failure"))
+            });
+            let payload = diagnose_runtime_fixture(
+                &layout,
+                Some(owned_object("runtime-tool", LifecycleStatus::Installed)),
+                Some(RUNTIME_DEPS),
+                false,
+                &|deps, env| resolver.resolve(deps, env),
+            );
+            let component = &payload.components[0];
+            assert_eq!(
+                component.dependencies[0].status,
+                DoctorDependencyStatus::Unresolved
+            );
+            assert_eq!(
+                component.dependencies[1].status,
+                DoctorDependencyStatus::Unresolved
+            );
+            assert_eq!(
+                component.dependencies[2].status,
+                DoctorDependencyStatus::Unresolvable
+            );
+            assert_eq!(
+                component.findings[2].detail.as_deref(),
+                Some("could not read /proc/filesystems to verify btrfs support")
+            );
+            assert_eq!(*runner.calls.borrow(), ["rpm -q libfoo", "node --version"]);
+        }
+    }
+
+    #[test]
+    fn doctor_runtime_declaration_error_uses_manifest_finding() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let layout = FsLayout::system(Some(temp.path().to_path_buf()));
+        let runner = RuntimeRunner::new(Vec::new());
+        let resolver = DependencyResolver::with_probes(&runner, || -> std::io::Result<String> {
+            panic!("unknown checks must not read filesystems")
+        });
+        let payload = diagnose_runtime_fixture(
+            &layout,
+            Some(owned_object("runtime-tool", LifecycleStatus::Installed)),
+            Some(
+                "[[component.dependencies]]\nname = \"future\"\nkind = \"platform-capability\"\ncheck = \"unknown\"",
+            ),
+            false,
+            &|deps, env| resolver.resolve(deps, env),
+        );
+        let component = &payload.components[0];
+        assert!(component.dependencies.is_empty());
+        assert_eq!(component.findings.len(), 1);
+        assert_eq!(component.findings[0].code, "invalid_dependency_declaration");
+        assert_eq!(
+            component.findings[0].detail.as_deref(),
+            Some("dependency 'future' has unknown platform-capability check 'unknown'")
+        );
+        assert_eq!(component.fix_plan[0].action, "fix_manifest");
+        assert!(runner.calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn doctor_runtime_skip_paths_never_resolve() {
+        for scenario in [
+            "absent",
+            "no-manifest",
+            "empty",
+            "rpm",
+            "dry-run",
+            "rpm-dry-run",
+        ] {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let layout = FsLayout::system(Some(temp.path().to_path_buf()));
+            let object = match scenario {
+                "absent" => None,
+                "rpm" | "rpm-dry-run" => {
+                    Some(delegated_object("runtime-tool", LifecycleStatus::Installed))
+                }
+                _ => Some(owned_object("runtime-tool", LifecycleStatus::Installed)),
+            };
+            let deps = match scenario {
+                "no-manifest" => None,
+                "empty" => Some(""),
+                _ => Some(RUNTIME_DEPS),
+            };
+            let payload = diagnose_runtime_fixture(
+                &layout,
+                object,
+                deps,
+                scenario.contains("dry-run"),
+                &unexpected_runtime_dependencies,
+            );
+            let dependencies = &payload.components[0].dependencies;
+            if matches!(scenario, "rpm" | "dry-run" | "rpm-dry-run") {
+                assert_eq!(dependencies.len(), 3);
+                let note = if scenario.starts_with("rpm") {
+                    "RPM backend owns runtime dependency resolution"
+                } else {
+                    "dry-run: dependency probe not executed"
+                };
+                assert!(
+                    dependencies
+                        .iter()
+                        .all(|dep| dep.status == DoctorDependencyStatus::Skipped
+                            && dep.note.as_deref() == Some(note))
+                );
+            } else {
+                assert!(dependencies.is_empty(), "{scenario}");
+            }
+        }
+    }
+
+    #[test]
+    fn doctor_runtime_warning_and_version_detail_keep_order() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let layout = FsLayout::system(Some(temp.path().to_path_buf()));
+        let runner = RuntimeRunner::new(vec![
+            runtime_output(Some(0), ""),
+            runtime_output(Some(0), "unknown version"),
+        ]);
+        let resolver = DependencyResolver::with_probes(&runner, || Ok("ext4\n".to_string()));
+        let resolve = |deps: &[RuntimeDependency], env: &ResolverEnv| {
+            let mut plan = resolver.resolve(deps, env)?;
+            // The resolver currently emits no aggregate warnings; exercise the
+            // callback's existing warning projection without changing that policy.
+            plan.warnings.push("scripted resolver warning".to_string());
+            Ok(plan)
+        };
+        let payload = diagnose_runtime_fixture(
+            &layout,
+            Some(owned_object("runtime-tool", LifecycleStatus::Disabled)),
+            Some(RUNTIME_DEPS),
+            false,
+            &resolve,
+        );
+        let component = &payload.components[0];
+        assert_eq!(
+            component.dependencies[1].status,
+            DoctorDependencyStatus::Resolved
+        );
+        assert_eq!(
+            component.dependencies[1].detail.as_deref(),
+            Some("version not verified against '>=20'")
+        );
+        assert_eq!(
+            component
+                .findings
+                .iter()
+                .map(|finding| finding.code.as_str())
+                .collect::<Vec<_>>(),
+            ["dependency_warning", "dependency_unresolvable"]
+        );
+        assert_eq!(component.findings[0].severity, FindingSeverity::Warning);
+        assert_eq!(component.findings[0].message, "scripted resolver warning");
+        assert_eq!(*runner.calls.borrow(), ["rpm -q libfoo", "node --version"]);
+    }
+
+    #[test]
+    fn doctor_runtime_output_preserves_human_json_and_quiet() {
+        let (_, module) = module_path!().split_once("::").unwrap();
+        for healthy in [true, false] {
+            for mode in ["human", "json", "quiet"] {
+                // Capture the real renderer without redirecting process-global stdout
+                // in this test process, which runs other diagnostics concurrently.
+                let output = std::process::Command::new(std::env::current_exe().unwrap())
+                    .args([
+                        format!("{module}::doctor_runtime_output_child"),
+                        "--exact".to_string(),
+                        "--nocapture".to_string(),
+                    ])
+                    .env("ANOLISA_TEST_DOCTOR_RUNTIME_OUTPUT", mode)
+                    .env("ANOLISA_TEST_DOCTOR_RUNTIME_HEALTHY", healthy.to_string())
+                    .output()
+                    .unwrap();
+                assert_eq!(output.status.code(), Some(if healthy { 0 } else { 2 }));
+                assert!(output.stderr.is_empty());
+                let stdout = String::from_utf8(output.stdout).unwrap();
+                let (_, rendered) = stdout.split_once("DOCTOR_OUTPUT_BEGIN\n").unwrap();
+                let (rendered, _) = rendered.split_once("DOCTOR_OUTPUT_END\n").unwrap();
+                match mode {
+                    "json" => {
+                        let json: serde_json::Value = serde_json::from_str(rendered).unwrap();
+                        assert_eq!(json["command"], "doctor");
+                        assert_eq!(json["schema_version"], crate::response::SCHEMA_VERSION);
+                        assert_eq!(json["ok"], healthy);
+                        assert_eq!(json["data"]["dry_run"], false);
+                        assert_eq!(json["data"]["summary"]["failed"], usize::from(!healthy));
+                        let component = &json["data"]["components"][0];
+                        assert_eq!(component["dependencies"][0]["name"], "libfoo");
+                        assert_eq!(component["dependencies"][1]["name"], "node");
+                        assert_eq!(component["dependencies"][2]["name"], "kernel-btrfs");
+                        if !healthy {
+                            assert_eq!(
+                                component["fix_plan"][0]["command"],
+                                "sudo dnf install libfoo"
+                            );
+                            assert_eq!(component["findings"][2]["code"], "dependency_unresolvable");
+                        }
+                    }
+                    "human" if healthy => {
+                        assert!(
+                            rendered.starts_with("Doctor: 1 checked, 1 ok, 0 degraded, 0 failed\n")
+                        );
+                        assert!(rendered.contains("no issues found"));
+                    }
+                    "human" => {
+                        assert!(
+                            rendered.starts_with("Doctor: 1 checked, 0 ok, 0 degraded, 1 failed\n")
+                        );
+                        let package = rendered.find("[dependency_unresolved]").unwrap();
+                        let detail = rendered.find("found 18.0.0, need >=20").unwrap();
+                        let platform = rendered.find("[dependency_unresolvable]").unwrap();
+                        let fix = rendered.find("Recommended:").unwrap();
+                        assert!(package < detail && detail < platform && platform < fix);
+                        assert!(rendered.contains("sudo dnf install libfoo"));
+                        assert!(rendered.contains("satisfy_platform_requirement"));
+                    }
+                    "quiet" => assert!(rendered.is_empty()),
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn doctor_runtime_output_child() {
+        let Ok(mode) = std::env::var("ANOLISA_TEST_DOCTOR_RUNTIME_OUTPUT") else {
+            return;
+        };
+        let healthy = std::env::var("ANOLISA_TEST_DOCTOR_RUNTIME_HEALTHY").unwrap() == "true";
+        let sandbox = crate::test_support::TestSandbox::new();
+        let ctx = sandbox.context_with(
+            crate::context::InstallMode::System,
+            crate::test_support::TestContextOptions {
+                json: mode == "json",
+                quiet: mode == "quiet",
+                ..Default::default()
+            },
+        );
+        let runner = RuntimeRunner::new(vec![
+            runtime_output(Some(if healthy { 0 } else { 1 }), ""),
+            runtime_output(Some(0), if healthy { "v20.0.0" } else { "v18.0.0" }),
+        ]);
+        let resolver = DependencyResolver::with_probes(&runner, || {
+            Ok(if healthy { "btrfs\n" } else { "ext4\n" }.to_string())
+        });
+        let payload = diagnose_runtime_fixture(
+            ctx.layout(),
+            Some(owned_object("runtime-tool", LifecycleStatus::Installed)),
+            Some(RUNTIME_DEPS),
+            false,
+            &|deps, env| resolver.resolve(deps, env),
+        );
+        let has_issues = payload_has_issues(&payload);
+        println!("DOCTOR_OUTPUT_BEGIN");
+        render_doctor(&ctx, &payload, !has_issues).unwrap();
+        println!("DOCTOR_OUTPUT_END");
+        let code = if has_issues {
+            CliError::DiagnosticsFound {
+                command: COMMAND.to_string(),
+            }
+            .exit_code()
+        } else {
+            0
+        };
+        drop(sandbox);
+        std::process::exit(code.into());
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/provision.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/provision.rs
@@ -45,11 +45,11 @@ pub(crate) fn run_runtime_preflight(
     run_runtime_preflight_with(manifest, env, command, &resolver)
 }
 
-fn run_runtime_preflight_with<R: CommandRunner>(
+fn run_runtime_preflight_with<R: CommandRunner, P: Fn() -> std::io::Result<String>>(
     manifest: &ComponentManifest,
     env: &anolisa_env::EnvFacts,
     command: &str,
-    resolver: &DependencyResolver<R>,
+    resolver: &DependencyResolver<R, P>,
 ) -> Result<Vec<String>, CliError> {
     if manifest.runtime_deps.is_empty() {
         return Ok(Vec::new());
@@ -118,7 +118,7 @@ pub(crate) fn run_provision(
 // injected, so introducing a second request object would obscure the existing
 // production signature without reducing call-site complexity.
 #[allow(clippy::too_many_arguments)]
-fn run_provision_with<R, F>(
+fn run_provision_with<R, P, F>(
     manifest: &ComponentManifest,
     env: &anolisa_env::EnvFacts,
     ctx: &CliContext,
@@ -126,11 +126,12 @@ fn run_provision_with<R, F>(
     warnings: &mut Vec<String>,
     journals: &JournalInventory,
     layout: &FsLayout,
-    resolver: &DependencyResolver<R>,
+    resolver: &DependencyResolver<R, P>,
     detect_manager: F,
 ) -> Result<Vec<String>, CliError>
 where
     R: CommandRunner,
+    P: Fn() -> std::io::Result<String>,
     F: FnOnce(Option<&str>) -> Result<Box<dyn PackageManager>, PkgError>,
 {
     if manifest.runtime_deps.is_empty() {
@@ -579,6 +580,169 @@ mod tests {
                 vec!["-q".to_string(), "libfoo".to_string()]
             )]
         );
+    }
+
+    #[test]
+    fn injected_btrfs_reader_controls_preflight_and_provisioning() {
+        for supported in [true, false] {
+            let sandbox = TestSandbox::new();
+            let ctx = sandbox.context(InstallMode::System);
+            let layout = ctx.layout();
+            let inventory = inventory_for(layout, &[]);
+            let manifest = manifest_with_deps(vec![platform_dep("btrfs", "btrfs")]);
+            let env = rpm_host_env();
+            let reads = Cell::new(0);
+            let runner = ScriptedRunner::with_codes([]);
+            let resolver = DependencyResolver::with_probes(runner.clone(), || {
+                reads.set(reads.get() + 1);
+                Ok(if supported {
+                    "nodev\tbtrfs\n"
+                } else {
+                    "ext4\n"
+                }
+                .to_string())
+            });
+
+            let preflight = run_runtime_preflight_with(&manifest, &env, "update", &resolver);
+            assert_eq!(reads.get(), 1);
+            let mut warnings = Vec::new();
+            let provision = run_provision_with(
+                &manifest,
+                &env,
+                &ctx,
+                "install component-a",
+                &mut warnings,
+                &inventory,
+                layout,
+                &resolver,
+                |_| panic!("platform capabilities must not invoke a package manager"),
+            );
+            if supported {
+                assert!(preflight.unwrap().is_empty());
+                assert!(provision.unwrap().is_empty());
+            } else {
+                let preflight = preflight.unwrap_err().reason();
+                assert!(preflight.contains("missing runtime dependencies; no files were changed"));
+                let provision = provision.unwrap_err().reason();
+                assert!(
+                    provision
+                        .contains("unsatisfiable platform requirements; no files were changed")
+                );
+                for reason in [preflight, provision] {
+                    assert!(
+                        reason.contains(
+                            "btrfs is not supported by the running kernel (absent from /proc/filesystems)"
+                        )
+                    );
+                }
+            }
+            assert_eq!(reads.get(), 2);
+            assert!(runner.calls().is_empty());
+            assert!(warnings.is_empty());
+        }
+    }
+
+    #[test]
+    fn injected_btrfs_read_failure_blocks_before_manager_detection() {
+        let sandbox = TestSandbox::new();
+        let ctx = sandbox.context(InstallMode::System);
+        let layout = ctx.layout();
+        let inventory = inventory_for(layout, &[]);
+        let manifest = manifest_with_deps(vec![platform_dep("btrfs", "btrfs")]);
+        let reads = Cell::new(0);
+        let resolver = DependencyResolver::with_probes(ScriptedRunner::with_codes([]), || {
+            reads.set(reads.get() + 1);
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "scripted denial",
+            ))
+        });
+        let err = run_provision_with(
+            &manifest,
+            &rpm_host_env(),
+            &ctx,
+            "install component-a",
+            &mut Vec::new(),
+            &inventory,
+            layout,
+            &resolver,
+            |_| panic!("an unreadable capability probe must block before manager detection"),
+        )
+        .unwrap_err();
+        assert!(
+            err.reason()
+                .contains("could not read /proc/filesystems to verify btrfs support")
+        );
+        assert_eq!(reads.get(), 1);
+    }
+
+    #[test]
+    fn provisioning_reuses_btrfs_reader_after_install() {
+        for recheck_code in [Some(0), Some(1)] {
+            let sandbox = TestSandbox::new();
+            let ctx = sandbox.context(InstallMode::System);
+            let layout = ctx.layout();
+            let inventory = inventory_for(layout, &[]);
+            let manifest = manifest_with_deps(vec![
+                system_dep("foo", "libfoo"),
+                platform_dep("btrfs", "btrfs"),
+            ]);
+            let runner = ScriptedRunner::with_codes([Some(1), recheck_code]);
+            let manager = FakePackageManager::default();
+            let reads = Cell::new(0);
+            let detections = Cell::new(0);
+            let resolver = DependencyResolver::with_probes(runner.clone(), || {
+                reads.set(reads.get() + 1);
+                assert_eq!(runner.calls().len(), reads.get());
+                if reads.get() == 1 {
+                    assert_eq!(detections.get(), 0);
+                    assert!(manager.install_calls().is_empty());
+                } else {
+                    assert_eq!(detections.get(), 1);
+                    assert_eq!(manager.install_calls(), vec![vec!["libfoo".to_string()]]);
+                }
+                Ok("btrfs\n".to_string())
+            });
+            let result = run_provision_with(
+                &manifest,
+                &rpm_host_env(),
+                &ctx,
+                "install component-a",
+                &mut Vec::new(),
+                &inventory,
+                layout,
+                &resolver,
+                |pkg_base| {
+                    assert_eq!(reads.get(), 1);
+                    assert_eq!(pkg_base, Some("rpm"));
+                    detections.set(detections.get() + 1);
+                    Ok(Box::new(manager.clone()))
+                },
+            );
+            if recheck_code == Some(0) {
+                assert_eq!(result.unwrap(), vec!["libfoo".to_string()]);
+            } else {
+                let reason = result.unwrap_err().reason();
+                assert!(reason.contains("dependencies still unsatisfied after install"));
+                assert!(reason.contains("system packages were installed and retained: libfoo"));
+            }
+            assert_eq!(reads.get(), 2);
+            assert_eq!(detections.get(), 1);
+            assert_eq!(manager.install_calls(), vec![vec!["libfoo".to_string()]]);
+            assert_eq!(
+                runner.calls(),
+                vec![
+                    (
+                        "rpm".to_string(),
+                        vec!["-q".to_string(), "libfoo".to_string()]
+                    ),
+                    (
+                        "rpm".to_string(),
+                        vec!["-q".to_string(), "libfoo".to_string()]
+                    ),
+                ]
+            );
+        }
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/resolver.rs
+++ b/src/anolisa/crates/anolisa-core/src/resolver.rs
@@ -110,25 +110,46 @@ pub enum ResolverError {
     },
 }
 
-/// Probes declared runtime dependencies against the host. Generic over the
-/// command runner so tests inject a fake; the default runs real commands.
-pub struct DependencyResolver<R: CommandRunner = SystemCommandRunner> {
+/// Probes declared runtime dependencies through a command runner and a lazy
+/// filesystem-capability reader. The defaults use real host probes.
+pub struct DependencyResolver<
+    R: CommandRunner = SystemCommandRunner,
+    F: Fn() -> std::io::Result<String> = fn() -> std::io::Result<String>,
+> {
     runner: R,
+    read_filesystems: F,
 }
 
 impl DependencyResolver<SystemCommandRunner> {
-    /// Build a resolver that runs real host commands.
+    /// Build a resolver that runs real host commands and reads `/proc/filesystems`
+    /// only when a btrfs capability check reaches that probe.
     pub fn system() -> Self {
-        Self {
-            runner: SystemCommandRunner,
-        }
+        Self::with_runner(SystemCommandRunner)
     }
 }
 
 impl<R: CommandRunner> DependencyResolver<R> {
-    /// Build a resolver backed by a custom runner (primarily for tests).
+    /// Build a resolver backed by a custom command runner.
+    ///
+    /// The btrfs probe still reads the host's `/proc/filesystems`; use
+    /// [`Self::with_probes`] to replace both host boundaries.
     pub fn with_runner(runner: R) -> Self {
-        Self { runner }
+        Self::with_probes(runner, || std::fs::read_to_string("/proc/filesystems"))
+    }
+}
+
+impl<R: CommandRunner, F: Fn() -> std::io::Result<String>> DependencyResolver<R, F> {
+    /// Build a resolver with custom command and filesystem-capability probes.
+    ///
+    /// `read_filesystems` supplies raw `/proc/filesystems` content or its read
+    /// error. It is called once per evaluated btrfs dependency, after the kernel
+    /// gate; construction and unrelated checks do not call it. Results are not
+    /// cached, so a later resolution observes the reader again.
+    pub fn with_probes(runner: R, read_filesystems: F) -> Self {
+        Self {
+            runner,
+            read_filesystems,
+        }
     }
 
     /// Probe every dependency and aggregate the outcome. Never mutates the host.
@@ -147,7 +168,9 @@ impl<R: CommandRunner> DependencyResolver<R> {
             let (status, detail) = match dep.kind {
                 DependencyKind::SystemPackage => self.resolve_system_package(dep, env),
                 DependencyKind::LanguageRuntime => self.resolve_language_runtime(dep),
-                DependencyKind::PlatformCapability => resolve_platform_capability(dep, env)?,
+                DependencyKind::PlatformCapability => {
+                    resolve_platform_capability(dep, env, &self.read_filesystems)?
+                }
             };
             plan.resolutions.push(DependencyResolution {
                 name: dep.name.clone(),
@@ -263,6 +286,7 @@ enum ProbeOutcome {
 fn resolve_platform_capability(
     dep: &RuntimeDependency,
     env: &ResolverEnv,
+    read_filesystems: &impl Fn() -> std::io::Result<String>,
 ) -> Result<(DependencyStatus, Option<String>), ResolverError> {
     if let Some(min) = &dep.min_kernel {
         match kernel_satisfies(env.kernel.as_deref(), min) {
@@ -289,9 +313,11 @@ fn resolve_platform_capability(
     }
 
     if let Some(check) = &dep.check {
-        let result = evaluate_check(check, env).ok_or_else(|| ResolverError::UnknownCheck {
-            name: dep.name.clone(),
-            check: check.clone(),
+        let result = evaluate_check(check, env, read_filesystems).ok_or_else(|| {
+            ResolverError::UnknownCheck {
+                name: dep.name.clone(),
+                check: check.clone(),
+            }
         })?;
         return Ok(match result {
             CheckResult::Supported => (DependencyStatus::Resolved, None),
@@ -349,11 +375,15 @@ enum CheckResult {
 /// Dispatch a built-in `check` identifier. `None` → unknown identifier (a
 /// contract bug the caller turns into [`ResolverError::UnknownCheck`]). The set
 /// is intentionally small; extend it deliberately.
-fn evaluate_check(check: &str, env: &ResolverEnv) -> Option<CheckResult> {
+fn evaluate_check(
+    check: &str,
+    env: &ResolverEnv,
+    read_filesystems: &impl Fn() -> std::io::Result<String>,
+) -> Option<CheckResult> {
     match check {
         "btf" => Some(bool_fact(env.btf, "kernel BTF (/sys/kernel/btf/vmlinux)")),
         "cap_bpf" => Some(bool_fact(env.cap_bpf, "CAP_BPF capability")),
-        "btrfs" => Some(btrfs_supported()),
+        "btrfs" => Some(btrfs_supported(read_filesystems)),
         _ => None,
     }
 }
@@ -374,8 +404,8 @@ fn bool_fact(fact: Option<bool>, label: &str) -> CheckResult {
 }
 
 /// Whether the running kernel supports btrfs, read from `/proc/filesystems`.
-fn btrfs_supported() -> CheckResult {
-    match std::fs::read_to_string("/proc/filesystems") {
+fn btrfs_supported(read_filesystems: &impl Fn() -> std::io::Result<String>) -> CheckResult {
+    match read_filesystems() {
         Ok(contents) if fs_supported(&contents, "btrfs") => CheckResult::Supported,
         Ok(_) => CheckResult::Unsupported {
             reason: "btrfs is not supported by the running kernel (absent from /proc/filesystems)"
@@ -838,6 +868,199 @@ mod tests {
         assert!(fs_supported(procfs, "btrfs"));
         assert!(fs_supported(procfs, "ext4"));
         assert!(!fs_supported(procfs, "xfs"));
+    }
+
+    #[test]
+    fn btrfs_probe_classifies_injected_filesystems() {
+        for (contents, supported) in [
+            ("nodev\tsysfs\n\tbtrfs\n", true),
+            ("nodev\tbtrfs\n", true),
+            ("\text4\n", false),
+            ("", false),
+            ("\tbtrfs_backup\n\tmybtrfs\nbtrfs\text4\n", false),
+        ] {
+            let reads = std::cell::Cell::new(0);
+            let resolver = DependencyResolver::with_probes(FakeRunner::default(), || {
+                reads.set(reads.get() + 1);
+                Ok(contents.to_string())
+            });
+            assert_eq!(reads.get(), 0, "construction must not read the host");
+            let mut dependency = dep("kernel-btrfs", DependencyKind::PlatformCapability);
+            dependency.check = Some("btrfs".to_string());
+            let plan = resolver
+                .resolve(&[dependency], &rpm_env())
+                .expect("resolve");
+            assert_eq!(reads.get(), 1);
+            assert_eq!(plan.resolutions[0].detail, None);
+            assert_eq!(
+                plan.resolutions[0].status,
+                if supported {
+                    DependencyStatus::Resolved
+                } else {
+                    DependencyStatus::Unresolvable {
+                        reason: "btrfs is not supported by the running kernel (absent from /proc/filesystems)".to_string(),
+                    }
+                },
+                "{contents:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn btrfs_probe_read_failure_keeps_existing_reason() {
+        for kind in [
+            io::ErrorKind::NotFound,
+            io::ErrorKind::PermissionDenied,
+            io::ErrorKind::InvalidData,
+        ] {
+            let reads = std::cell::Cell::new(0);
+            let resolver = DependencyResolver::with_probes(FakeRunner::default(), || {
+                reads.set(reads.get() + 1);
+                Err(io::Error::new(kind, "scripted filesystem read error"))
+            });
+            let mut dependency = dep("kernel-btrfs", DependencyKind::PlatformCapability);
+            dependency.check = Some("btrfs".to_string());
+            let plan = resolver
+                .resolve(&[dependency], &rpm_env())
+                .expect("read error is evidence");
+            assert_eq!(reads.get(), 1);
+            assert_eq!(
+                plan.resolutions[0].status,
+                DependencyStatus::Unresolvable {
+                    reason: "could not read /proc/filesystems to verify btrfs support".to_string(),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn unrelated_checks_and_kernel_gates_never_read_filesystems() {
+        let resolver = DependencyResolver::with_probes(
+            FakeRunner::default()
+                .ok("rpm", 0, "")
+                .ok("node", 0, "v20.0.0"),
+            || -> io::Result<String> { panic!("filesystem reader must not run") },
+        );
+        assert!(
+            resolver
+                .resolve(&[], &rpm_env())
+                .expect("empty")
+                .is_satisfied()
+        );
+        for kind in [
+            DependencyKind::SystemPackage,
+            DependencyKind::LanguageRuntime,
+        ] {
+            assert!(
+                resolver
+                    .resolve(&[dep("node", kind)], &rpm_env())
+                    .expect("command")
+                    .is_satisfied()
+            );
+        }
+        for check in [None, Some("btf"), Some("cap_bpf")] {
+            let mut dependency = dep("capability", DependencyKind::PlatformCapability);
+            dependency.check = check.map(str::to_string);
+            let env = ResolverEnv {
+                btf: Some(true),
+                cap_bpf: Some(true),
+                ..rpm_env()
+            };
+            assert!(
+                resolver
+                    .resolve(&[dependency], &env)
+                    .expect("capability")
+                    .is_satisfied()
+            );
+        }
+        for kernel in [None, Some("3.10.0")] {
+            let mut dependency = dep("kernel-btrfs", DependencyKind::PlatformCapability);
+            dependency.check = Some("btrfs".to_string());
+            dependency.min_kernel = Some("5.4".to_string());
+            let env = ResolverEnv {
+                kernel: kernel.map(str::to_string),
+                ..rpm_env()
+            };
+            assert!(
+                !resolver
+                    .resolve(&[dependency], &env)
+                    .expect("kernel gate")
+                    .is_satisfied()
+            );
+        }
+        let mut invalid = dep("future-capability", DependencyKind::PlatformCapability);
+        invalid.check = Some("unknown".to_string());
+        assert!(matches!(
+            resolver.resolve(&[invalid], &rpm_env()),
+            Err(ResolverError::UnknownCheck { .. })
+        ));
+    }
+
+    #[test]
+    fn dependency_probes_preserve_order_and_repeat_reads() {
+        use std::cell::RefCell;
+
+        struct RecordingRunner<'a>(&'a RefCell<Vec<String>>);
+        impl CommandRunner for RecordingRunner<'_> {
+            fn run(&self, program: &str, args: &[&str]) -> io::Result<CommandOutput> {
+                self.0
+                    .borrow_mut()
+                    .push(format!("{program} {}", args.join(" ")));
+                Ok(CommandOutput {
+                    code: Some(0),
+                    stdout: String::new(),
+                    stderr: String::new(),
+                })
+            }
+        }
+        let events = RefCell::new(Vec::new());
+        let reads = std::cell::Cell::new(0);
+        let resolver = DependencyResolver::with_probes(RecordingRunner(&events), || {
+            events.borrow_mut().push("filesystems".to_string());
+            reads.set(reads.get() + 1);
+            Ok(if reads.get() <= 2 {
+                "btrfs\n"
+            } else {
+                "ext4\n"
+            }
+            .to_string())
+        });
+        let mut capability = dep("kernel-btrfs", DependencyKind::PlatformCapability);
+        capability.check = Some("btrfs".to_string());
+        capability.min_kernel = Some("5.4".to_string());
+        let env = ResolverEnv {
+            kernel: Some("5.10.0".to_string()),
+            ..rpm_env()
+        };
+        let deps = [
+            capability.clone(),
+            dep("tool", DependencyKind::SystemPackage),
+            capability,
+        ];
+        assert!(
+            resolver
+                .resolve(&deps, &env)
+                .expect("first pass")
+                .is_satisfied()
+        );
+        assert!(
+            !resolver
+                .resolve(&deps, &env)
+                .expect("second pass")
+                .is_satisfied()
+        );
+        assert_eq!(reads.get(), 4);
+        assert_eq!(
+            *events.borrow(),
+            [
+                "filesystems",
+                "rpm -q tool",
+                "filesystems",
+                "filesystems",
+                "rpm -q tool",
+                "filesystems"
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

Doctor still constructed its runtime dependency resolver inside the diagnostic path, and the shared btrfs check read `/proc/filesystems` directly. These remaining host dependencies prevented deterministic tests of the real diagnostic and provisioning flows.

## What changed

Pass a private, borrowed resolution callback through doctor's existing contexts. Add a lazy, injectable filesystem reader to `DependencyResolver`, with the existing constructors retaining their production behavior. Extend provisioning's existing injection functions to use the same resolver for initial resolution and post-install verification.

- Preserve declaration order, kernel early rejection, per-probe call counts, and existing error classifications.
- Preserve absent-record, missing-manifest, empty-dependency, RPM-managed and dry-run skip paths, including RPM skip precedence.
- Add scripted resolver, doctor and provisioning tests, plus human/JSON/quiet output coverage. Snapshot conformance fixtures reject any unexpected runtime dependency resolution.

## Related issue

Closes #3079
Part of #2628, which remains open. Follows #3056.

## User / Agent impact

None. Existing CLI arguments, diagnostics, remediation suggestions, JSON fields, output ordering and exit codes are preserved. Production btrfs checks still read `/proc/filesystems` only when reached, without caching.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The core Rust API gains `DependencyResolver::with_probes` and a defaulted reader type parameter. Existing `system()`, `with_runner()` and `resolve()` call patterns remain supported. No CLI/wire schema, ComponentSnapshot contract, package-manager selection, service behavior or dependency-error classification changes. Tests use fake package/service collaborators and isolated filesystem layouts.

## Validation

Passed on the current code:

```text
cargo fmt --all
cargo fmt --all -- --check
cargo test -p anolisa-core resolver --locked
cargo test -p anolisa-cli doctor --locked
cargo test -p anolisa-cli provision --locked
cargo test -p anolisa-cli observation_conformance --locked
cargo check --workspace --locked
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo test -p anolisa-cli --locked
cargo test --workspace --locked
cargo doc --workspace --no-deps --locked
git diff --check
```

ALinux 4 validation used `anolisa/alinux4-rust-selftest:20260824` in a disposable `--rm` container as UID 1000, with networking disabled, read-only source and vendored dependencies, and a separate temporary target directory. Resolver (24), doctor (54 unit + 1 CLI help), and provisioning (24) targeted tests passed. No host helper, services or existing containers were used or modified.

## Documentation and rollback

Rustdoc documents the new reader boundary and the default reader behavior. The local Chinese roadmap was updated for tracking but is intentionally excluded from this PR. Revert this commit to restore the previous internal wiring; no data or schema migration is required.
