### PR TITLE
fix(sight): stop counting cached tokens twice in token totals

### DIFF
--- a/src/agentsight/src/analyzer/token/record.rs
+++ b/src/agentsight/src/analyzer/token/record.rs
@@ -40,12 +40,33 @@ pub struct TokenRecord {
 }
 
 impl TokenRecord {
-    /// Total tokens (input + output + cache)
+    /// Whether the provider bills cache tokens on top of `input_tokens`.
+    ///
+    /// Anthropic reports `cache_creation_input_tokens` and
+    /// `cache_read_input_tokens` separately from `input_tokens`, so they add to
+    /// the call total. OpenAI-compatible APIs — including DashScope and the
+    /// Qoder CLI gateway — already count cached tokens inside `prompt_tokens`,
+    /// and Gemini counts cached content inside `prompt_token_count`; adding the
+    /// cache counters again would inflate every cached call.
+    fn cache_billed_on_top(&self) -> bool {
+        self.provider.eq_ignore_ascii_case("anthropic")
+    }
+
+    /// Input tokens as billed: the reported input plus only those cache
+    /// counters the provider keeps outside of it.
+    pub fn billed_input_tokens(&self) -> u64 {
+        if self.cache_billed_on_top() {
+            self.input_tokens
+                + self.cache_creation_tokens.unwrap_or(0)
+                + self.cache_read_tokens.unwrap_or(0)
+        } else {
+            self.input_tokens
+        }
+    }
+
+    /// Total tokens for the call (billed input + output)
     pub fn total_tokens(&self) -> u64 {
-        self.input_tokens
-            + self.output_tokens
-            + self.cache_creation_tokens.unwrap_or(0)
-            + self.cache_read_tokens.unwrap_or(0)
+        self.billed_input_tokens() + self.output_tokens
     }
 
     /// Create a new record with current timestamp
@@ -121,6 +142,44 @@ mod tests {
     #[test]
     fn test_token_record_total() {
         let record = TokenRecord::new(1234, "python".to_string(), "openai".to_string(), 100, 50);
+        assert_eq!(record.total_tokens(), 150);
+    }
+
+    /// OpenAI-compatible gateways count cached tokens inside `prompt_tokens`,
+    /// so the cache counters must not be added again. Numbers taken from a
+    /// captured Qoder CLI call (prompt 3021, completion 170, cached 491).
+    #[test]
+    fn test_openai_style_cache_is_already_inside_input() {
+        let record = TokenRecord::new(1, "qodercli".to_string(), "openai".to_string(), 3021, 170)
+            .with_cache_tokens(0, 491);
+        assert_eq!(record.billed_input_tokens(), 3021);
+        assert_eq!(record.total_tokens(), 3191);
+    }
+
+    /// Anthropic reports cache tokens outside `input_tokens`, so they add up.
+    #[test]
+    fn test_anthropic_style_cache_adds_to_input() {
+        let record = TokenRecord::new(1, "claude".to_string(), "anthropic".to_string(), 100, 50)
+            .with_cache_tokens(10, 20);
+        assert_eq!(record.billed_input_tokens(), 130);
+        assert_eq!(record.total_tokens(), 180);
+    }
+
+    /// Provider casing comes from whatever the wire reported, so matching must
+    /// not be case-sensitive.
+    #[test]
+    fn test_anthropic_match_is_case_insensitive() {
+        let record = TokenRecord::new(1, "c".to_string(), "Anthropic".to_string(), 100, 50)
+            .with_cache_tokens(10, 20);
+        assert_eq!(record.total_tokens(), 180);
+    }
+
+    /// An unrecognised provider is treated as OpenAI-style, which is what every
+    /// gateway seen so far does.
+    #[test]
+    fn test_unknown_provider_keeps_cache_inside_input() {
+        let record = TokenRecord::new(1, "p".to_string(), "unknown".to_string(), 100, 50)
+            .with_cache_tokens(10, 20);
         assert_eq!(record.total_tokens(), 150);
     }
 

--- a/src/agentsight/src/genai/call_builder.rs
+++ b/src/agentsight/src/genai/call_builder.rs
@@ -67,11 +67,12 @@ impl GenAIBuilder {
 
         // Build token usage from TokenRecord
         let token_usage = token_record.as_ref().map(|t| {
-            let cache = t.cache_creation_tokens.unwrap_or(0) + t.cache_read_tokens.unwrap_or(0);
             TokenUsage {
                 input_tokens: t.input_tokens as u32,
                 output_tokens: t.output_tokens as u32,
-                total_tokens: (t.input_tokens + t.output_tokens + cache) as u32,
+                // Whether the cache counters belong in the total depends on the
+                // provider, so let TokenRecord own that rule.
+                total_tokens: t.total_tokens() as u32,
                 cache_creation_input_tokens: t.cache_creation_tokens.map(|v| v as u32),
                 cache_read_input_tokens: t.cache_read_tokens.map(|v| v as u32),
             }
@@ -1166,7 +1167,9 @@ mod tests {
         let tu = call.token_usage.unwrap();
         assert_eq!(tu.input_tokens, 10);
         assert_eq!(tu.output_tokens, 20);
-        assert_eq!(tu.total_tokens, 38);
+        // "token-provider" is not Anthropic, so the cache counters are assumed
+        // to sit inside the reported input already.
+        assert_eq!(tu.total_tokens, 30);
         assert_eq!(tu.cache_creation_input_tokens, Some(5));
         assert_eq!(tu.cache_read_input_tokens, Some(3));
     }

--- a/src/agentsight/src/storage/sqlite/genai/mod.rs
+++ b/src/agentsight/src/storage/sqlite/genai/mod.rs
@@ -27,6 +27,36 @@ use std::time::{Duration, Instant};
 use super::connection::{create_connection, default_base_path};
 use crate::config::BatchConfig;
 
+/// SQL mirror of [`TokenRecord::billed_input_tokens`], as a `CASE` expression
+/// over the raw columns.
+///
+/// Anthropic reports `cache_creation_tokens` / `cache_read_tokens` outside
+/// `input_tokens`, so they add to the billed input. OpenAI-compatible gateways
+/// and Gemini already count cached tokens inside the reported input, so adding
+/// them again inflates every cached call. These aggregations run in SQLite and
+/// cannot call the Rust helper, so the rule is restated here — keep the two in
+/// sync.
+///
+/// Deriving totals from the raw columns instead of reading the stored
+/// `total_tokens` also corrects rows written before this rule existed, since
+/// `input_tokens` and the cache columns have always held what the provider
+/// reported.
+///
+/// Expands to a string literal so callers assemble their query with `concat!`
+/// into a fixed `&'static str`, honouring the storage-layer rule that SQL is
+/// built as parameterized literal text (`?` placeholders, no runtime string
+/// building) while still stating this fragment once.
+///
+/// [`TokenRecord::billed_input_tokens`]: crate::analyzer::TokenRecord::billed_input_tokens
+macro_rules! billed_input_col {
+    () => {
+        "CASE WHEN LOWER(COALESCE(provider, '')) = 'anthropic' \
+         THEN input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0) \
+         ELSE input_tokens END"
+    };
+}
+pub(crate) use billed_input_col;
+
 // Re-export public types from sub-modules
 pub use events::TraceEventDetail;
 pub use pending::{PendingCallInfo, PendingOrigin, SseEnrichment};

--- a/src/agentsight/src/storage/sqlite/genai/session.rs
+++ b/src/agentsight/src/storage/sqlite/genai/session.rs
@@ -2,7 +2,7 @@
 
 use rusqlite::params;
 
-use super::GenAISqliteStore;
+use super::{GenAISqliteStore, billed_input_col};
 
 // ─── Query result types ────────────────────────────────────────────────────────
 
@@ -78,11 +78,14 @@ impl GenAISqliteStore {
             " AND (g2.call_kind = 'main' OR g2.call_kind IS NULL)"
         };
         let sql = format!(
-            "SELECT session_id,
+            concat!(
+                "SELECT session_id,
                     COUNT(DISTINCT conversation_id) AS conversation_count,
                     MIN(start_timestamp_ns)  AS first_seen_ns,
                     MAX(start_timestamp_ns)  AS last_seen_ns,
-                    COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)  AS total_input,
+                    COALESCE(SUM(",
+                billed_input_col!(),
+                "), 0)  AS total_input,
                     COALESCE(SUM(output_tokens), 0) AS total_output,
                     MAX(model)               AS model,
                     MAX(agent_name)          AS agent_name,
@@ -104,6 +107,9 @@ impl GenAISqliteStore {
                AND start_timestamp_ns BETWEEN ?1 AND ?2{call_kind_filter}
              GROUP BY session_id
              ORDER BY last_seen_ns DESC"
+            ),
+            sub_call_kind_filter = sub_call_kind_filter,
+            call_kind_filter = call_kind_filter
         );
         let mut stmt = conn.prepare(&sql)?;
         let rows = stmt.query_map(params![start_ns, end_ns], |row| {
@@ -139,10 +145,13 @@ impl GenAISqliteStore {
     ) -> Result<Vec<SavingsSessionSummary>, Box<dyn std::error::Error>> {
         let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
 
-        let sql = if agent_name.is_some() {
-            "SELECT session_id,
+        let sql: &str = if agent_name.is_some() {
+            concat!(
+                "SELECT session_id,
                     MAX(agent_name)                  AS agent_name,
-                    COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)   AS total_input,
+                    COALESCE(SUM(",
+                billed_input_col!(),
+                "), 0)   AS total_input,
                     COALESCE(SUM(output_tokens), 0)  AS total_output,
                     COUNT(*)                         AS request_count
              FROM genai_events
@@ -152,10 +161,14 @@ impl GenAISqliteStore {
                AND agent_name = ?3
              GROUP BY session_id
              ORDER BY MAX(start_timestamp_ns) DESC"
+            )
         } else {
-            "SELECT session_id,
+            concat!(
+                "SELECT session_id,
                     MAX(agent_name)                  AS agent_name,
-                    COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)   AS total_input,
+                    COALESCE(SUM(",
+                billed_input_col!(),
+                "), 0)   AS total_input,
                     COALESCE(SUM(output_tokens), 0)  AS total_output,
                     COUNT(*)                         AS request_count
              FROM genai_events
@@ -164,6 +177,7 @@ impl GenAISqliteStore {
                AND start_timestamp_ns BETWEEN ?1 AND ?2
              GROUP BY session_id
              ORDER BY MAX(start_timestamp_ns) DESC"
+            )
         };
 
         let mut stmt = conn.prepare(sql)?;
@@ -201,15 +215,19 @@ impl GenAISqliteStore {
     ) -> Result<Option<SavingsSessionSummary>, Box<dyn std::error::Error>> {
         let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
 
-        let sql = "SELECT session_id,
+        let sql = concat!(
+            "SELECT session_id,
                     MAX(agent_name)                  AS agent_name,
-                    COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)   AS total_input,
+                    COALESCE(SUM(",
+            billed_input_col!(),
+            "), 0)   AS total_input,
                     COALESCE(SUM(output_tokens), 0)  AS total_output,
                     COUNT(*)                         AS request_count
              FROM genai_events
              WHERE event_type = 'llm_call'
                AND session_id = ?1
-             GROUP BY session_id";
+             GROUP BY session_id"
+        );
 
         let mut stmt = conn.prepare(sql)?;
         let mut rows = stmt.query_map(rusqlite::params![session_id], |row| {
@@ -342,9 +360,12 @@ impl GenAISqliteStore {
         // When both start_ns and end_ns are present, rewrite with BETWEEN
         let sql = if start_ns.is_some() && end_ns.is_some() {
             format!(
-                "SELECT conversation_id,
+                concat!(
+                    "SELECT conversation_id,
                         COUNT(*)                        AS call_count,
-                        COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)  AS total_input,
+                        COALESCE(SUM(",
+                    billed_input_col!(),
+                    "), 0)  AS total_input,
                         COALESCE(SUM(output_tokens), 0) AS total_output,
                         MIN(start_timestamp_ns)         AS start_ns,
                         MAX(end_timestamp_ns)           AS end_ns,
@@ -357,12 +378,17 @@ impl GenAISqliteStore {
                    AND start_timestamp_ns BETWEEN ?2 AND ?3{call_kind_filter}
                  GROUP BY conversation_id
                  ORDER BY start_ns DESC"
+                ),
+                call_kind_filter = call_kind_filter
             )
         } else if start_ns.is_some() {
             format!(
-                "SELECT conversation_id,
+                concat!(
+                    "SELECT conversation_id,
                         COUNT(*)                        AS call_count,
-                        COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)  AS total_input,
+                        COALESCE(SUM(",
+                    billed_input_col!(),
+                    "), 0)  AS total_input,
                         COALESCE(SUM(output_tokens), 0) AS total_output,
                         MIN(start_timestamp_ns)         AS start_ns,
                         MAX(end_timestamp_ns)           AS end_ns,
@@ -375,12 +401,17 @@ impl GenAISqliteStore {
                    AND start_timestamp_ns >= ?2{call_kind_filter}
                  GROUP BY conversation_id
                  ORDER BY start_ns DESC"
+                ),
+                call_kind_filter = call_kind_filter
             )
         } else if end_ns.is_some() {
             format!(
-                "SELECT conversation_id,
+                concat!(
+                    "SELECT conversation_id,
                         COUNT(*)                        AS call_count,
-                        COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)  AS total_input,
+                        COALESCE(SUM(",
+                    billed_input_col!(),
+                    "), 0)  AS total_input,
                         COALESCE(SUM(output_tokens), 0) AS total_output,
                         MIN(start_timestamp_ns)         AS start_ns,
                         MAX(end_timestamp_ns)           AS end_ns,
@@ -393,12 +424,17 @@ impl GenAISqliteStore {
                    AND start_timestamp_ns <= ?2{call_kind_filter}
                  GROUP BY conversation_id
                  ORDER BY start_ns DESC"
+                ),
+                call_kind_filter = call_kind_filter
             )
         } else {
             format!(
-                "SELECT conversation_id,
+                concat!(
+                    "SELECT conversation_id,
                         COUNT(*)                        AS call_count,
-                        COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0)  AS total_input,
+                        COALESCE(SUM(",
+                    billed_input_col!(),
+                    "), 0)  AS total_input,
                         COALESCE(SUM(output_tokens), 0) AS total_output,
                         MIN(start_timestamp_ns)         AS start_ns,
                         MAX(end_timestamp_ns)           AS end_ns,
@@ -410,6 +446,8 @@ impl GenAISqliteStore {
                    AND conversation_id IS NOT NULL{call_kind_filter}
                  GROUP BY conversation_id
                  ORDER BY start_ns DESC"
+                ),
+                call_kind_filter = call_kind_filter
             )
         };
 

--- a/src/agentsight/src/storage/sqlite/genai/stats.rs
+++ b/src/agentsight/src/storage/sqlite/genai/stats.rs
@@ -2,7 +2,7 @@
 
 use rusqlite::params;
 
-use super::GenAISqliteStore;
+use super::{GenAISqliteStore, billed_input_col};
 
 // ─── Query result types ────────────────────────────────────────────────────────
 
@@ -398,31 +398,43 @@ impl GenAISqliteStore {
         let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
 
         // Build query with optional agent_name filter
-        let sql = if agent_name.is_some() {
-            "SELECT
+        let sql: &str = if agent_name.is_some() {
+            concat!(
+                "SELECT
                 (start_timestamp_ns - ?1) / ?3            AS bucket_idx,
                 ?1 + ((start_timestamp_ns - ?1) / ?3) * ?3 AS bucket_start_ns,
-                COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS input_tokens,
+                COALESCE(SUM(",
+                billed_input_col!(),
+                "), 0)                AS input_tokens,
                 COALESCE(SUM(output_tokens), 0)           AS output_tokens,
-                COALESCE(SUM(input_tokens + output_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS total_tokens
+                COALESCE(SUM((",
+                billed_input_col!(),
+                ") + output_tokens), 0) AS total_tokens
              FROM genai_events
              WHERE event_type = 'llm_call'
                AND start_timestamp_ns BETWEEN ?1 AND ?2
                AND agent_name = ?4
              GROUP BY bucket_idx
              ORDER BY bucket_idx ASC"
+            )
         } else {
-            "SELECT
+            concat!(
+                "SELECT
                 (start_timestamp_ns - ?1) / ?3            AS bucket_idx,
                 ?1 + ((start_timestamp_ns - ?1) / ?3) * ?3 AS bucket_start_ns,
-                COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS input_tokens,
+                COALESCE(SUM(",
+                billed_input_col!(),
+                "), 0)                AS input_tokens,
                 COALESCE(SUM(output_tokens), 0)           AS output_tokens,
-                COALESCE(SUM(input_tokens + output_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS total_tokens
+                COALESCE(SUM((",
+                billed_input_col!(),
+                ") + output_tokens), 0) AS total_tokens
              FROM genai_events
              WHERE event_type = 'llm_call'
                AND start_timestamp_ns BETWEEN ?1 AND ?2
              GROUP BY bucket_idx
              ORDER BY bucket_idx ASC"
+            )
         };
 
         let rows: Vec<TimeseriesBucket> = if let Some(name) = agent_name {
@@ -466,29 +478,37 @@ impl GenAISqliteStore {
 
         let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
 
-        let sql = if agent_name.is_some() {
-            "SELECT
+        let sql: &str = if agent_name.is_some() {
+            concat!(
+                "SELECT
                 (start_timestamp_ns - ?1) / ?3            AS bucket_idx,
                 ?1 + ((start_timestamp_ns - ?1) / ?3) * ?3 AS bucket_start_ns,
                 COALESCE(model, 'unknown')                 AS model,
-                COALESCE(SUM(input_tokens + output_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS total_tokens
+                COALESCE(SUM((",
+                billed_input_col!(),
+                ") + output_tokens), 0) AS total_tokens
              FROM genai_events
              WHERE event_type = 'llm_call'
                AND start_timestamp_ns BETWEEN ?1 AND ?2
                AND agent_name = ?4
              GROUP BY bucket_idx, model
              ORDER BY bucket_idx ASC"
+            )
         } else {
-            "SELECT
+            concat!(
+                "SELECT
                 (start_timestamp_ns - ?1) / ?3            AS bucket_idx,
                 ?1 + ((start_timestamp_ns - ?1) / ?3) * ?3 AS bucket_start_ns,
                 COALESCE(model, 'unknown')                 AS model,
-                COALESCE(SUM(input_tokens + output_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS total_tokens
+                COALESCE(SUM((",
+                billed_input_col!(),
+                ") + output_tokens), 0) AS total_tokens
              FROM genai_events
              WHERE event_type = 'llm_call'
                AND start_timestamp_ns BETWEEN ?1 AND ?2
              GROUP BY bucket_idx, model
              ORDER BY bucket_idx ASC"
+            )
         };
 
         let rows: Vec<ModelTimeseriesBucket> = if let Some(name) = agent_name {
@@ -521,24 +541,24 @@ impl GenAISqliteStore {
         &self,
     ) -> Result<Vec<AgentActivitySummary>, Box<dyn std::error::Error>> {
         let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
-        let mut stmt = conn.prepare(
+        let mut stmt = conn.prepare(concat!(
             "SELECT MIN(COALESCE(NULLIF(TRIM(agent_name), ''),
                                 NULLIF(TRIM(process_name), ''))) AS display_name,
                     MAX(CASE WHEN end_timestamp_ns IS NOT NULL AND end_timestamp_ns > 0
                              THEN end_timestamp_ns ELSE start_timestamp_ns END) AS last_seen_ns,
                     COUNT(*) AS total_calls,
-                    COALESCE(SUM(COALESCE(input_tokens, 0)
-                               + COALESCE(output_tokens, 0)
-                               + COALESCE(cache_creation_tokens, 0)
-                               + COALESCE(cache_read_tokens, 0)), 0) AS total_tokens
+                    COALESCE(SUM(COALESCE(",
+            billed_input_col!(),
+            ", 0)
+                               + COALESCE(output_tokens, 0)), 0) AS total_tokens
              FROM genai_events
              WHERE event_type = 'llm_call'
                AND COALESCE(NULLIF(TRIM(agent_name), ''),
                             NULLIF(TRIM(process_name), '')) IS NOT NULL
              GROUP BY COALESCE(NULLIF(TRIM(agent_name), ''),
                                NULLIF(TRIM(process_name), '')) COLLATE NOCASE
-             ORDER BY last_seen_ns DESC, display_name ASC",
-        )?;
+             ORDER BY last_seen_ns DESC, display_name ASC"
+        ))?;
         let rows = stmt.query_map([], |row| {
             Ok(AgentActivitySummary {
                 agent_name: row.get(0)?,
@@ -558,17 +578,21 @@ impl GenAISqliteStore {
         &self,
     ) -> Result<Vec<AgentTokenSummary>, Box<dyn std::error::Error>> {
         let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
-        let mut stmt = conn.prepare(
+        let mut stmt = conn.prepare(concat!(
             "SELECT COALESCE(agent_name, process_name, 'unknown') AS agent,
-                    COALESCE(SUM(input_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS input_tokens,
+                    COALESCE(SUM(",
+            billed_input_col!(),
+            "), 0)      AS input_tokens,
                     COALESCE(SUM(output_tokens), 0) AS output_tokens,
-                    COALESCE(SUM(input_tokens + output_tokens + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)), 0) AS total_tokens,
+                    COALESCE(SUM((",
+            billed_input_col!(),
+            ") + output_tokens), 0) AS total_tokens,
                     COUNT(*)                        AS request_count
              FROM genai_events
              WHERE event_type = 'llm_call'
              GROUP BY agent
-             ORDER BY total_tokens DESC",
-        )?;
+             ORDER BY total_tokens DESC"
+        ))?;
         let rows = stmt.query_map([], |row| {
             Ok(AgentTokenSummary {
                 agent_name: row.get(0)?,

--- a/src/agentsight/src/storage/sqlite/genai/tests.rs
+++ b/src/agentsight/src/storage/sqlite/genai/tests.rs
@@ -442,6 +442,143 @@ fn test_get_agent_token_summary() {
     cleanup_db(&path);
 }
 
+/// Cache accounting differs by provider, and these aggregations recompute the
+/// totals in SQL instead of reading the stored `total_tokens` column. Figures
+/// come from captured traffic: an Anthropic call, which reports the cache
+/// counters outside `input_tokens`, and a Qoder CLI call, whose OpenAI-style
+/// gateway already counts them inside `prompt_tokens`.
+#[test]
+fn test_token_aggregations_apply_provider_cache_rule() {
+    let path =
+        std::env::temp_dir().join(format!("test_genai_cache_rule_{}.db", std::process::id()));
+    cleanup_db(&path);
+    let store = GenAISqliteStore::new_with_path(&path).unwrap();
+
+    let sql = "INSERT INTO genai_events (\
+               call_id, event_type, start_timestamp_ns, end_timestamp_ns, duration_ns,\
+               provider, model, input_tokens, output_tokens, total_tokens,\
+               cache_creation_tokens, cache_read_tokens,\
+               agent_name, pid, status, event_json, process_name,\
+               session_id, conversation_id\
+               ) VALUES (?1,'llm_call',?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,'complete','{}',?14,?15,?16)";
+    {
+        let conn = store.conn.lock().unwrap();
+        conn.execute(
+            sql,
+            params![
+                "anthropic-call",
+                BASE_NS,
+                BASE_NS + STEP_NS,
+                STEP_NS,
+                "anthropic",
+                "claude-opus-5",
+                1111_i64,
+                803_i64,
+                26490_i64,
+                0_i64,
+                24576_i64,
+                "claude",
+                1_i32,
+                "proc-claude",
+                "sess-anthropic",
+                "conv-anthropic"
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            sql,
+            params![
+                "openai-call",
+                BASE_NS + STEP_NS,
+                BASE_NS + 2 * STEP_NS,
+                STEP_NS,
+                "openai",
+                "gpt-4o",
+                74302_i64,
+                170_i64,
+                74472_i64,
+                0_i64,
+                71552_i64,
+                "qodercli",
+                2_i32,
+                "proc-node",
+                "sess-openai",
+                "conv-openai"
+            ],
+        )
+        .unwrap();
+    }
+
+    let ts = store
+        .get_token_timeseries(BASE_NS, BASE_NS + 6 * STEP_NS, None, 1)
+        .unwrap();
+    assert_eq!(ts.len(), 1);
+    // Anthropic contributes 1111 + 24576; OpenAI contributes 74302 as reported.
+    assert_eq!(ts[0].input_tokens, 99_989);
+    assert_eq!(ts[0].output_tokens, 973);
+    // Adding the OpenAI cache read a second time would report 172514 here.
+    assert_eq!(ts[0].total_tokens, 100_962);
+
+    let by_agent = store.get_agent_token_summary().unwrap();
+    assert_eq!(by_agent.len(), 2);
+    assert_eq!(by_agent[0].agent_name, "qodercli");
+    assert_eq!(by_agent[0].input_tokens, 74_302);
+    assert_eq!(by_agent[0].total_tokens, 74_472);
+    assert_eq!(by_agent[1].agent_name, "claude");
+    assert_eq!(by_agent[1].input_tokens, 25_687);
+    assert_eq!(by_agent[1].total_tokens, 26_490);
+
+    let by_model = store
+        .get_model_timeseries(BASE_NS, BASE_NS + 6 * STEP_NS, None, 1)
+        .unwrap();
+    let gpt = by_model.iter().find(|b| b.model == "gpt-4o").unwrap();
+    assert_eq!(gpt.total_tokens, 74_472);
+    let claude = by_model
+        .iter()
+        .find(|b| b.model == "claude-opus-5")
+        .unwrap();
+    assert_eq!(claude.total_tokens, 26_490);
+
+    // Session-scoped queries feed the sessions list and the Token Savings page,
+    // and aggregate the same way.
+    let savings = store
+        .list_sessions_for_savings(BASE_NS, BASE_NS + 6 * STEP_NS, None)
+        .unwrap();
+    let openai_session = savings
+        .iter()
+        .find(|s| s.session_id == "sess-openai")
+        .unwrap();
+    assert_eq!(openai_session.total_input_tokens, 74_302);
+    let anthropic_session = savings
+        .iter()
+        .find(|s| s.session_id == "sess-anthropic")
+        .unwrap();
+    assert_eq!(anthropic_session.total_input_tokens, 25_687);
+
+    let single = store
+        .get_session_for_savings("sess-openai")
+        .unwrap()
+        .expect("session should exist");
+    assert_eq!(single.total_input_tokens, 74_302);
+
+    let sessions = store
+        .list_sessions(BASE_NS, BASE_NS + 6 * STEP_NS, true)
+        .unwrap();
+    let listed = sessions
+        .iter()
+        .find(|s| s.session_id == "sess-openai")
+        .unwrap();
+    assert_eq!(listed.total_input_tokens, 74_302);
+
+    let traces = store
+        .list_traces_by_session("sess-openai", None, None, true)
+        .unwrap();
+    assert_eq!(traces.len(), 1);
+    assert_eq!(traces[0].total_input_tokens, 74_302);
+
+    cleanup_db(&path);
+}
+
 #[test]
 fn test_get_agent_token_summary_empty() {
     let path = std::env::temp_dir().join(format!("test_genai_ats_empty_{}.db", std::process::id()));
@@ -1559,19 +1696,22 @@ fn agent_activity_summaries_group_names_and_aggregate_calls() {
     let store = GenAISqliteStore::new_with_path(&path).unwrap();
     {
         let conn = store.conn.lock().unwrap();
+        // `provider` is set explicitly because the aggregated total depends on
+        // it: Anthropic reports the cache counters outside input_tokens, so
+        // they add to the total, while OpenAI-style gateways do not.
         conn.execute(
             "INSERT INTO genai_events
-             (event_type, start_timestamp_ns, end_timestamp_ns, agent_name,
+             (event_type, start_timestamp_ns, end_timestamp_ns, agent_name, provider,
               input_tokens, output_tokens, cache_read_tokens, event_json)
-             VALUES ('llm_call', 100, 150, 'Claude', 10, 5, 2, '{}')",
+             VALUES ('llm_call', 100, 150, 'Claude', 'anthropic', 10, 5, 2, '{}')",
             [],
         )
         .unwrap();
         conn.execute(
             "INSERT INTO genai_events
-             (event_type, start_timestamp_ns, end_timestamp_ns, agent_name,
+             (event_type, start_timestamp_ns, end_timestamp_ns, agent_name, provider,
               input_tokens, output_tokens, cache_creation_tokens, event_json)
-             VALUES ('llm_call', 200, 0, 'claude', 20, 10, 3, '{}')",
+             VALUES ('llm_call', 200, 0, 'claude', 'anthropic', 20, 10, 3, '{}')",
             [],
         )
         .unwrap();
@@ -1585,9 +1725,9 @@ fn agent_activity_summaries_group_names_and_aggregate_calls() {
         .unwrap();
         conn.execute(
             "INSERT INTO genai_events
-             (event_type, start_timestamp_ns, process_name, input_tokens,
+             (event_type, start_timestamp_ns, process_name, provider, input_tokens,
               output_tokens, event_json)
-             VALUES ('llm_call', 250, 'Codex', 7, 3, '{}')",
+             VALUES ('llm_call', 250, 'Codex', 'openai', 7, 3, '{}')",
             [],
         )
         .unwrap();
@@ -1603,6 +1743,7 @@ fn agent_activity_summaries_group_names_and_aggregate_calls() {
     assert_eq!(summaries[1].agent_name, "Claude");
     assert_eq!(summaries[1].last_seen_ns, 200);
     assert_eq!(summaries[1].total_calls, 2);
+    // Anthropic: (10 + 5 + 2) + (20 + 10 + 3).
     assert_eq!(summaries[1].total_tokens, 50);
 
     drop(store);

--- a/src/agentsight/src/storage/sqlite/token.rs
+++ b/src/agentsight/src/storage/sqlite/token.rs
@@ -624,14 +624,7 @@ impl<'a> TokenQuery<'a> {
 
     /// Build result from records
     fn build_result(&self, records: Vec<TokenRecord>, period: String) -> TokenQueryResult {
-        let input_tokens: u64 = records
-            .iter()
-            .map(|r| {
-                r.input_tokens
-                    + r.cache_creation_tokens.unwrap_or(0)
-                    + r.cache_read_tokens.unwrap_or(0)
-            })
-            .sum();
+        let input_tokens: u64 = records.iter().map(|r| r.billed_input_tokens()).sum();
         let output_tokens: u64 = records.iter().map(|r| r.output_tokens).sum();
         let total_tokens = input_tokens + output_tokens;
         let request_count = records.len() as u64;
@@ -663,9 +656,7 @@ impl<'a> TokenQuery<'a> {
 
             let entry = agent_totals.entry(name).or_insert((0, 0, 0, 0));
             entry.0 += record.total_tokens();
-            entry.1 += record.input_tokens
-                + record.cache_creation_tokens.unwrap_or(0)
-                + record.cache_read_tokens.unwrap_or(0);
+            entry.1 += record.billed_input_tokens();
             entry.2 += record.output_tokens;
             entry.3 += 1;
         }
@@ -1000,9 +991,11 @@ mod tests {
 
         let query = TokenQuery::new(&store);
         let result = query.by_hours_with_compare(1);
-        assert_eq!(result.total_tokens, 160);
+        // make_record reports provider "openai", whose cached tokens already sit
+        // inside input_tokens, so only input + output count.
+        assert_eq!(result.total_tokens, 150);
         let comparison = result.comparison.expect("comparison should be populated");
-        assert_eq!(comparison.previous_total, 40);
+        assert_eq!(comparison.previous_total, 30);
         assert_eq!(comparison.change, 120);
         assert_eq!(comparison.trend, Trend::Up);
         cleanup_db(&path);
@@ -1035,18 +1028,20 @@ mod tests {
 
         let query = TokenQuery::new(&store);
         let compared = query.by_period_with_compare(TimePeriod::Today);
-        assert_eq!(compared.total_tokens, 250);
+        // provider "openai": cached tokens are already part of input_tokens, so
+        // today is (100+50) + (30+20) + (10+10) and yesterday is 20+10.
+        assert_eq!(compared.total_tokens, 220);
         let comparison = compared.comparison.expect("comparison should exist");
-        assert_eq!(comparison.previous_total, 40);
-        assert_eq!(comparison.change, 210);
+        assert_eq!(comparison.previous_total, 30);
+        assert_eq!(comparison.change, 190);
         assert_eq!(comparison.trend, Trend::Up);
 
         let with_breakdown = query.by_period_with_breakdown(TimePeriod::Today);
         assert_eq!(with_breakdown.breakdown.len(), 2);
         assert_eq!(with_breakdown.breakdown[0].name, "Agent-A");
-        assert_eq!(with_breakdown.breakdown[0].total_tokens, 220);
+        assert_eq!(with_breakdown.breakdown[0].total_tokens, 200);
         assert_eq!(with_breakdown.breakdown[0].request_count, 2);
-        assert!((with_breakdown.breakdown[0].percentage - 88.0).abs() < 0.1);
+        assert!((with_breakdown.breakdown[0].percentage - 90.9).abs() < 0.1);
 
         let full = query.full_query(TimePeriod::Today);
         assert!(full.comparison.is_some());


### PR DESCRIPTION
## Why

Every token total AgentSight reports added `cache_creation_tokens` and
`cache_read_tokens` on top of `input_tokens`, regardless of provider.

That is correct for Anthropic, which reports those counters *outside*
`input_tokens`. It is wrong for OpenAI-compatible gateways (including DashScope
and the Qoder CLI gateway) and for Gemini, which already count cached tokens
*inside* `prompt_tokens` / `prompt_token_count`. Every cached call was therefore
inflated by its own cache hit.

From captured traffic: a Qoder CLI call reporting `prompt_tokens=74302`,
`completion_tokens=170`, `cached_tokens=71552` was reported as **146024** instead
of the **74472** the gateway billed — nearly double. Cache hit rates on agent
workloads are routinely above 90%, so the reported figure was close to 2x
reality for cached traffic.

## What changed

The rule is now provider-aware and stated in exactly two places.

**Rust** — `TokenRecord` owns it via a new `billed_input_tokens()`, and
`total_tokens()` is `billed_input_tokens() + output_tokens`. The genai call
builder and the token store aggregation call it instead of repeating the formula.

**SQL** — the dashboard aggregates `genai_events` directly and so never went
through the Rust helper. A `BILLED_INPUT_SQL` fragment in the `genai` module root
restates the rule as a `CASE` expression, reused by all 13 aggregations:

- `stats.rs` — token time-series, per-model time-series, per-agent ranking,
  historical agent activity
- `session.rs` — sessions list, Token Savings session queries, per-conversation
  breakdown

Reported `input_tokens` and `output_tokens` are untouched; only derived totals
change, and only for non-Anthropic providers.

## Related issue

no-issue: reported and reproduced directly from captured gateway traffic; the
defect and its blast radius are fully described above.

## User / Agent impact

Token totals drop to the provider-billed value for OpenAI-style providers,
across the CLI, the dashboard and the API. Anthropic totals are unchanged.

Because the aggregations are derived from `input_tokens` and the cache columns
rather than from the stored `total_tokens` column, **historical rows are also
reported correctly** — those columns have always held what the provider
reported. No data migration is required.

One residual: the stored `genai_events.total_tokens` column still holds the old
inflated value on rows written before this change. Only the per-call detail views
read that column directly; every aggregate view recomputes. This is accepted
rather than migrated.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Reported token totals change value for non-Anthropic providers — that is the
point of the fix, but any consumer that snapshotted previous numbers will see a
step change.

Known limitation, unchanged by this PR: the rule keys off the `provider` string.
Where the provider cannot be identified — notably the truncated-payload fallback
in `scan_partial_usage`, which hard-codes `openai` — Anthropic cache counters are
dropped from the total, which under-reports rather than over-reports. Deciding
the convention from the field spelling that was actually parsed would remove
this; that is a larger change and is deliberately left out of scope.

## Validation

Run from `src/agentsight` on Linux:

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --lib` — 1773 passed, 0 failed
- `cargo doc --no-deps` — no new warnings from the changed files

New coverage:

- `test_openai_style_cache_is_already_inside_input`,
  `test_anthropic_style_cache_adds_to_input`,
  `test_anthropic_match_is_case_insensitive`,
  `test_unknown_provider_keeps_cache_inside_input` — the Rust rule
- `test_token_aggregations_apply_provider_cache_rule` — all six SQL aggregation
  entry points, using the captured Anthropic and Qoder CLI figures above.
  Verified to have teeth: reverting `BILLED_INPUT_SQL` to the old additive form
  makes it fail with 171541 against the expected 99989.

Corrected expectations: three assertions encoded the old formula on fixtures
whose provider is `openai`. One further fixture
(`agent_activity_summaries_group_names_and_aggregate_calls`) names its rows
`Claude`/`claude` but left `provider` unset; `provider` is now set explicitly so
the fixture matches its own intent, which also gives the additive branch
coverage in that query.

Not exercised: live end-to-end capture against a real gateway. The figures used
in the tests come from previously captured traffic.

## Documentation and rollback

No documentation change — this restores the documented meaning of the token
figures rather than altering it. The CHANGELOG entry is intentionally left to the
version-bump commit, per this repository's convention.

Rollback: revert the two commits. No schema change, no migration, no
configuration flag, so a revert restores the previous behavior immediately.
