### PR TITLE
fix(tokenless): retry stale plugin registry index in claude-code detect

### DIFF
--- a/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
+++ b/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
@@ -16,12 +16,12 @@ PLUGIN_SRC="$ADAPTER_DIR/claude-code"
 CLAUDE_BIN="${CLAUDE_BIN:-}"
 export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
 
-# First-run settling retries: right after provisioning, the claude binary or
-# the plugin registry may be transiently invisible on the very first detect.sh
-# execution (filesystem/PATH init timing race). settle() only retries checks
-# that report a retryable failure (exit status 1); checks that succeed or
-# report a definitive result return immediately, so steady-state runs stay
-# fast.
+# First-run settling retries: right after provisioning, the claude binary, the
+# `plugin list` call, or the CLI's plugin registry index may be transiently
+# unavailable on the very first detect.sh execution (filesystem/PATH init and
+# marketplace-scan timing races). settle() only retries checks that report a
+# retryable failure (exit status 1); checks that succeed or report a definitive
+# result return immediately, so steady-state runs stay fast.
 DETECT_RETRIES="${TOKENLESS_DETECT_RETRIES:-3}"
 DETECT_RETRY_DELAY="${TOKENLESS_DETECT_RETRY_DELAY:-1}"
 
@@ -84,7 +84,14 @@ else
     field "claude config dir" "missing (created on first claude run)"
 fi
 
+# The two local manifests say what this adapter is able to install, and the
+# plugin probe below reuses them as its "plugin payload fully staged" signal,
+# so record both results here instead of stat'ing the files a second time.
+MARKETPLACE_STAGED=0
+PLUGIN_MANIFEST_STAGED=0
+
 if [ -f "$PLUGIN_SRC/.claude-plugin/marketplace.json" ]; then
+    MARKETPLACE_STAGED=1
     field "marketplace.json"  "present"
 else
     field "marketplace.json"  "missing"
@@ -92,18 +99,30 @@ else
 fi
 
 if [ -f "$PLUGIN_SRC/.claude-plugin/plugin.json" ]; then
+    PLUGIN_MANIFEST_STAGED=1
     field "plugin.json"       "present"
 else
     field "plugin.json"       "missing (run: make stamp-adapter-templates)"
 fi
 
 # claude_plugin_listed — probe the plugin registry, using the settle()
