### PR TITLE
fix(cosh-ng): [shell] heal raw tty after SIGKILL

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/main.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/main.rs
@@ -110,9 +110,9 @@ fn main() {
         ) {
             Invocation::ExecShell(plan) => std::process::exit(exec_shell(plan)),
             Invocation::Tui(entry) => {
-                runtime::terminal::install_terminal_recovery();
                 let cosh_config = config::load_config();
                 runtime::logging::init_logging(&cosh_config.log_level);
+                runtime::terminal::install_terminal_recovery();
                 tracing::info!(version = env!("CARGO_PKG_VERSION"), "cosh-shell starting");
                 // The classifier only admits valid UTF-8 launch arguments;
                 // argv[0] may be arbitrary bytes, so it never reaches the
@@ -166,11 +166,12 @@ fn main() {
         }
     }
 
-    runtime::terminal::install_terminal_recovery();
-
     // Initialize structured logging (file output to ~/.copilot-shell/logs/)
+    // before terminal recovery so that the self-heal warning is captured.
     let cosh_config = config::load_config();
     runtime::logging::init_logging(&cosh_config.log_level);
+
+    runtime::terminal::install_terminal_recovery();
     tracing::info!(version = env!("CARGO_PKG_VERSION"), "cosh-shell starting");
 
     if !has_subcommand {

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/terminal.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/terminal.rs
@@ -19,10 +19,35 @@ pub(crate) fn install_terminal_recovery() {
     if unsafe { libc::tcgetattr(fd, &mut original) } < 0 {
         return;
     }
-    let original_flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    let mut original_flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
     if original_flags < 0 {
         return;
     }
+
+    // SIGKILL cannot be caught, so a previous cosh-shell session may have
+    // left the outer tty in raw mode. Heal that residue before saving the
+    // "original" state used by panic/signal recovery paths.
+    if termios_looks_like_raw_mode(&original) {
+        tracing::warn!("detected stale raw mode from a previous session, self-healing terminal");
+        restore_minimal_sane_terminal_modes(fd);
+        clear_nonblock(fd);
+        unsafe {
+            libc::write(
+                libc::STDOUT_FILENO,
+                crate::shell_host::MODIFY_OTHER_KEYS_DISABLE.as_ptr().cast(),
+                crate::shell_host::MODIFY_OTHER_KEYS_DISABLE.len(),
+            );
+        }
+        // Re-sample the terminal so the recovery snapshot is sane, not raw.
+        if unsafe { libc::tcgetattr(fd, &mut original) } < 0 {
+            return;
+        }
+        let flags_after_heal = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        if flags_after_heal >= 0 {
+            original_flags = flags_after_heal;
+        }
+    }
+
     unsafe { ORIGINAL_TERMIOS = Some(original) };
     ORIGINAL_FILE_STATUS_FLAGS.store(original_flags, Ordering::Release);
 
@@ -49,6 +74,36 @@ pub(crate) fn install_terminal_recovery() {
             libc::SIGQUIT,
             restore_and_exit as *const () as libc::sighandler_t,
         );
+    }
+}
+
+fn termios_looks_like_raw_mode(termios: &libc::termios) -> bool {
+    let required_off = libc::ECHO | libc::ICANON | libc::ISIG;
+    termios.c_lflag & required_off == 0
+}
+
+fn restore_minimal_sane_terminal_modes(fd: i32) {
+    let mut termios = unsafe { std::mem::zeroed::<libc::termios>() };
+    if unsafe { libc::tcgetattr(fd, &mut termios) } < 0 {
+        return;
+    }
+    termios.c_lflag |= libc::ECHO | libc::ICANON | libc::ISIG | libc::IEXTEN;
+    termios.c_iflag |= libc::ICRNL | libc::IXON;
+    termios.c_oflag |= libc::OPOST;
+    unsafe {
+        // Best-effort: if the tty cannot be configured, the subsequent
+        // cosh-shell session will still attempt to enter raw mode and the
+        // user will see the failure surface.
+        let _ = libc::tcsetattr(fd, libc::TCSANOW, &termios);
+    }
+}
+
+fn clear_nonblock(fd: i32) {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags >= 0 && flags & libc::O_NONBLOCK != 0 {
+        unsafe {
+            let _ = libc::fcntl(fd, libc::F_SETFL, flags & !libc::O_NONBLOCK);
+        }
     }
 }
 
@@ -103,5 +158,27 @@ impl<W: Write> Write for CrLfWriter<'_, W> {
 
     fn flush(&mut self) -> io::Result<()> {
         self.inner.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn termios_looks_like_raw_mode_detects_cfmakeraw_signature() {
+        let mut termios = unsafe { std::mem::zeroed::<libc::termios>() };
+        assert!(termios_looks_like_raw_mode(&termios));
+        termios.c_lflag = libc::ECHO | libc::ICANON | libc::ISIG;
+        assert!(!termios_looks_like_raw_mode(&termios));
+    }
+
+    #[test]
+    fn termios_looks_like_raw_mode_does_not_flag_partial_noncanonical() {
+        let mut termios = unsafe { std::mem::zeroed::<libc::termios>() };
+        termios.c_lflag = libc::ECHO | libc::ISIG;
+        assert!(!termios_looks_like_raw_mode(&termios));
+        termios.c_lflag = libc::ICANON;
+        assert!(!termios_looks_like_raw_mode(&termios));
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/mod.rs
@@ -28,6 +28,7 @@ pub(crate) use model::{HintCardRenderer, ShellEventView};
 pub use model::{ScriptedInput, ShellHostConfig, ShellHostOutput, ShellIntegration};
 pub(crate) use raw_relay::interactive_sentinel::InputWaitStatus;
 pub(crate) use raw_runner::raw_mode_guard::restore_raw_mode_signal_state;
+pub(crate) use raw_runner::raw_mode_guard::MODIFY_OTHER_KEYS_DISABLE;
 pub use raw_runner::{
     run_raw_interactive_bash, run_raw_interactive_bash_with_observer,
     run_raw_interactive_bash_with_output_control, run_raw_interactive_zsh_with_output_control,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner/raw_mode_guard.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner/raw_mode_guard.rs
@@ -9,7 +9,7 @@ static SIGNAL_OUTPUT_FD: AtomicI32 = AtomicI32::new(-1);
 static SIGNAL_OUTPUT_IS_TTY: AtomicBool = AtomicBool::new(false);
 static SIGNAL_RECOVERY_ARMED: AtomicBool = AtomicBool::new(false);
 
-const MODIFY_OTHER_KEYS_DISABLE: &[u8] = b"\x1b[>4;0m";
+pub(crate) const MODIFY_OTHER_KEYS_DISABLE: &[u8] = b"\x1b[>4;0m";
 
 fn arm_signal_recovery(output_fd: i32) {
     SIGNAL_OUTPUT_FD.store(output_fd, Ordering::Relaxed);

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/termios.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/termios.rs
@@ -668,6 +668,204 @@ mod parent_lifecycle {
             "exit preserves the foreground command signal status"
         );
     }
+
+    #[test]
+    fn raw_cli_self_heals_stale_raw_mode_after_sigkill() {
+        let _guard = shell_host_run_guard();
+
+        let pty = nix::pty::openpty(None, None).expect("open parent PTY");
+        let mut master = File::from(pty.master);
+        let terminal = File::from(pty.slave);
+
+        let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
+        assert!(flags >= 0, "read parent PTY master flags");
+        assert_eq!(
+            unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK,) },
+            0,
+            "make parent PTY master nonblocking"
+        );
+
+        let original = read_termios(terminal.as_raw_fd());
+        let original_flags = read_file_status_flags(terminal.as_raw_fd());
+
+        let root = std::env::temp_dir().join(format!(
+            "cosh-shell-sigkill-heal-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let home = root.join("home");
+        let work = root.join("work");
+        std::fs::create_dir_all(&home).expect("create isolated HOME");
+        std::fs::create_dir_all(&work).expect("create isolated work dir");
+
+        let mut output = Vec::new();
+
+        // First session: activate raw mode, then die via SIGKILL.
+        let mut child1 = spawn_cosh_on_pty(&terminal, &work, &home, "sigkill-first");
+        wait_for_raw_mode(&mut master, terminal.as_raw_fd(), &mut child1, &mut output);
+        assert_eq!(
+            unsafe { libc::kill(child1.id() as i32, libc::SIGKILL) },
+            0,
+            "send SIGKILL to first cosh-shell"
+        );
+        let _ = child1.wait();
+
+        let residual = read_termios(terminal.as_raw_fd());
+        assert_eq!(
+            residual.c_lflag & (libc::ECHO | libc::ICANON | libc::ISIG),
+            0,
+            "tty should still be raw after SIGKILL"
+        );
+        let residual_flags = read_file_status_flags(terminal.as_raw_fd());
+        assert_ne!(
+            residual_flags & libc::O_NONBLOCK,
+            0,
+            "O_NONBLOCK should be left set after SIGKILL"
+        );
+
+        output.clear();
+
+        // Second session on the same PTY: startup self-heal should restore
+        // a sane baseline before entering raw mode again.
+        let mut child2 = spawn_cosh_on_pty(&terminal, &work, &home, "sigkill-second");
+        wait_for_raw_mode(&mut master, terminal.as_raw_fd(), &mut child2, &mut output);
+        write_to_pty(&mut master, b"exit\n");
+        let status2 = wait_for_child(&mut master, &mut child2, &mut output);
+        assert!(
+            status2.success(),
+            "second session should exit cleanly: {status2:?}"
+        );
+
+        let after = read_termios(terminal.as_raw_fd());
+        assert_termios_eq(&after, &original);
+        assert_eq!(
+            read_file_status_flags(terminal.as_raw_fd()),
+            original_flags,
+            "file status flags should be restored after second session exits"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+        unsafe {
+            let _ = libc::tcsetattr(terminal.as_raw_fd(), libc::TCSANOW, &original);
+        }
+    }
+
+    fn spawn_cosh_on_pty(terminal: &File, work: &Path, home: &Path, _label: &str) -> Child {
+        let stdin = terminal.try_clone().expect("clone PTY stdin");
+        let stdout = terminal.try_clone().expect("clone PTY stdout");
+        let stderr = terminal.try_clone().expect("clone PTY stderr");
+        let mut command = Command::new(env!("CARGO_BIN_EXE_cosh-shell"));
+        command
+            .args(["raw", "fake", "--shell", "bash"])
+            .stdin(Stdio::from(stdin))
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr))
+            .current_dir(work)
+            .env("HOME", home)
+            .env("COSH_SHELL_ISOLATED", "1")
+            .env("COSH_SHELL_INTEGRATION", "enhanced")
+            .env("COSH_SHELL_RAW_SHELL", "bash")
+            .env("COSH_SHELL_DEFAULT_SHELL", "bash")
+            .env("COSH_SHELL_LANG", "en-US")
+            .env("COSH_SHELL_BOOTSTRAP_PATH", "0")
+            .env("COSH_SHELL_HEALTH_SCAN", "disabled")
+            .env("COSH_RECOMMENDATIONS_ENABLED", "0")
+            .env("TERM", "xterm-256color")
+            .env("LANG", "C.UTF-8")
+            .env("LC_ALL", "C.UTF-8");
+        unsafe {
+            command.pre_exec(|| {
+                // Each invocation must become its own session leader and
+                // acquire the PTY as its controlling terminal.
+                if libc::setsid() < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                if libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY as _, 0) < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                if libc::tcsetpgrp(libc::STDIN_FILENO, libc::getpgrp()) < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        command.spawn().expect("spawn cosh-shell on parent PTY")
+    }
+
+    fn wait_for_raw_mode(
+        master: &mut File,
+        terminal_fd: i32,
+        child: &mut Child,
+        output: &mut Vec<u8>,
+    ) {
+        let deadline = Instant::now() + TERMINAL_LIFECYCLE_TIMEOUT;
+        while Instant::now() < deadline {
+            drain_master(master, output);
+            let current = read_termios(terminal_fd);
+            let modify_other_keys_enabled = output
+                .windows(b"\x1b[>4;1m".len())
+                .any(|window| window == b"\x1b[>4;1m");
+            if current.c_lflag & (libc::ECHO | libc::ICANON) == 0 && modify_other_keys_enabled {
+                return;
+            }
+            if child
+                .try_wait()
+                .expect("poll wrapper while waiting for raw mode")
+                .is_some()
+            {
+                panic!("cosh-shell exited before activating raw mode");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("cosh-shell did not activate raw mode");
+    }
+
+    fn wait_for_child(master: &mut File, child: &mut Child, output: &mut Vec<u8>) -> ExitStatus {
+        let deadline = Instant::now() + TERMINAL_LIFECYCLE_TIMEOUT;
+        let status = loop {
+            drain_master(master, output);
+            if let Some(status) = child.try_wait().expect("poll cosh-shell") {
+                break status;
+            }
+            if Instant::now() >= deadline {
+                panic!("cosh-shell did not exit within {TERMINAL_LIFECYCLE_TIMEOUT:?}");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        };
+        drain_master(master, output);
+        status
+    }
+
+    fn write_to_pty(master: &mut File, bytes: &[u8]) {
+        let deadline = Instant::now() + TERMINAL_LIFECYCLE_TIMEOUT;
+        let mut written = 0;
+        while written < bytes.len() {
+            match master.write(&bytes[written..]) {
+                Ok(0) => panic!("parent PTY accepted zero input bytes"),
+                Ok(count) => written += count,
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    if Instant::now() >= deadline {
+                        panic!("timed out writing parent PTY input");
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("write parent PTY input: {error}"),
+            }
+        }
+    }
+
+    fn drain_master(master: &mut File, output: &mut Vec<u8>) {
+        let mut buffer = [0_u8; 4096];
+        loop {
+            match master.read(&mut buffer) {
+                Ok(0) => return,
+                Ok(count) => output.extend_from_slice(&buffer[..count]),
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => return,
+                Err(error) if error.raw_os_error() == Some(libc::EIO) => return,
+                Err(error) => panic!("drain parent PTY output: {error}"),
+            }
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
问题：cosh-shell 被 SIGKILL（或 OOM kill）杀死后，外部 tty 残留 raw 模式，导致用户终端“卡死”。
方案：在 `install_terminal_recovery()` 启动时检测残留 raw 状态，恢复 sane termios 并清除 `O_NONBLOCK`，再保存恢复快照。

## Why
When cosh-shell is killed by SIGKILL (or OOM kill), none of the in-process recovery paths (Drop, panic hook, signal handlers) run, leaving the outer terminal in raw mode with `O_NONBLOCK` set. The next cosh-shell session should be able to recover this transparently on startup.

## What changed
- `runtime/terminal.rs`: detect stale raw mode in `install_terminal_recovery()` and restore minimal sane termios + clear `O_NONBLOCK` before saving the recovery snapshot.
- `shell_host/raw_runner/raw_mode_guard.rs` + `shell_host/mod.rs`: expose `MODIFY_OTHER_KEYS_DISABLE` so the startup recovery can also withdraw modifyOtherKeys.
- `main.rs`: initialize logging before terminal recovery so the self-heal warning is captured.
- `tests/shell_host/termios.rs`: add Linux-only integration test that kills cosh-shell with SIGKILL and verifies the next session self-heals.

## Related issue
closes alibaba/anolisa#2555

## User / Agent impact
Terminal no longer stays frozen in raw mode after an unclean cosh-shell death; the next launch repairs it automatically. A `tracing::warn!` event is emitted when self-healing occurs.

## Risk and compatibility
- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: the change only affects startup when stdin is a tty and the detected state matches cosh-shell's raw-mode signature. No public API or wire protocol changes.

## Validation
- `cargo fmt --all -- --check` passed.
- `cargo clippy --workspace --all-targets -- -D warnings` passed.
- `cargo test --package cosh-shell --bin cosh-shell termios_looks_like_raw_mode` passed.
- `cargo test --package cosh-shell --test shell_host termios::parent_lifecycle::raw_cli_self_heals_stale_raw_mode_after_sigkill` passed.
- Existing `raw_cli_restores_parent_termios_*` tests passed.

## Documentation and rollback
No user-facing documentation changes. Revert this commit to disable the startup self-heal behavior.