### PR TITLE
fix(tokenless): re-list the claude plugin registry on first-run detect

### DIFF
--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -476,8 +476,9 @@ claude-code-install:
 	@# detect.sh exits 1 (installable) or 2 (missing prereq); we tolerate both
 	@# and let install.sh make the final call (it gracefully no-ops without claude CLI).
 	@# This pre-install probe runs on a steady-state machine and its output is
-	@# informational only, so skip detect.sh's first-run settling retries.
-	@$(ADAPTER_ENV) ANOLISA_TARGET=claude-code TOKENLESS_DETECT_RETRIES=0 bash $(CLAUDE_CODE_ADAPTER_DIR)/scripts/detect.sh || true
+	@# informational only, so skip detect.sh's first-run settling retries and
+	@# the plugin registry re-lists that ride out the GH #3082 index lag.
+	@$(ADAPTER_ENV) ANOLISA_TARGET=claude-code TOKENLESS_DETECT_RETRIES=0 TOKENLESS_DETECT_PLUGIN_RELISTS=0 bash $(CLAUDE_CODE_ADAPTER_DIR)/scripts/detect.sh || true
 	@$(ADAPTER_ENV) ANOLISA_TARGET=claude-code bash $(CLAUDE_CODE_ADAPTER_DIR)/scripts/install.sh
 
 claude-code-uninstall:

--- a/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
+++ b/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
@@ -24,6 +24,14 @@ export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
 # fast.
 DETECT_RETRIES="${TOKENLESS_DETECT_RETRIES:-3}"
 DETECT_RETRY_DELAY="${TOKENLESS_DETECT_RETRY_DELAY:-1}"
+# Separate, smaller budget for one result that only looks definitive: a
+# `plugin list` that succeeds but omits the plugin. `claude plugin install`
+# writes marketplace.json/plugin.json, yet the CLI's plugin registry index
+# only picks them up on a later scan, so the very first list right after
+# provisioning can succeed and still omit the just-installed plugin (GH
+# #3082). Kept apart from DETECT_RETRIES so a genuinely absent plugin pays a
+# couple of cheap re-lists rather than the whole settling budget.
+DETECT_PLUGIN_RELISTS="${TOKENLESS_DETECT_PLUGIN_RELISTS:-2}"
 
 # settle <cmd...> — run cmd once; if it reports a retryable failure (exit
 # status 1), sleep DETECT_RETRY_DELAY and retry, up to DETECT_RETRIES retries
@@ -97,13 +105,21 @@ else
     field "plugin.json"       "missing (run: make stamp-adapter-templates)"
 fi
 
+# plugin_manifests_staged — true when the local manifests that
+# `claude plugin install` consumes (the single-plugin marketplace plus the
+# stamped plugin manifest) are both on disk. Their presence is what makes an
+# omitted plugin ambiguous: the installer had something to register, so the
+# CLI's registry index may simply not have caught up with it yet.
+plugin_manifests_staged() {
+    [ -f "$PLUGIN_SRC/.claude-plugin/marketplace.json" ] \
+        && [ -f "$PLUGIN_SRC/.claude-plugin/plugin.json" ]
+}
+
 # claude_plugin_listed — probe the plugin registry, using the settle()
 # exit-status contract: 0 = plugin listed; 1 = `claude plugin list` itself
 # failed (the CLI may still be initializing ~/.claude on first run, so a
 # retry may still succeed); 2 = `plugin list` ran successfully but did not