-# exit-status contract: 0 = plugin listed; 1 = `claude plugin list` itself
-# failed (the CLI may still be initializing ~/.claude on first run, so a
-# retry may still succeed); 2 = `plugin list` ran successfully but did not
-# list the plugin. That is a definitive absent result — no retry can change
-# it — so settle() must return immediately instead of sleeping out the
-# retry budget and invoking the CLI DETECT_RETRIES + 1 times.
+# exit-status contract:
+#   0 = the plugin is listed.
+#   1 = retryable. Either `claude plugin list` itself failed (the CLI may still
+#       be initializing ~/.claude on first run), or the list succeeded while
+#       omitting a plugin whose payload is fully staged on disk. The latter is
+#       the GH #3082 first-run race: marketplace.json / plugin.json are in
+#       place and `claude plugin install` has registered them, but the CLI
+#       refreshes its plugin registry index only on its next marketplace scan,
+#       so the very first `plugin list` after an install can succeed (exit 0)
+#       and still omit the plugin that is in fact installed. Reporting that
+#       omission as definitive made the first detect.sh run on a freshly
+#       provisioned host claim "not installed".
+#   2 = definitive absent: the list succeeded, the plugin is not in it, and the
+#       adapter has no staged payload for a stale index to be hiding either
+#       (e.g. an unstamped dev checkout). No retry can change that, so settle()
+#       must return immediately instead of sleeping out the retry budget and
+#       invoking the CLI DETECT_RETRIES + 1 times.
 claude_plugin_listed() {
     local listing
     if ! listing="$("$CLAUDE_BIN" plugin list 2>&1)"; then
@@ -112,14 +131,24 @@ claude_plugin_listed() {
     if printf '%s\n' "$listing" | grep -qF "$PLUGIN_ID"; then
         return 0
     fi
+    if [ "$MARKETPLACE_STAGED" -eq 1 ] && [ "$PLUGIN_MANIFEST_STAGED" -eq 1 ]; then
+        # Payload staged but not listed: ride out the registry-index refresh
+        # window instead of declaring the plugin absent.
+        return 1
+    fi
     return 2
 }
 
 if [ -n "$CLAUDE_BIN" ] && [ -x "$CLAUDE_BIN" ]; then
-    # First-run race: `claude plugin list` may transiently fail while the CLI
-    # initializes ~/.claude; settle() retries while that failure (status 1)
-    # persists. A successful list that simply omits the plugin is definitive
-    # (status 2) and is reported as "not installed" without further retries.
+    # First-run races: `claude plugin list` may transiently fail while the CLI
+    # initializes ~/.claude, and it may transiently omit an installed plugin
+    # while the registry index catches up with the on-disk manifests. settle()
+    # retries both (status 1) inside the bounded budget — a host whose plugin
+    # really is absent therefore reports "not installed" after at most
+    # DETECT_RETRIES extra listings (none at all with
+    # TOKENLESS_DETECT_RETRIES=0, which is what `make claude-code-install`
+    # uses for its informational pre-install probe). An omission with no staged
+    # payload stays definitive (status 2) and is reported without retries.
     if settle claude_plugin_listed; then
         field "plugin install"    "installed ($PLUGIN_ID)"
     else

--- a/src/tokenless/tests/test-claude-code-detect-retry.sh
+++ b/src/tokenless/tests/test-claude-code-detect-retry.sh
@@ -20,10 +20,17 @@
 # first `plugin list`. With settling retries, detect.sh must ride out the
 # race and report ready (exit 0); without retries (scenario 2) the same
 # first execution must fail with exit 2, proving the retries are what fix
-# it. Scenarios 3-4 pin the plugin probe's retry semantics: a successful
-# `plugin list` that omits the plugin is a definitive result and must not
-# consume the retry budget, while a failing `plugin list` is transient and
-# is retried.
+# it. Scenarios 3-6 pin the plugin probe's retry semantics. GH #3082 showed
+# that a successful `plugin list` omitting the plugin is not always
+# definitive: right after `claude plugin install` the CLI's plugin registry
+# index still lags the manifests on disk, so the first listing can omit a
+# plugin that is in fact installed. detect.sh now treats that omission as
+# retryable whenever the adapter's own marketplace.json + plugin.json payload
+# is fully staged (scenario 5) and as definitive only when nothing is staged
+# (scenario 3). A failing listing stays retryable (scenario 4), and a
+# genuinely absent plugin still terminates inside the bounded budget —
+# including the zero-retry opt-out `make claude-code-install` uses (scenario
+# 6).
 
 set -euo pipefail
 
@@ -38,7 +45,16 @@ PLUGIN_ID="tokenless@anolisa-tokenless"
 CALL_LOG="$TEST_DIR/claude-calls.log"
 STUB_MODE_FILE="$TEST_DIR/stub-mode"
 FLAKY_MARKER="$TEST_DIR/flaky-marker"
+LATE_MARKER="$TEST_DIR/late-list-marker"
 PROVISIONER_PID=""
+
+# detect.sh derives PLUGIN_SRC from ANOLISA_ADAPTER_DIR and its plugin probe
+# keys off the manifests staged there, so point it at a fixture adapter rather
+# than the real tree: a repo checkout has marketplace.json but no stamped
+# plugin.json, and `make stamp-adapter-templates` would silently change which
+# branch of the probe the scenarios exercise.
+FAKE_ADAPTER="$TEST_DIR/adapters/tokenless"
+FAKE_PLUGIN_SRC="$FAKE_ADAPTER/claude-code"
 
 cleanup() {
     if [ -n "$PROVISIONER_PID" ]; then
@@ -50,6 +66,37 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p "$FAKE_BIN" "$SHARED_HOOKS"
+
+# Fixture adapter payload. stage_plugin_payload reproduces a fully installed
+# adapter resource tree (both manifests present); unstage_plugin_manifest
+# reproduces the unstamped dev checkout (plugin.json missing). The hook
+# dispatcher is staged once — its absence would be an unrelated prerequisite
+# failure (exit 2) and would mask the plugin-probe assertions.
+stage_plugin_payload() {
+    mkdir -p "$FAKE_PLUGIN_SRC/.claude-plugin" "$FAKE_PLUGIN_SRC/hooks"
+    cat >"$FAKE_PLUGIN_SRC/.claude-plugin/marketplace.json" <<'JSON'
+{
+  "name": "anolisa-tokenless",
+  "plugins": [
+    { "name": "tokenless", "source": "./" }
+  ]
+}
+JSON
+    cat >"$FAKE_PLUGIN_SRC/.claude-plugin/plugin.json" <<'JSON'
+{
+  "name": "tokenless",
+  "version": "9.9.9-test"
+}
+JSON
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$FAKE_PLUGIN_SRC/hooks/run-hook.sh"
+    chmod +x "$FAKE_PLUGIN_SRC/hooks/run-hook.sh"
+}
+
+unstage_plugin_manifest() {
+    rm -f "$FAKE_PLUGIN_SRC/.claude-plugin/plugin.json"
+}
+
+stage_plugin_payload
 
 # detect.sh also requires `tokenless` and `rtk` on PATH (their absence is a
 # prerequisite failure). Provide isolated stubs so this test is
@@ -67,10 +114,13 @@ fail() {
 }
 
 # Stub claude CLI. `plugin list` behaviour is steered via $STUB_MODE_FILE:
-#   ready  — the list succeeds and contains the tokenless plugin (default)
-#   absent — the list succeeds but does not contain the plugin
-#   flaky  — the first `plugin list` call fails while the registry
-#            initializes; later calls succeed
+#   ready     — the list succeeds and contains the tokenless plugin (default)
+#   absent    — the list succeeds but never contains the plugin
+#   flaky     — the first `plugin list` call fails while the registry
+#               initializes; later calls succeed
+#   late-list — the first `plugin list` call succeeds but omits the plugin
+#               (registry index not rescanned since the install); later calls
+#               list it
 # Like the real CLI, `plugin list` creates $HOME/.claude when it first
 # runs; the config dir does not exist before that. Every invocation is
 # appended to $CALL_LOG so the tests can count CLI calls.
@@ -86,6 +136,12 @@ case "${1:-}" in
     ;;
 plugin)
     if [ "$mode" = "absent" ]; then
+        echo "NAME                          STATUS"
+        exit 0
+    fi
+    if [ "$mode" = "late-list" ] && [ ! -f "$LATE_MARKER" ]; then
+        : >"$LATE_MARKER"
+        mkdir -p "$HOME/.claude"
         echo "NAME                          STATUS"
         exit 0
     fi
@@ -128,21 +184,24 @@ cancel_provisioner() {
 
 reset_env() {
     rm -rf "$FAKE_HOME/.claude"
-    rm -f "$FAKE_BIN/claude" "$FLAKY_MARKER"
+    rm -f "$FAKE_BIN/claude" "$FLAKY_MARKER" "$LATE_MARKER"
+    stage_plugin_payload
     echo ready >"$STUB_MODE_FILE"
 }
 
 run_detect() { # run_detect <retries> <retry-delay>
     : >"$CALL_LOG"
-    rm -f "$FLAKY_MARKER"
+    rm -f "$FLAKY_MARKER" "$LATE_MARKER"
     # Inherit only /usr/local/bin:/usr/bin:/bin (detect.sh itself prepends
     # $HOME/.local/bin): a claude installed elsewhere in the CI PATH must
     # not leak into the window while the stub is not yet provisioned.
     HOME="$FAKE_HOME" \
     PATH="/usr/local/bin:/usr/bin:/bin" \
     CALL_LOG="$CALL_LOG" \
+    ANOLISA_ADAPTER_DIR="$FAKE_ADAPTER" \
     STUB_MODE_FILE="$STUB_MODE_FILE" \
     FLAKY_MARKER="$FLAKY_MARKER" \
+    LATE_MARKER="$LATE_MARKER" \
     TOKENLESS_DETECT_RETRIES="$1" \
     TOKENLESS_DETECT_RETRY_DELAY="$2" \
         bash "$DETECT" 2>&1
@@ -197,14 +256,15 @@ grep -qF "claude CLI" <<<"$out" \
 grep -qF "missing prerequisites" <<<"$out" \
     || fail "the first execution without retries should report missing prerequisites" "$out"
 
-# --- Scenario 3: definitive plugin-absent must not retry (PR review P2) ---
-# The CLI is installed and `plugin list` works, but the tokenless plugin is
-# not registered — the ordinary pre-install state. A successful list that
-# omits the plugin is definitive: detect.sh must report "not installed"
-# after exactly one `plugin list` invocation, without sleeping out the
-# retry budget.
+# --- Scenario 3: unstaged payload + omitted plugin must not retry ----------
+# The CLI is installed and `plugin list` works, the tokenless plugin is not
+# registered, and the adapter has no stamped plugin.json that a stale registry
+# index could be hiding — the pre-install state of an unstamped dev checkout.
+# Such an omission is definitive: detect.sh must report "not installed" after
+# exactly one `plugin list` invocation, without sleeping out the retry budget.
 reset_env
 install_claude_stub
+unstage_plugin_manifest
 echo absent >"$STUB_MODE_FILE"
 mkdir -p "$FAKE_HOME/.claude"
 set +e
@@ -218,6 +278,8 @@ grep -qF "not installed" <<<"$out" \
 calls="$(plugin_list_calls)"
 [ "$calls" -eq 1 ] \
     || fail "definitive plugin-absent must not retry: plugin list ran $calls times" "$out"
+grep -qF "missing (run: make stamp-adapter-templates)" <<<"$out" \
+    || fail "the unstamped manifest that makes the omission definitive should be reported" "$out"
 
 # --- Scenario 4: transient plugin-list failures are still retried ---------
 # A `plugin list` call that fails outright (as opposed to one that succeeds
@@ -234,5 +296,64 @@ grep -qF "installed ($PLUGIN_ID)" <<<"$out" \
 calls="$(plugin_list_calls)"
 [ "$calls" -eq 2 ] \
     || fail "the transient plugin-list failure should be retried once (saw $calls calls)" "$out"
+
+# --- Scenario 5: stale registry index after install is retried (GH #3082) --
+# The nightly failure path: the host has just installed the plugin, so the
+# adapter payload is fully staged on disk, but the CLI has not rescanned its
+# plugin registry yet — the first `plugin list` succeeds (exit 0) and omits
+# tokenless@anolisa-tokenless. detect.sh must ride out that window on its very
+# first execution and report ready (exit 0), instead of declaring the plugin
+# "not installed" and failing the framework-ready assertion.
+reset_env
+install_claude_stub
+echo late-list >"$STUB_MODE_FILE"
+mkdir -p "$FAKE_HOME/.claude"
+if ! out="$(run_detect 3 0)"; then
+    fail "detect.sh should exit 0 (ready) once the registry index catches up with the staged payload" "$out"
+fi
+grep -qF "installed ($PLUGIN_ID)" <<<"$out" \
+    || fail "plugin should be reported installed after the stale-index window" "$out"
+grep -qF "claude-code: ready" <<<"$out" \
+    || fail "claude-code should be reported ready after the stale-index window" "$out"
+calls="$(plugin_list_calls)"
+[ "$calls" -eq 2 ] \
+    || fail "the stale-index omission should be retried once (saw $calls plugin list calls)" "$out"
+
+# --- Scenario 6: a genuinely absent plugin stays bounded -------------------
+# Retrying the omission must not turn the pre-install probe into an unbounded
+# one: with the payload staged and the plugin never listed, detect.sh stops
+# after 1 + TOKENLESS_DETECT_RETRIES listings and still reports "not
+# installed" (exit 1). TOKENLESS_DETECT_RETRIES=0 — the opt-out
+# `make claude-code-install` uses for its informational pre-install probe —
+# keeps that path to a single listing.
+reset_env
+install_claude_stub
+echo absent >"$STUB_MODE_FILE"
+mkdir -p "$FAKE_HOME/.claude"
+set +e
+out="$(run_detect 2 0)"
+rc=$?
+set -e
+[ "$rc" -eq 1 ] \
+    || fail "an absent plugin should still exit 1 (installable), got $rc" "$out"
+grep -qF "not installed" <<<"$out" \
+    || fail "plugin should be reported not installed once the bounded retries are spent" "$out"
+calls="$(plugin_list_calls)"
+[ "$calls" -eq 3 ] \
+    || fail "stale-index retries must stay bounded at 1 + TOKENLESS_DETECT_RETRIES listings (saw $calls)" "$out"
+
+reset_env
+install_claude_stub
+echo absent >"$STUB_MODE_FILE"
+mkdir -p "$FAKE_HOME/.claude"
+set +e
+out="$(run_detect 0 0)"
+rc=$?
+set -e
+[ "$rc" -eq 1 ] \
+    || fail "the zero-retry opt-out should still exit 1 (installable), got $rc" "$out"
+calls="$(plugin_list_calls)"
+[ "$calls" -eq 1 ] \
+    || fail "TOKENLESS_DETECT_RETRIES=0 must skip the stale-index retries (saw $calls listings)" "$out"
 
 echo "claude-code detect retry test passed"


### PR DESCRIPTION
## 问题

Fixes #3082

claude-code adapter 的 `detect.sh` 在**首轮检测**（宿主机刚完成 `claude plugin install` 后立即调用）会把已安装的插件误报为 `not installed` 并 exit 1，第二次检测才正确返回 `ready` (exit 0)。Nightly「框架就绪检测」用例断言首轮 `rc == 0`，因此连续 3 个 nightly 失败、单用例重试均通过。

## 根因

`src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh`：

- `claude_plugin_listed()` 把「`plugin list` 成功执行（exit 0）但输出里没有该插件」映射为 `return 2`；
- `settle()` 只重试 `rc == 1`，`rc == 2` 视为 definitive 立即返回。

插件安装会写盘 `marketplace.json` / `plugin.json`，但 Claude Code CLI 的插件注册索引要等下一次 marketplace 扫描才刷新，所以刚装完的第一次 `plugin list` 会「成功但漏列」。该窗口内的漏列是**瞬时**的，却被当成**确定性未安装** → 首轮 exit 1。#2519 只覆盖了「`plugin list` 失败」与「claude 二进制尚不可见」两条路径。

## 修复

只改 `detect.sh` 的插件探测语义，`settle()` 契约与重试预算不变：

- 报告里已有的两处 manifest 探测顺手记录结果到 `MARKETPLACE_STAGED` / `PLUGIN_MANIFEST_STAGED`（不额外 stat）。
- `claude_plugin_listed()` 返回值：
  - `0` — 已列出；
  - `1`（可重试）— `plugin list` 本身失败，**或** list 成功但漏列、而本地插件载荷已完整就位（`marketplace.json` + `plugin.json` 都 present，即刚安装完成后的状态 → 判定为索引未刷新的瞬时窗口）；
  - `2`（确定性）— list 成功、插件不在其中，且本地没有已就位的载荷（例如未 stamp 的开发检出），重试不可能改变结论。

边界（都写进注释并被测试钉住）：

- 插件确实未安装时，最多多花 `DETECT_RETRIES` 次 listing（默认 3 次、默认 1s 间隔 ≈ 3s）后照常报告 `not installed` (exit 1)；
- `TOKENLESS_DETECT_RETRIES=0`（`make claude-code-install` 的信息性 pre-install 探测已在用）仍然只调用一次 `plugin list`，快路径不受影响；
- 输出格式、tri-state exit 语义（0/1/2）完全不变，无 packaging/spec 改动。

## 测试

`src/tokenless/tests/test-claude-code-detect-retry.sh`：

- Scenario 3 按 issue 建议调整为「本地载荷未就位（`plugin.json` 未 stamp）时，漏列才是确定性、不得重试」，仍断言恰好 1 次 `plugin list` + exit 1；
- 新增 Scenario 5：复现 #3082 —— 载荷已就位、首次 `plugin list` 成功但漏列（新 stub 模式 `late-list`），要求**首轮**就 ride out 索引刷新窗口并 `ready` (exit 0)，恰好 2 次 listing；
- 新增 Scenario 6：载荷已就位但插件始终未列出时，重试必须有界（`1 + TOKENLESS_DETECT_RETRIES` 次 listing，exit 1），且 `TOKENLESS_DETECT_RETRIES=0` 仍为 1 次；
- 测试改为通过 `ANOLISA_ADAPTER_DIR` 驱动 fixture adapter 目录，manifest「已就位/未就位」不再依赖当前检出是否执行过 `make stamp-adapter-templates`（原写法在 stamp 过的树上会让 Scenario 3 语义漂移）。
- Scenario 1/2/4（二进制可见性竞态、零重试对照、`plugin list` 失败重试）保持不变且继续通过。

## 测试情况

**环境概要**：Linux x86_64；GNU bash 4.4.20；Python 3.8.17；GNU Make 4.2.1；rustc/cargo 1.96.0（仅用于 hook parity 目标构建 CLI）。

**实际执行的命令与结果**：

| # | 命令 | 结果 |
| --- | --- | --- |
| 1 | `bash -n` on `detect.sh` + `test-claude-code-detect-retry.sh` | 语法检查通过 |
| 2 | `bash src/tokenless/tests/test-claude-code-detect-retry.sh` | 通过（6 个 scenario 全绿），连续执行 2 次结果一致，单次耗时 ≈ 0.8s |
| 3 | `make -C src/tokenless test-claude-code-detect` | 通过：`claude-code detect retry test passed` |
| 4 | `make -C src/tokenless test-hook-parity` | 通过：`cargo build -p tokenless-cli` 成功（Finished dev profile），`Ran 2 tests ... OK` |
| 5 | `make -C src/tokenless test-hooks` | 55/70 —— **与本改动无关的既有环境失败**，见下 |

**修复前 / 修复后对比（针对性验证）**：

1. 用新测试回归：把 `detect.sh` 还原为 `origin/main` 版本、只保留新测试 → Scenario 5 失败，输出与 nightly 报告完全一致（`marketplace.json present` / `plugin.json present` / `plugin install not installed` / `claude-code: not installed (ready to install)`，`rc=1`）；换回本 PR 的 `detect.sh` → 全部通过。
2. 另做了一个**基于时间窗口**的临时复现脚本（未提交进仓库）：伪造 claude CLI，让 `plugin list` 在「安装完成后 N 秒内」成功但漏列，N 秒后正常列出，其余前置（`tokenless`/`rtk`/shared hooks/manifests）齐备：

| 场景 | `detect.sh` | 结果 |
| --- | --- | --- |
| 索引滞留 2s，默认重试 | 修复前（`origin/main`） | `plugin install not installed`，`rc=1`，耗时 0.02s（立刻误判） |
| 索引滞留 2s，默认重试 | 修复后 | `plugin install installed (tokenless@anolisa-tokenless)` / `claude-code: ready`，`rc=0`，耗时 2.05s |
| 索引滞留 3s，默认重试（3 次 × 1s） | 修复后 | `rc=0`，耗时 3.07s（预算内 ride out） |
| 索引滞留 2s，`TOKENLESS_DETECT_RETRIES=0` | 修复后 | `rc=1`，耗时 0.03s（pre-install 快路径未变慢） |

**关于第 5 项（`make test-hooks`，55/70）**：失败项集中在 `run-all-tests.sh` 的压缩链路用例，报错为 `unrecognized subcommand 'compress'`——执行机上全局安装的是 tokenless 0.7.4，而仓库（0.8.0）的 hook 期望 `tokenless compress` 子命令。已用 `git stash` 在**未修改的 `origin/main`** 上跑同一目标做对照，结果同为 `55/70 passed`、失败项完全一致，确认为既有环境差异，与本 PR（只改 claude-code `detect.sh` 及其测试）无关。

**未运行项及原因**：

- `cargo test --workspace` / `cargo clippy` / `cargo fmt`：本 PR 未改动任何 Rust 代码（只有 2 个 shell 文件），故未运行；`make test-hook-parity` 已完成 `cargo build -p tokenless-cli`，编译链路正常。
- `shellcheck`：执行环境未安装该工具；已改用 `bash -n` 做语法校验，并保持了脚本原有的 `set -euo pipefail`、引用与缩进风格。
- `make test-raw-package` / `test-npm-package` / `test-adapters`：涉及打包与 openclaw/dsh 插件构建，与本改动的 claude-code detect 路径无关，未运行。
- 真机 claude-code CLI（v2.1.251）上的首轮验证：本环境无 Claude Code CLI，按上述 stub + 时间窗口方式复现，未在真实 CLI 上跑。
