### PR TITLE
feat(chore): honor explicit rustup servers

### DIFF
--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -788,6 +788,11 @@ install_rust() {
     }
 
     _source_cargo
+    # Capture overrides before automatic mirror selection exports its defaults.
+    local rustup_server_override=false
+    if [[ -n "${RUSTUP_DIST_SERVER:-}" || -n "${RUSTUP_UPDATE_ROOT:-}" ]]; then
+        rustup_server_override=true
+    fi
     _configure_cargo_mirror
 
     if _rust_ver_ok; then
@@ -800,8 +805,10 @@ install_rust() {
     # RUSTUP_DIST_SERVER remains selected for sec-core's pinned Rust toolchain.
     if cmd_exists rustup; then
         info "Updating via rustup ..."
-        local stable_picked stable_dist stable_update_root
-        stable_picked=$(_pick_rustup_stable_mirror 2>/dev/null || echo "")
+        local stable_picked="" stable_dist stable_update_root
+        if ! $rustup_server_override; then
+            stable_picked=$(_pick_rustup_stable_mirror 2>/dev/null || echo "")
+        fi
         if [[ -n "$stable_picked" ]]; then
             stable_dist="${stable_picked%%|*}"
             stable_update_root="${stable_picked##*|}"
@@ -1030,24 +1037,10 @@ _configure_cargo_mirror() {
     # rustup silently downloads the pinned toolchain (7+ components, ~300MB)
     # from the configured dist server — defaulting to static.rust-lang.org,
     # which is effectively unreachable from China and causes long hangs.
-    local picked dist update_root probe_path
-    probe_path="$(_rustup_probe_path)"
-    if [[ -n "${RUSTUP_DIST_SERVER:-}" ]]; then
-        if _rustup_dist_has_toolchain "$RUSTUP_DIST_SERVER" "$probe_path"; then
-            info "RUSTUP_DIST_SERVER=${RUSTUP_DIST_SERVER}"
-        else
-            warn "RUSTUP_DIST_SERVER=${RUSTUP_DIST_SERVER} cannot serve Rust ${SEC_CORE_RUST_TOOLCHAIN}; selecting fallback mirror"
-            picked=$(_pick_rustup_mirror 2>/dev/null || echo "")
-            if [[ -n "$picked" ]]; then
-                dist="${picked%%|*}"
-                update_root="${picked##*|}"
-                export RUSTUP_DIST_SERVER="$dist"
-                export RUSTUP_UPDATE_ROOT="$update_root"
-                info "RUSTUP_DIST_SERVER=${RUSTUP_DIST_SERVER}"
-            else
-                warn "No fallback rustup mirror verified for ${SEC_CORE_RUST_TOOLCHAIN}"
-            fi
-        fi
+    local picked dist update_root
+    if [[ -n "${RUSTUP_DIST_SERVER:-}" || -n "${RUSTUP_UPDATE_ROOT:-}" ]]; then
+        # Let rustup use the configured endpoints and report download failures.
+        info "Using configured rustup servers"
     else
         picked=$(_pick_rustup_mirror 2>/dev/null || echo "")
         if [[ -n "$picked" ]]; then

--- a/tests/test-build-all-runtime-deps.sh
+++ b/tests/test-build-all-runtime-deps.sh
@@ -785,6 +785,83 @@ test_dry_run_skips_host_preflight() {
     (( preflight_line < install_line )) || fail "dry-run listed install before preflight"
 }
 
+reset_rustup_stubs() {
+    reset_preflight_stubs
+    export CARGO_HOME="$TEST_TMP/rustup-cargo"
+    mkdir -p "$CARGO_HOME"
+    echo '[source.crates-io]' > "$CARGO_HOME/config.toml"
+    unset RUSTUP_DIST_SERVER RUSTUP_UPDATE_ROOT
+    TEST_RUST_VERSION=1.80.0
+    TEST_RUSTUP_CALL=""
+    TEST_RUSTUP_PROBES="$TEST_TMP/rustup-probes"
+    : > "$TEST_RUSTUP_PROBES"
+    # Keep the host environment and all network/package operations isolated.
+    source() { :; }
+    curl() { return 1; }
+    sudo() { fail "unexpected package installation"; }
+    query_repo_ver() { fail "unexpected package lookup"; }
+    _rustup_host_triple() { echo x86_64-unknown-linux-gnu; }
+    rustc() { echo "rustc $TEST_RUST_VERSION"; }
+    cargo() { :; }
+    rustup() {
+        TEST_RUSTUP_CALL="$*|${RUSTUP_DIST_SERVER-unset}|${RUSTUP_UPDATE_ROOT-unset}"
+        TEST_RUST_VERSION=1.93.0
+    }
+    _pick_rustup_mirror() {
+        echo pinned >> "$TEST_RUSTUP_PROBES"
+        echo 'https://pinned.example|https://pinned.example/rustup'
+    }
+    _pick_rustup_stable_mirror() {
+        echo stable >> "$TEST_RUSTUP_PROBES"
+        echo 'https://stable.example|https://stable.example/rustup'
+    }
+}
+
+test_rustup_explicit_servers_are_preserved() {
+    local mode expected_dist expected_update
+    for mode in both dist update; do
+        reset_rustup_stubs
+        if [[ "$mode" != update ]]; then
+            export RUSTUP_DIST_SERVER=https://custom.example
+        fi
+        if [[ "$mode" != dist ]]; then
+            export RUSTUP_UPDATE_ROOT=https://updater.example/rustup
+        fi
+        expected_dist="${RUSTUP_DIST_SERVER-unset}"
+        expected_update="${RUSTUP_UPDATE_ROOT-unset}"
+
+        # Even failed probes must not replace explicit configuration, including
+        # across repeated configuration and the stable update command.
+        _configure_cargo_mirror > "$TEST_OUTPUT" 2>&1
+        _configure_cargo_mirror >> "$TEST_OUTPUT" 2>&1
+        install_rust >> "$TEST_OUTPUT" 2>&1
+
+        [[ "${RUSTUP_DIST_SERVER-unset}" == "$expected_dist" ]] || \
+            fail "$mode: distribution server changed"
+        [[ "${RUSTUP_UPDATE_ROOT-unset}" == "$expected_update" ]] || \
+            fail "$mode: update root changed"
+        [[ "$TEST_RUSTUP_CALL" == "update stable|$expected_dist|$expected_update" ]] || \
+            fail "$mode: stable update did not inherit explicit configuration"
+        [[ ! -s "$TEST_RUSTUP_PROBES" ]] || fail "$mode: auto-selected a mirror"
+    done
+}
+
+test_rustup_automatic_mirrors_still_select_by_channel() {
+    reset_rustup_stubs
+
+    install_rust > "$TEST_OUTPUT" 2>&1
+
+    [[ "$RUSTUP_DIST_SERVER" == https://pinned.example ]] || \
+        fail "pinned-toolchain distribution server changed"
+    [[ "$RUSTUP_UPDATE_ROOT" == https://pinned.example/rustup ]] || \
+        fail "pinned-toolchain update root changed"
+    [[ "$TEST_RUSTUP_CALL" == \
+        'update stable|https://stable.example|https://stable.example/rustup' ]] || \
+        fail "stable update did not use the stable-channel mirror"
+    assert_contains "$TEST_RUSTUP_PROBES" pinned
+    assert_contains "$TEST_RUSTUP_PROBES" stable
+}
+
 run_test() {
     local name="$1" status
     set +e
@@ -833,3 +910,5 @@ run_test test_no_install_skips_runtime_preflight
 run_test test_preflight_failure_precedes_first_install
 run_test test_ignore_deps_skips_install_preflight
 run_test test_dry_run_skips_host_preflight
+run_test test_rustup_explicit_servers_are_preserved
+run_test test_rustup_automatic_mirrors_still_select_by_channel


### PR DESCRIPTION
## Why

`build-all.sh` can replace an explicitly configured Rustup server after a failed probe or when updating stable. Users need a reliable way to select endpoints appropriate for their network.

## What changed

Preserve `RUSTUP_DIST_SERVER` and `RUSTUP_UPDATE_ROOT` whenever either has a nonempty user-provided value, letting Rustup report download failures from the configured endpoints. Capture that choice before automatic configuration so stable updates inherit it; users without overrides retain the existing pinned/stable mirror selection.

## Related issue

Closes #3090

## User / Agent impact

Explicit endpoint settings now survive dependency setup, stable updates, and repeated build-time configuration. Setting only one variable preserves that value and leaves the other unset for Rustup's default behavior.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

An unavailable explicitly configured endpoint is no longer replaced automatically. Unset the overrides to restore automatic selection. Automatic mirror order and Cargo registry configuration are unchanged.

## Validation

- macOS arm64, Bash 5.3.15: `bash tests/test-build-all-runtime-deps.sh` — all 36 tests passed.
- New regression coverage checks both variables together, either variable alone, repeated configuration with failed mocked probes, and stable-update inheritance. It also verifies separate pinned/stable mirror selection with no overrides.
- The explicit-configuration regression failed against the original implementation before the fix.
- `bash -n scripts/build-all.sh tests/test-build-all-runtime-deps.sh` and `git diff --check` passed.
- The local copilot-shell pre-commit hook could not start because `lint-staged` was missing. Its configured JS/TS/JSON/Markdown patterns do not include these Shell files, so it was skipped for this commit; the Shell checks above passed.
- Network and package operations were stubbed; no full Rust build or US-network download was performed.

## Documentation and rollback

No documentation files changed. Inline comments explain why the override is captured before automatic configuration. Revert this commit to restore the previous behavior.