-# list the plugin. That is a definitive absent result — no retry can change
-# it — so settle() must return immediately instead of sleeping out the
-# retry budget and invoking the CLI DETECT_RETRIES + 1 times.
+# list the plugin.
 claude_plugin_listed() {
     local listing
     if ! listing="$("$CLAUDE_BIN" plugin list 2>&1)"; then
@@ -115,12 +131,39 @@ claude_plugin_listed() {
     return 2
 }
 
+# settle_plugin_listed — settle() for the plugin probe, extended with a
+# bounded re-list of the "list succeeded but omitted the plugin" case.
+#
+# With nothing staged on disk that omission is definitive — there was no
+# plugin for the registry to index — so it is returned immediately (status
+# 2) without spending any budget. With the manifests staged it is also the
+# shape of the GH #3082 first-run race, where the registry index lags one
+# scan behind the installer and the just-installed plugin is missing from an
+# otherwise successful list. Re-list up to DETECT_PLUGIN_RELISTS times to
+# ride out that refresh window; a genuinely absent plugin still ends up
+# reported as "not installed", only a few cheap calls later.
+#
+# Like settle(), this must be called in a condition context so that `set -e`
+# stays suppressed while the probe reports a non-zero status.
+settle_plugin_listed() {
+    local relist=0 rc=0
+    settle claude_plugin_listed; rc=$?
+    while [ "$rc" -eq 2 ] && [ "$relist" -lt "$DETECT_PLUGIN_RELISTS" ] \
+        && plugin_manifests_staged; do
+        relist=$((relist + 1))
+        sleep "$DETECT_RETRY_DELAY"
+        settle claude_plugin_listed; rc=$?
+    done
+    return "$rc"
+}
+
 if [ -n "$CLAUDE_BIN" ] && [ -x "$CLAUDE_BIN" ]; then
     # First-run race: `claude plugin list` may transiently fail while the CLI
-    # initializes ~/.claude; settle() retries while that failure (status 1)
-    # persists. A successful list that simply omits the plugin is definitive
-    # (status 2) and is reported as "not installed" without further retries.
-    if settle claude_plugin_listed; then
+    # initializes ~/.claude (status 1), and may transiently omit a plugin
+    # whose manifests were staged only moments ago (status 2). Both are
+    # retried within their own bounded budgets, and "not installed" is
+    # reported only once those budgets are exhausted.
+    if settle_plugin_listed; then
         field "plugin install"    "installed ($PLUGIN_ID)"
     else
         field "plugin install"    "not installed"

--- a/src/tokenless/tests/test-claude-code-detect-retry.sh
+++ b/src/tokenless/tests/test-claude-code-detect-retry.sh
@@ -20,10 +20,26 @@
 # first `plugin list`. With settling retries, detect.sh must ride out the
 # race and report ready (exit 0); without retries (scenario 2) the same
 # first execution must fail with exit 2, proving the retries are what fix
-# it. Scenarios 3-4 pin the plugin probe's retry semantics: a successful
-# `plugin list` that omits the plugin is a definitive result and must not
-# consume the retry budget, while a failing `plugin list` is transient and
-# is retried.
+# it. The remaining scenarios pin the plugin probe's retry semantics.
+#
+# GH #3082 reported a second, distinct first-run race: `claude plugin
+# install` writes the marketplace/plugin manifests, but the CLI's plugin
+# registry index only picks them up on a later scan, so the very first
+# `plugin list` right after provisioning succeeds (exit 0) and still omits
+# the just-installed plugin. detect.sh used to treat that omission as
+# definitive and report "not installed" (exit 1) on the first run, while the
+# second run correctly reported ready. It now re-lists that one case a
+# bounded number of times (scenarios 4-5), but only while the local
+# manifests are staged — with nothing on disk for the installer to have
+# registered, the omission really is definitive and must not spend any
+# budget (scenario 6). Scenario 3 pins the cost of that re-listing in the
+# ordinary pre-install state, and scenario 7 keeps the pre-existing rule
+# that an outright failing `plugin list` is transient and is retried.
+#
+# detect.sh reads the manifests and the hook dispatcher from
+# $ANOLISA_ADAPTER_DIR, so every scenario points it at a synthetic adapter
+# tree the test controls; no scenario depends on the state of the checked-out
+# source tree (whether plugin.json has been stamped, for instance).
 
 set -euo pipefail
 
@@ -38,6 +54,12 @@ PLUGIN_ID="tokenless@anolisa-tokenless"
 CALL_LOG="$TEST_DIR/claude-calls.log"
 STUB_MODE_FILE="$TEST_DIR/stub-mode"
 FLAKY_MARKER="$TEST_DIR/flaky-marker"
+# Synthetic adapter tree handed to detect.sh through ANOLISA_ADAPTER_DIR, so
+# the scenarios control whether marketplace.json / plugin.json are staged.
+FAKE_ADAPTER_DIR="$TEST_DIR/adapters/tokenless"
+FAKE_PLUGIN_SRC="$FAKE_ADAPTER_DIR/claude-code"
+LATE_COUNT_FILE="$TEST_DIR/late-count"
+LATE_OMISSIONS=1
 PROVISIONER_PID=""
 
 cleanup() {
@@ -71,6 +93,9 @@ fail() {
 #   absent — the list succeeds but does not contain the plugin
 #   flaky  — the first `plugin list` call fails while the registry
 #            initializes; later calls succeed
+#   late   — the first $LATE_OMISSIONS `plugin list` calls succeed but
+#            omit the plugin (GH #3082: the registry index has not caught up
+#            with the manifests the installer just wrote); later calls list it
 # Like the real CLI, `plugin list` creates $HOME/.claude when it first
 # runs; the config dir does not exist before that. Every invocation is
 # appended to $CALL_LOG so the tests can count CLI calls.
@@ -94,6 +119,16 @@ plugin)
         echo "initializing plugin registry" >&2
         exit 1
     fi
+    if [ "$mode" = "late" ]; then
+        n=$(cat "$LATE_COUNT_FILE" 2>/dev/null || echo 0)
+        n=$((n + 1))
+        echo "$n" >"$LATE_COUNT_FILE"
+        if [ "$n" -le "$LATE_OMISSIONS" ]; then
+            mkdir -p "$HOME/.claude"
+            echo "NAME                          STATUS"
+            exit 0
+        fi
+    fi
     mkdir -p "$HOME/.claude"
     echo "NAME                          STATUS"
     echo "tokenless@anolisa-tokenless   enabled"
@@ -104,6 +139,24 @@ plugin)
 esac
 STUB
     chmod +x "$FAKE_BIN/claude"
+}
+
+stage_adapter() { # stage_adapter <marketplace:yes|no> <plugin-json:yes|no>
+    # Build the synthetic adapter tree detect.sh inspects. The hook dispatcher
+    # is always present (its absence is a prerequisite failure that would mask
+    # the plugin-probe behaviour under test).
+    rm -rf "$FAKE_ADAPTER_DIR"
+    mkdir -p "$FAKE_PLUGIN_SRC/.claude-plugin" "$FAKE_PLUGIN_SRC/hooks"
+    printf '#!/bin/sh\nexit 0\n' >"$FAKE_PLUGIN_SRC/hooks/run-hook.sh"
+    chmod +x "$FAKE_PLUGIN_SRC/hooks/run-hook.sh"
+    if [ "$1" = yes ]; then
+        printf '{\n  "name": "anolisa-tokenless",\n  "plugins": []\n}\n' \
+            >"$FAKE_PLUGIN_SRC/.claude-plugin/marketplace.json"
+    fi
+    if [ "$2" = yes ]; then
+        printf '{\n  "name": "tokenless",\n  "version": "0.0.0-test"\n}\n' \
+            >"$FAKE_PLUGIN_SRC/.claude-plugin/plugin.json"
+    fi
 }
 
 schedule_claude() { # schedule_claude <delay-seconds>
@@ -128,13 +181,14 @@ cancel_provisioner() {
 
 reset_env() {
     rm -rf "$FAKE_HOME/.claude"
-    rm -f "$FAKE_BIN/claude" "$FLAKY_MARKER"
+    rm -f "$FAKE_BIN/claude" "$FLAKY_MARKER" "$LATE_COUNT_FILE"
     echo ready >"$STUB_MODE_FILE"
+    LATE_OMISSIONS=1
 }
 
-run_detect() { # run_detect <retries> <retry-delay>
+run_detect() { # run_detect <retries> <retry-delay> <plugin-relists>
     : >"$CALL_LOG"
-    rm -f "$FLAKY_MARKER"
+    rm -f "$FLAKY_MARKER" "$LATE_COUNT_FILE"
     # Inherit only /usr/local/bin:/usr/bin:/bin (detect.sh itself prepends
     # $HOME/.local/bin): a claude installed elsewhere in the CI PATH must
     # not leak into the window while the stub is not yet provisioned.
@@ -143,8 +197,12 @@ run_detect() { # run_detect <retries> <retry-delay>
     CALL_LOG="$CALL_LOG" \
     STUB_MODE_FILE="$STUB_MODE_FILE" \
     FLAKY_MARKER="$FLAKY_MARKER" \
+    LATE_COUNT_FILE="$LATE_COUNT_FILE" \
+    LATE_OMISSIONS="$LATE_OMISSIONS" \
+    ANOLISA_ADAPTER_DIR="$FAKE_ADAPTER_DIR" \
     TOKENLESS_DETECT_RETRIES="$1" \
     TOKENLESS_DETECT_RETRY_DELAY="$2" \
+    TOKENLESS_DETECT_PLUGIN_RELISTS="$3" \
         bash "$DETECT" 2>&1
 }
 
@@ -158,8 +216,9 @@ plugin_list_calls() {
 # while detect.sh is still settling (retry delay 0.5s). $HOME/.claude does
 # not exist until the CLI's first `plugin list`. Expect ready (exit 0).
 reset_env
+stage_adapter yes yes
 schedule_claude 0.2
-if ! out="$(run_detect 3 0.5)"; then
+if ! out="$(run_detect 3 0.5 2)"; then
     fail "detect.sh should exit 0 (ready) once the settling retries find the claude binary" "$out"
 fi
 finish_provisioner
@@ -184,9 +243,10 @@ grep -qF "missing (created on first claude run)" <<<"$out" \
 # (provisioning completes only after the check), and must fail exactly like
 # the nightly framework-ready check did: exit 2, missing prerequisites.
 reset_env
+stage_adapter yes yes
 schedule_claude 2
 set +e
-out="$(run_detect 0 0)"
+out="$(run_detect 0 0 2)"
 rc=$?
 set -e
 cancel_provisioner
@@ -197,18 +257,20 @@ grep -qF "claude CLI" <<<"$out" \
 grep -qF "missing prerequisites" <<<"$out" \
     || fail "the first execution without retries should report missing prerequisites" "$out"
 
-# --- Scenario 3: definitive plugin-absent must not retry (PR review P2) ---
+# --- Scenario 3: absent plugin is reported after bounded re-lists ---------
 # The CLI is installed and `plugin list` works, but the tokenless plugin is
-# not registered — the ordinary pre-install state. A successful list that
-# omits the plugin is definitive: detect.sh must report "not installed"
-# after exactly one `plugin list` invocation, without sleeping out the
-# retry budget.
+# not registered — the ordinary pre-install state on a host whose adapter
+# manifests are staged. detect.sh cannot tell that from the GH #3082 registry
+# lag on the first list, so it re-lists up to the budget and then reports
+# "not installed" (exit 1). The re-lists are bounded: exactly
+# 1 + TOKENLESS_DETECT_PLUGIN_RELISTS `plugin list` invocations.
 reset_env
 install_claude_stub
+stage_adapter yes yes
 echo absent >"$STUB_MODE_FILE"
 mkdir -p "$FAKE_HOME/.claude"
 set +e
-out="$(run_detect 3 1)"
+out="$(run_detect 3 0 2)"
 rc=$?
 set -e
 [ "$rc" -eq 1 ] \
@@ -216,17 +278,82 @@ set -e
 grep -qF "not installed" <<<"$out" \
     || fail "plugin should be reported not installed" "$out"
 calls="$(plugin_list_calls)"
-[ "$calls" -eq 1 ] \
-    || fail "definitive plugin-absent must not retry: plugin list ran $calls times" "$out"
+[ "$calls" -eq 3 ] \
+    || fail "plugin-absent detection should stop after 1 + 2 re-lists (saw $calls calls)" "$out"
 
-# --- Scenario 4: transient plugin-list failures are still retried ---------
-# A `plugin list` call that fails outright (as opposed to one that succeeds
-# without listing the plugin) is not definitive — the CLI may still be
-# initializing — so settle() retries it.
+# --- Scenario 4: GH #3082, registry index lags behind the installer -------
+# The first `plugin list` right after provisioning succeeds but omits the
+# just-installed plugin (the CLI's registry index has not rescanned the
+# staged manifests yet); the second one lists it. detect.sh must ride out
+# that window and report ready (exit 0) on this very first execution.
 reset_env
 install_claude_stub
+stage_adapter yes yes
+echo late >"$STUB_MODE_FILE"
+LATE_OMISSIONS=1
+if ! out="$(run_detect 3 0 2)"; then
+    fail "detect.sh should exit 0 (ready) once a re-list sees the just-installed plugin" "$out"
+fi
+grep -qF "installed ($PLUGIN_ID)" <<<"$out" \
+    || fail "plugin should be reported installed after the registry index catches up" "$out"
+grep -qF "claude-code: ready" <<<"$out" \
+    || fail "claude-code should be reported ready after the registry index catches up" "$out"
+calls="$(plugin_list_calls)"
+[ "$calls" -eq 2 ] \
+    || fail "the omitted plugin should be re-listed once (saw $calls calls)" "$out"
+
+# --- Scenario 5 (control): same first execution, re-lists disabled --------
+# Without the re-list budget the very same lagging-index first execution
+# reports "not installed" (exit 1) after a single `plugin list`, which is
+# exactly the GH #3082 nightly failure. Proves the re-lists are what fix it.
+reset_env
+install_claude_stub
+stage_adapter yes yes
+echo late >"$STUB_MODE_FILE"
+LATE_OMISSIONS=1
+set +e
+out="$(run_detect 3 0 0)"
+rc=$?
+set -e
+[ "$rc" -eq 1 ] \
+    || fail "without re-lists the lagging-index first execution should exit 1, got $rc" "$out"
+grep -qF "not installed" <<<"$out" \
+    || fail "without re-lists the plugin should be reported not installed" "$out"
+calls="$(plugin_list_calls)"
+[ "$calls" -eq 1 ] \
+    || fail "without a re-list budget plugin list must run exactly once (saw $calls calls)" "$out"
+
+# --- Scenario 6: unstaged manifests make the omission definitive ---------
+# marketplace.json is present but plugin.json is not (an unstamped adapter
+# tree), so `claude plugin install` never had a manifest to register and the
+# registry index has nothing to catch up with: the omission is definitive and
+# must not spend the re-list budget.
+reset_env
+install_claude_stub
+stage_adapter yes no
+echo absent >"$STUB_MODE_FILE"
+mkdir -p "$FAKE_HOME/.claude"
+set +e
+out="$(run_detect 3 0 2)"
+rc=$?
+set -e
+[ "$rc" -eq 1 ] \
+    || fail "unstaged-manifest plugin-absent detection should exit 1, got $rc" "$out"
+grep -qF "not installed" <<<"$out" \
+    || fail "plugin should be reported not installed when nothing is staged" "$out"
+calls="$(plugin_list_calls)"
+[ "$calls" -eq 1 ] \
+    || fail "definitive plugin-absent must not re-list: plugin list ran $calls times" "$out"
+
+# --- Scenario 7: transient plugin-list failures are still retried ---------
+# A `plugin list` call that fails outright (as opposed to one that succeeds
+# without listing the plugin) is not definitive — the CLI may still be
+# initializing — so settle() retries it under its own budget.
+reset_env
+install_claude_stub
+stage_adapter yes yes
 echo flaky >"$STUB_MODE_FILE"
-if ! out="$(run_detect 3 0)"; then
+if ! out="$(run_detect 3 0 2)"; then
     fail "detect.sh should exit 0 after retrying a transient plugin-list failure" "$out"
 fi
 grep -qF "installed ($PLUGIN_ID)" <<<"$out" \


### PR DESCRIPTION
Fixes #3082

## What

`claude-code`'s `detect.sh` reported `not installed` (exit 1) on the **first** run right after the plugin was installed, and `ready` (exit 0) on the second — turning the nightly framework-ready assertion into a failure on three consecutive runs.

## Why

`claude plugin install` writes `marketplace.json` / `plugin.json`, but the CLI's plugin registry index only picks them up on a later scan. So the very first `claude plugin list` after provisioning **succeeds (exit 0) and still omits** the just-installed plugin.

`claude_plugin_listed()` mapped that omission to status `2`, which `settle()` treats as a definitive result and returns without retrying. #2519 covered two transient paths (`plugin list` failing outright, and the `claude` binary not yet visible) but not this third one.

## How

- New `settle_plugin_listed()` wraps `settle claude_plugin_listed` with a **separate, bounded re-list budget** for the "list succeeded but omitted the plugin" case: `TOKENLESS_DETECT_PLUGIN_RELISTS` (default `2`), sleeping the existing `TOKENLESS_DETECT_RETRY_DELAY`. Keeping it apart from `DETECT_RETRIES` means a genuinely absent plugin pays 1 + 2 cheap re-lists rather than the whole settling budget.
- The budget is only spent while `plugin_manifests_staged()` is true, i.e. both `$PLUGIN_SRC/.claude-plugin/marketplace.json` and `plugin.json` are on disk. With nothing for the installer to have registered, the omission stays **definitive** and costs exactly one call, as before.
- `make claude-code-install`'s informational pre-install probe already sets `TOKENLESS_DETECT_RETRIES=0`; it now also sets `TOKENLESS_DETECT_PLUGIN_RELISTS=0`, so a steady-state `make adapter-install` stays fast.
- The regression test points `detect.sh` at a synthetic `ANOLISA_ADAPTER_DIR` tree, so each scenario controls manifest staging instead of depending on whether `plugin.json` happens to be stamped in the checked-out source tree.

### Behaviour when `plugin list` succeeds but omits the plugin

| manifests staged | plugin actually installed | before | after |
| --- | --- | --- | --- |
| yes | yes, index lagging (first run) | exit 1 after 1 call | **exit 0 after 2 calls** |
| yes | no (ordinary pre-install) | exit 1 after 1 call | exit 1 after 3 calls |
| no | no | exit 1 after 1 call | exit 1 after 1 call (unchanged) |

## Files

- `src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh`
- `src/tokenless/tests/test-claude-code-detect-retry.sh`
- `src/tokenless/Makefile`

## Test report

**Environment**: Linux x86_64 · GNU bash 4.4.20 · GNU Make 4.2.1 · cargo 1.96.0 · shellcheck 0.10.0 · Python 3.8.17

### Commands actually executed

| # | Command | Result |
| --- | --- | --- |
| 1 | `bash -n` on both changed shell files | pass (syntax OK) |
| 2 | `make -C src/tokenless test-claude-code-detect` | **pass** — `claude-code detect retry test passed` |
| 3 | same test, 5 consecutive runs | **5/5 pass** (~0.8 s each; no flakiness observed) |
| 4 | `cargo check --workspace --offline` in `src/tokenless` | **pass** — `Finished dev profile in 13.35s`, 0 warnings |
| 5 | `shellcheck -s bash` on `tests/test-claude-code-detect-retry.sh` | **pass** — 0 findings |
| 6 | `shellcheck -s bash` on `claude-code/scripts/detect.sh` | 13 findings, all `SC2317` (info) — **byte-identical count to the pre-change baseline**. All are "command appears to be unreachable" inside `find_claude_bin` / `claude_plugin_listed`, which are invoked indirectly through `settle`. No new findings. |
| 7 | `make -C src/tokenless -n claude-code-install` | pass — recipe renders with both retry knobs set to `0` |
| 8 | `detect.sh` executed directly on a host without `claude` | pass — reports `claude CLI missing` → exit 2, behaviour unchanged |

### Reproduce → verify

A minimal harness was built with a stub `claude` whose **first** `plugin list` succeeds but omits `tokenless@anolisa-tokenless` and whose second lists it (exactly the reported registry lag), plus staged `marketplace.json` / `plugin.json`:

```text
# detect.sh from main (before the fix)
[tokenless]   marketplace.json           present
[tokenless]   plugin.json                present
[tokenless]   plugin install             not installed
[tokenless] claude-code: not installed (ready to install)
rc=1  plugin_list_calls=1

# detect.sh from this branch (after the fix)
[tokenless]   marketplace.json           present
[tokenless]   plugin.json                present
[tokenless]   plugin install             installed (tokenless@anolisa-tokenless)
[tokenless] claude-code: ready
rc=0  plugin_list_calls=2
```

The "before" output reproduces the log in the issue verbatim.

### Regression-test gate

Running the **new** test against the **pre-fix** `detect.sh` fails, and against the fixed one passes — so the test genuinely pins the fix:

```text
pre-fix detect.sh  -> FAIL: plugin-absent detection should stop after 1 + 2 re-lists (saw 1 calls)
fixed   detect.sh  -> claude-code detect retry test passed
```

### Test scenarios

| Scenario | Covers |
| --- | --- |
| 1–2 | unchanged: claude binary appears late → settling retries ride it out (exit 0); control with retries disabled → exit 2 |
| 3 | **changed**: staged manifests + genuinely absent plugin → exit 1 after exactly `1 + 2` `plugin list` calls (pins the bounded cost) |
| 4 | **new**: the #3082 registry lag → exit 0 `ready` on the first execution, 2 calls |
| 5 | **new** control: same as 4 with `TOKENLESS_DETECT_PLUGIN_RELISTS=0` → exit 1 after 1 call (proves the re-lists are what fix it) |
| 6 | **new**: `plugin.json` not staged → omission definitive, exit 1, exactly 1 call |
| 7 | unchanged (was scenario 4): outright failing `plugin list` is still retried → exit 0, 2 calls |

### Not run, and why

- `cargo test --workspace`, `cargo clippy`, `cargo fmt --check` — this change touches **no Rust code** (one shell script, its test, one Makefile recipe), so the Rust gates are unaffected; `cargo check --workspace` was run as the compile sanity gate, and CI runs the full set.
- `make test-hooks` / `test-integration` / `test-adapters` / `test-hook-parity` — require a built `tokenless` binary plus Node bundles, and none of them exercise `claude-code/scripts/detect.sh`.
- End-to-end verification against a real `claude` CLI on a freshly provisioned host — no Claude Code install is available in this environment, so the registry lag is reproduced with a stub CLI instead (see above).
