### PR TITLE
feat(sight): capture rustls plaintext for cosh-ng

### DIFF
--- a/src/agentsight/src/aggregator/http2.rs
+++ b/src/agentsight/src/aggregator/http2.rs
@@ -176,9 +176,16 @@ fn response_sse_stream_ended(payload: &[u8]) -> bool {
         b"data: [END]",
         b"data:[END]",
     ];
-    TERMINATORS
-        .iter()
-        .any(|t| payload.windows(t.len()).any(|w| w == *t))
+    // Match only at SSE field boundaries: the terminator must sit at the very
+    // start of the payload or be preceded by a newline. A bare substring search
+    // would false-positive on model output that happens to contain the literal
+    // text (e.g. a JSON delta whose `content` is `"data: [DONE]"`).
+    TERMINATORS.iter().any(|t| {
+        payload
+            .windows(t.len())
+            .enumerate()
+            .any(|(i, w)| w == *t && (i == 0 || payload[i - 1] == b'\n'))
+    })
 }
 
 /// A complete or partial HTTP/2 stream
@@ -1507,6 +1514,12 @@ mod tests {
         ));
         assert!(!response_sse_stream_ended(b"data: {\"delta\":\"x\"}\n\n"));
         assert!(!response_sse_stream_ended(b""));
+        // Model output whose content is the literal terminator text must NOT
+        // close the stream — the `data: [DONE]` sits mid-JSON, not at a line
+        // start. This is the false-positive the line-boundary check prevents.
+        assert!(!response_sse_stream_ended(
+            b"data: {\"choices\":[{\"delta\":{\"content\":\"data: [DONE]\"}}]}\n\n"
+        ));
     }
 
     #[test]

--- a/src/agentsight/src/aggregator/http2.rs
+++ b/src/agentsight/src/aggregator/http2.rs
@@ -151,6 +151,36 @@ impl Http2StreamState {
     }
 }
 
+/// Whether a response DATA payload carries the SSE terminator that ends the
+/// body, letting the stream be closed without waiting for END_STREAM.
+///
+/// A stream normally closes on the END_STREAM flag, but that flag can never
+/// arrive: a client which recognises `[DONE]` as the end of the answer may exit
+/// before reading the server's final, empty DATA frame. The stream then sits in
+/// `ReceivingResponse` forever and no token usage is ever extracted from it —
+/// the HTTP/1.1 path already avoids this by synthesising a done marker from the
+/// chunked terminator (see `parser::unified`), and this is the HTTP/2 equivalent.
+///
+/// Only the OpenAI-style literal terminator counts, deliberately:
+///
+/// - It is unambiguous, and by protocol no body bytes follow it, so closing here
+///   yields the same aggregated frames a later END_STREAM would have produced.
+/// - Anthropic (`message_stop`) and the DashScope native protocol have their own
+///   terminators, but those streams close on END_STREAM today. Recognising them
+///   here would change when an already-working stream completes, for no gain.
+fn response_sse_stream_ended(payload: &[u8]) -> bool {
+    // Both spacings occur in the wild; `data:[DONE]` is legal SSE.
+    const TERMINATORS: [&[u8]; 4] = [
+        b"data: [DONE]",
+        b"data:[DONE]",
+        b"data: [END]",
+        b"data:[END]",
+    ];
+    TERMINATORS
+        .iter()
+        .any(|t| payload.windows(t.len()).any(|w| w == *t))
+}
+
 /// A complete or partial HTTP/2 stream
 #[derive(Debug, Clone)]
 pub struct Http2Stream {
@@ -942,8 +972,9 @@ impl Http2StreamAggregator {
                             return Http2StreamState::Complete(stream);
                         }
                     } else if frame.is_data() {
+                        let sse_ended = response_sse_stream_ended(frame.payload());
                         response_data_frames.push(frame.clone());
-                        if frame.has_end_stream() {
+                        if frame.has_end_stream() || sse_ended {
                             // Response is complete
                             let mut stream = Http2Stream::new(
                                 *stream_id,
@@ -1007,8 +1038,9 @@ impl Http2StreamAggregator {
                             return Http2StreamState::Complete(stream);
                         }
                     } else if frame.is_data() {
+                        let sse_ended = response_sse_stream_ended(frame.payload());
                         response_data_frames.push(frame.clone());
-                        if frame.has_end_stream() {
+                        if frame.has_end_stream() || sse_ended {
                             // Response is complete
                             let mut stream = Http2Stream::new(
                                 *stream_id,
@@ -1346,6 +1378,135 @@ mod tests {
         ));
 
         assert_eq!(stream.first_output_timestamp_ns(), None);
+    }
+
+    // ─── SSE terminator completion (HTTP/2 counterpart of the chunked
+    // synthetic done marker in parser::unified) ─────────────────────────────
+
+    /// Drive one request/response exchange and return the completed streams.
+    ///
+    /// `resp_data` are response DATA payloads with their END_STREAM flag, applied
+    /// in order, so a test can withhold END_STREAM the way a client that exits on
+    /// `[DONE]` does.
+    fn run_exchange(resp_data: &[(&[u8], bool)]) -> Vec<Http2Stream> {
+        let mut aggregator = Http2StreamAggregator::new();
+
+        // Request: HEADERS with END_STREAM, so the stream reaches RequestComplete.
+        let completed = aggregator.process_frames(vec![create_test_frame(
+            1,
+            1,
+            0x05,
+            b":method: POST\n:path: /v1/chat/completions".to_vec(),
+            create_test_event(1234, 0x1000, 1, 1000),
+        )]);
+        assert!(completed.is_empty(), "response has not started yet");
+
+        // Response HEADERS without END_STREAM: a body follows.
+        let mut completed = aggregator.process_frames(vec![create_test_frame(
+            1,
+            1,
+            0x04,
+            b":status: 200".to_vec(),
+            create_test_event(1234, 0x1000, 0, 2000),
+        )]);
+
+        for (i, (payload, end_stream)) in resp_data.iter().enumerate() {
+            let flags = if *end_stream { 0x01 } else { 0x00 };
+            completed.extend(aggregator.process_frames(vec![create_test_frame(
+                1,
+                0,
+                flags,
+                payload.to_vec(),
+                create_test_event(1234, 0x1000, 0, 3000 + i as u64),
+            )]));
+        }
+        completed
+    }
+
+    #[test]
+    fn sse_done_completes_stream_without_end_stream() {
+        // The regression this exists for: the client stops reading at `[DONE]`, so
+        // END_STREAM never arrives and the stream used to stall forever.
+        let completed = run_exchange(&[
+            (
+                b"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n",
+                false,
+            ),
+            (b"data: [DONE]\n\n", false),
+        ]);
+        assert_eq!(completed.len(), 1, "[DONE] must close the stream");
+        let stream = &completed[0];
+        assert!(stream.response_complete);
+        assert_eq!(
+            stream.response_data_frames.len(),
+            2,
+            "the terminator frame is part of the body, not dropped"
+        );
+    }
+
+    #[test]
+    fn end_stream_still_completes_without_sse_terminator() {
+        // Guards the pre-existing path: a plain JSON response has no `[DONE]` and
+        // must still complete on END_STREAM alone, at exactly that frame.
+        let completed = run_exchange(&[
+            (b"{\"usage\":{\"prompt_tokens\":7", false),
+            (b",\"completion_tokens\":3}}", true),
+        ]);
+        assert_eq!(completed.len(), 1);
+        assert_eq!(completed[0].response_data_frames.len(), 2);
+    }
+
+    #[test]
+    fn body_without_terminator_stays_open() {
+        // Neither END_STREAM nor `[DONE]`: the stream must keep collecting rather
+        // than be closed on a guess.
+        let completed = run_exchange(&[
+            (b"data: {\"delta\":\"a\"}\n\n", false),
+            (b"data: {\"delta\":\"b\"}\n\n", false),
+        ]);
+        assert!(completed.is_empty());
+    }
+
+    #[test]
+    fn anthropic_terminator_is_left_to_end_stream() {
+        // Anthropic streams close on END_STREAM today. `message_stop` is
+        // deliberately not treated as a terminator here, so their completion point
+        // is unchanged: the first two frames must not complete the stream.
+        let completed = run_exchange(&[
+            (
+                b"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+                false,
+            ),
+            (b"data: {\"type\":\"message_stop\"}\n\n", false),
+            (b"", true),
+        ]);
+        assert_eq!(
+            completed.len(),
+            1,
+            "completes on END_STREAM, not on message_stop"
+        );
+        assert_eq!(
+            completed[0].response_data_frames.len(),
+            3,
+            "all three frames were collected before END_STREAM closed it"
+        );
+    }
+
+    #[test]
+    fn sse_terminator_detection_boundaries() {
+        assert!(response_sse_stream_ended(b"data: [DONE]\n\n"));
+        assert!(response_sse_stream_ended(b"data:[DONE]\n\n"));
+        assert!(response_sse_stream_ended(b"data: [END]\n\n"));
+        // Embedded in a multi-event frame, not just at the end.
+        assert!(response_sse_stream_ended(
+            b"data: {\"a\":1}\n\ndata: [DONE]\n\n"
+        ));
+        // A payload merely mentioning the token is not a terminator.
+        assert!(!response_sse_stream_ended(
+            b"data: {\"text\":\"the [DONE] marker\"}\n\n"
+        ));
+        assert!(!response_sse_stream_ended(b"data: {\"delta\":\"x\"}\n\n"));
+        assert!(!response_sse_stream_ended(b""));
     }
 
     #[test]

--- a/src/agentsight/src/bpf/sslsniff.bpf.c
+++ b/src/agentsight/src/bpf/sslsniff.bpf.c
@@ -390,4 +390,277 @@ int BPF_URETPROBE(probe_SSL_do_handshake_exit) {
     return 0;
 }
 
+/* ─── rustls plaintext taps (#3042) ──────────────────────────────────────────
+ *
+ * rustls is pure Rust and exports no SSL_read/SSL_write, so every probe above
+ * is unattachable on a rustls process. The hooks here are its two plaintext
+ * chokepoints on `CommonState`, taken at function entry:
+ *
+ *   buffer_plaintext(&mut self, payload: OutboundChunks, sendable: &mut _) -> usize
+ *     rdi = &mut CommonState, rsi = &OutboundChunks
+ *   take_received_plaintext(&mut self, bytes: Payload)
+ *     rdi = &mut CommonState, rsi = &Payload
+ *
+ * Why this layer and not the AEAD one (`MessageEncrypter/Decrypter::encrypt`,
+ * which is also reachable): the encrypter and decrypter are two separate heap
+ * objects, so hooking them yields a different `self` per direction. Userspace
+ * keys connections on (pid, ssl_ptr), and the HTTP/2 aggregator correlates a
+ * request with its response inside one connection -- with split identities the
+ * request never completes and no token usage is ever extracted. Both hooks here
+ * take the *same* `&mut CommonState`, so one connection stays one connection.
+ *
+ * Hooking above the record layer also means: application data only, so no
+ * content-type filtering; independent of the negotiated cipher suite, so one
+ * probe per direction instead of one per suite; and the plaintext is an
+ * argument, so neither direction needs a uretprobe.
+ *
+ * The offsets below are NOT part of rustls' stable API. They were measured on a
+ * real build with `offset_of!` and cross-checked against the disassembly rather
+ * than inferred from the type declarations, because both types are niche-encoded
+ * in ways the source does not show. Nothing is trusted blindly: a NULL pointer
+ * or an implausible length is dropped, so a layout change degrades to capturing
+ * nothing rather than to emitting garbage.
+ */
+
+/* OutboundChunks (write direction) is niche-encoded: eightbyte 0 is Multiple's
+ * `chunks` pointer, and NULL there means the Single variant. The two variants
+ * overlap, so each eightbyte has a different meaning per variant and the names
+ * below are kept distinct on purpose -- reading Multiple's chunk count from
+ * Single's `len` slot silently yields `start`, which is 0 in practice and makes
+ * every gather write look empty.
+ *
+ *   Single   { tag = 0  @0, ptr @8, len   @16 }
+ *   Multiple { chunks   @0, n   @8, start @16, end @24 }
+ */
+#define RUSTLS_CHUNKS_TAG_OFF 0
+#define RUSTLS_SINGLE_PTR_OFF 8
+#define RUSTLS_SINGLE_LEN_OFF 16
+#define RUSTLS_MULTI_N_OFF 8
+#define RUSTLS_MULTI_START_OFF 16
+#define RUSTLS_MULTI_END_OFF 24
+/* Fat-pointer stride inside the `&[&[u8]]` array. */
+#define RUSTLS_SLICE_STRIDE 16
+/* Chunks emitted per gather write. HTTP/2 writes a frame header and its payload
+ * as separate slices, so a handful covers real traffic, and the bound keeps the
+ * unrolled loop inside the verifier's complexity budget. Overflow is counted
+ * rather than silently dropped. */
+#define RUSTLS_MAX_GATHER_CHUNKS 4
+/* Payload (read direction) needs no variant branch: Borrowed and Owned keep the
+ * slice pointer and length at the same offsets, because the discriminant is
+ * niche-encoded into the eightbyte that Owned uses as Vec's capacity (Borrowed
+ * stores 0x8000000000000000 there, which no real capacity can be). */
+#define RUSTLS_PAYLOAD_PTR_OFF 8
+#define RUSTLS_PAYLOAD_LEN_OFF 16
+
+/* Gather writes (OutboundChunks::Multiple) whose chunk count exceeded
+ * RUSTLS_MAX_GATHER_CHUNKS, so part of the payload was not emitted. Exposed
+ * through the skeleton's .bss so the gap is measurable instead of silent. */
+__u64 rustls_gather_skips = 0;
+
+/* Emit one plaintext buffer belonging to connection `conn`.
+ *
+ * `len` is the caller's full plaintext, which at this layer is a whole
+ * application write rather than a single TLS record, so it is bounded by the
+ * capture cap and not by the record size. SSL_EMIT_TIERED clamps the copy and
+ * flags truncation, exactly as it does for a large SSL_write.
+ */
+static __always_inline int rustls_emit(void *conn, u64 ptr, u64 len, int rw)
+{
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
+    u32 uid = bpf_get_current_uid_gid();
+    u64 ts = bpf_ktime_get_ns();
+
+    u32 ns_pid = trace_allowed(uid, pid);
+    if (!ns_pid)
+        return 0;
+    if (!ptr || len == 0 || len > MAX_BUF_SIZE)
+        return 0;
+
+    /* Captured at function entry, so there is no paired uretprobe and hence no
+     * measurable in-function duration. */
+    SSL_EMIT_TIERED((const char *)ptr, len, rw, ts, 0, ns_pid, tid, uid, (u64)conn, 0);
+    return 0;
+}
+
+/* Largest single chunk the gather path copies. Both bounds must be compile-time
+ * constants for the verifier to prove `off + take` stays inside the reservation,
+ * and HTTP/2's default max frame size is 16 KiB, so a per-frame slice fits. */
+#define RUSTLS_GATHER_CHUNK_MAX SSL_TIER_SMALL
+#define RUSTLS_GATHER_TIER SSL_TIER_MEDIUM
+
+/* Concatenate a gather write's chunks into a single ring-buffer record.
+ *
+ * `chunks` is rustls' `&[&[u8]]` data pointer, `n` its (already bounded) length,
+ * and [start,end) the logical window over the concatenation.
+ *
+ * Anything that would not fit is dropped whole and counted, never truncated:
+ * these bytes feed a framed protocol parser, so a short copy desynchronises the
+ * frame stream and produces garbage rather than partial data.
+ *
+ * Only one tier is used. Unrolling the copy loop once per tier multiplies
+ * program size, and a gather write is one request body per LLM call rather than
+ * a hot path. The medium tier is the smallest that holds a realistic chat
+ * request (an 18 KiB body was observed) without reserving the 4 MiB worst case
+ * that #759 removed.
+ */
+static __always_inline int rustls_gather_emit(void *conn, const char *chunks, u64 n, u64 start,
+                                             u64 end)
+{
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
+    u32 uid = bpf_get_current_uid_gid();
+    u64 ts = bpf_ktime_get_ns();
+
+    u32 ns_pid = trace_allowed(uid, pid);
+    if (!ns_pid)
+        return 0;
+
+    u64 total = end - start;
+    if (total == 0 || total > RUSTLS_GATHER_TIER) {
+        /* Too large for one reservation; a partial copy would corrupt framing. */
+        if (total)
+            __sync_fetch_and_add(&rustls_gather_skips, 1);
+        return 0;
+    }
+
+    struct probe_SSL_data_medium *d = bpf_ringbuf_reserve(&rb, sizeof(*d), 0);
+    if (!d)
+        return 0;
+
+    d->source = EVENT_SOURCE_SSL;
+    d->timestamp_ns = ts;
+    d->delta_ns = 0;
+    d->pid = ns_pid;
+    d->tid = tid;
+    d->uid = uid;
+    d->len = (u32)total;
+    d->rw = 1;
+    d->is_handshake = 0;
+    d->ssl_ptr = (u64)conn;
+    d->truncated = 0;
+    bpf_get_current_comm(&d->comm, sizeof(d->comm));
+
+    /* `pos` is the logical offset of the current chunk's first byte. */
+    u64 pos = 0;
+    u32 written = 0;
+    bool complete = true;
+#pragma unroll
+    for (int i = 0; i < RUSTLS_MAX_GATHER_CHUNKS; i++) {
+        if ((u64)i >= n || pos >= end)
+            break;
+
+        u64 cptr = 0;
+        u64 clen = 0;
+        const char *slot = chunks + (u64)i * RUSTLS_SLICE_STRIDE;
+        if (bpf_probe_read_user(&cptr, sizeof(cptr), slot) ||
+            bpf_probe_read_user(&clen, sizeof(clen), slot + 8)) {
+            complete = false;
+            break;
+        }
+
+        /* Intersect [pos, pos+clen) with the [start, end) window. */
+        u64 chunk_end = pos + clen;
+        u64 lo = pos > start ? pos : start;
+        u64 hi = chunk_end < end ? chunk_end : end;
+        u64 skip = lo - pos; /* bytes of this chunk before the window */
+        pos = chunk_end;
+        if (hi <= lo || !cptr)
+            continue;
+
+        u64 want = hi - lo;
+        /* Both operands of the bounds check are constants, which is what lets the
+         * verifier carry `off + take <= sizeof(buf)` across the spill that the
+         * helper call forces (same trap SSL_EMIT_ONE documents). */
+        if (want > RUSTLS_GATHER_CHUNK_MAX || written > RUSTLS_GATHER_TIER - RUSTLS_GATHER_CHUNK_MAX) {
+            complete = false;
+            break;
+        }
+        u32 off = written;
+        u32 take = (u32)want;
+        /* Re-clamp behind a barrier: the value is spilled across the call above,
+         * and the verifier reloads it as an unbounded scalar otherwise. */
+        asm volatile("" : "+r"(take));
+        if (take > RUSTLS_GATHER_CHUNK_MAX)
+            take = RUSTLS_GATHER_CHUNK_MAX;
+        asm volatile("" : "+r"(take));
+        if (take == 0)
+            continue;
+        if (bpf_probe_read_user(&d->buf[off], take, (const char *)(cptr + skip))) {
+            complete = false;
+            break;
+        }
+        written += take;
+    }
+
+    /* A hole anywhere makes the remaining bytes unparseable, so drop the record
+     * rather than hand the frame parser a corrupt stream. */
+    if (!complete || written != (u32)total) {
+        __sync_fetch_and_add(&rustls_gather_skips, 1);
+        bpf_ringbuf_discard(d, 0);
+        return 0;
+    }
+    d->buf_filled = 1;
+    d->buf_size = written;
+    bpf_ringbuf_submit(d, 0);
+    return 0;
+}
+
+SEC("uprobe/rustls_buffer_plaintext")
+int BPF_UPROBE(probe_rustls_write_plaintext, void *conn, void *chunks) {
+    u64 tag = 0;
+    if (bpf_probe_read_user(&tag, sizeof(tag), (const char *)chunks + RUSTLS_CHUNKS_TAG_OFF))
+        return 0;
+
+    if (tag == 0) {
+        u64 ptr = 0;
+        u64 len = 0;
+        if (bpf_probe_read_user(&ptr, sizeof(ptr), (const char *)chunks + RUSTLS_SINGLE_PTR_OFF))
+            return 0;
+        if (bpf_probe_read_user(&len, sizeof(len), (const char *)chunks + RUSTLS_SINGLE_LEN_OFF))
+            return 0;
+        return rustls_emit(conn, ptr, len, 1);
+    }
+
+    /* Multiple: a gather write. `tag` is the &[&[u8]] data pointer and the
+     * logical payload is the concatenation of the chunks sliced by [start,end).
+     *
+     * The chunks MUST be concatenated into one event rather than emitted one per
+     * chunk. HTTP/2 is framed, and `parse_ssl_event` parses each event on its
+     * own: a chunk that starts mid-frame is unparseable and degrades to RawData,
+     * which only the HTTP/1.1 path knows how to continue. Verified the hard way —
+     * per-chunk emission delivered every byte in order and still produced zero
+     * parsed frames.
+     */
+    u64 n = 0;
+    u64 start = 0;
+    u64 end = 0;
+    if (bpf_probe_read_user(&n, sizeof(n), (const char *)chunks + RUSTLS_MULTI_N_OFF))
+        return 0;
+    if (bpf_probe_read_user(&start, sizeof(start), (const char *)chunks + RUSTLS_MULTI_START_OFF))
+        return 0;
+    if (bpf_probe_read_user(&end, sizeof(end), (const char *)chunks + RUSTLS_MULTI_END_OFF))
+        return 0;
+    if (end <= start)
+        return 0;
+    if (n > RUSTLS_MAX_GATHER_CHUNKS) {
+        __sync_fetch_and_add(&rustls_gather_skips, 1);
+        n = RUSTLS_MAX_GATHER_CHUNKS;
+    }
+    return rustls_gather_emit(conn, (const char *)tag, n, start, end);
+}
+
+SEC("uprobe/rustls_take_received_plaintext")
+int BPF_UPROBE(probe_rustls_read_plaintext, void *conn, void *payload) {
+    u64 ptr = 0;
+    u64 len = 0;
+    if (bpf_probe_read_user(&ptr, sizeof(ptr), (const char *)payload + RUSTLS_PAYLOAD_PTR_OFF))
+        return 0;
+    if (bpf_probe_read_user(&len, sizeof(len), (const char *)payload + RUSTLS_PAYLOAD_LEN_OFF))
+        return 0;
+    return rustls_emit(conn, ptr, len, 0);
+}
+
 char LICENSE[] SEC("license") = "GPL";

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -347,8 +347,9 @@ impl SslSniff {
     /// Attach SSL probes to a running process by reading its `/proc/<pid>/maps`.
     ///
     /// Detects which SSL libraries the process has mapped (OpenSSL, GnuTLS, NSS,
-    /// or statically-linked SSL — BoringSSL/OpenSSL), attaches uprobes, and skips any
-    /// library whose inode has already been traced (dedup via `traced_files`) —
+    /// statically-linked SSL — BoringSSL/OpenSSL — or rustls), attaches uprobes,
+    /// and skips any library whose inode has already been traced (dedup via
+    /// `traced_files`) —
     /// unless that attachment is stale (older than the re-attach TTL), in
     /// which case the probes are re-attached and the old links are dropped
     /// only after the replacement succeeds.
@@ -455,6 +456,15 @@ impl SslSniff {
         self.stale_reattachs
     }
 
+    /// How many rustls gather writes (`OutboundChunks::Multiple`) were observed
+    /// and skipped because chunk reassembly is not implemented yet.
+    ///
+    /// A non-zero value means part of the request side of a rustls process was
+    /// not captured, so this is a coverage gap indicator rather than an error.
+    pub fn rustls_gather_skips(&self) -> u64 {
+        self.skel.bss().rustls_gather_skips
+    }
+
     /// Record a successful attach for `inode`, replacing any prior entry
     /// (whose links are dropped, detaching the old probes).
     fn record_attach(&mut self, inode: u64, links: Vec<Link>) {
@@ -479,6 +489,24 @@ impl SslSniff {
             SslLibKind::OpenSsl => attach_openssl(&mut self.skel, path, -1),
             SslLibKind::GnuTls => attach_gnutls(&mut self.skel, path, -1),
             SslLibKind::Nss => attach_nss(&mut self.skel, path, -1),
+            SslLibKind::Rustls => match find_rustls_offsets(path) {
+                Some(off) => {
+                    log::info!(
+                        "[attach_process] pid={pid}: rustls plaintext probes on {path} \
+                         (write={:x?}, read={:x?})",
+                        off.write,
+                        off.read
+                    );
+                    attach_rustls(&mut self.skel, path, &off, -1)
+                }
+                None => {
+                    log::warn!(
+                        "[attach_process] pid={pid}: rustls detection failed for {path} \
+                         (neither plaintext prologue matched -- rustls or the toolchain likely moved), skipping"
+                    );
+                    return AttachOutcome::Untraceable;
+                }
+            },
             SslLibKind::Static => {
                 match attach_static_ssl_by_symbol(&mut self.skel, path, -1) {
                     Ok(ls) => Ok(ls),
@@ -923,6 +951,93 @@ fn find_static_ssl_offsets(path: &str) -> Option<StaticSslOffsets> {
     })
 }
 
+/// Offsets of rustls' two plaintext chokepoints inside a stripped binary.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct RustlsOffsets {
+    /// `CommonState::buffer_plaintext` — outbound application data.
+    write: Option<usize>,
+    /// `CommonState::take_received_plaintext` — inbound application data.
+    read: Option<usize>,
+}
+
+impl RustlsOffsets {
+    /// Whether anything worth attaching was found.
+    ///
+    /// One direction alone is still attached, but it degrades HTTP/2: the
+    /// aggregator pairs a request with its response inside one connection, so a
+    /// half-captured connection never completes. `attach_rustls` warns about it.
+    fn is_usable(&self) -> bool {
+        self.write.is_some() || self.read.is_some()
+    }
+}
+
+/// Locate rustls' plaintext chokepoints in `path` by function-prologue matching.
+///
+/// `CommonState::buffer_plaintext` and `CommonState::take_received_plaintext` are
+/// the narrowest pair of functions that (a) survive cosh-ng's `lto = true` build
+/// and (b) share one `&mut CommonState`, which is what keeps both directions of a
+/// connection under a single `ssl_ptr`. The obvious `Writer::write` /
+/// `Reader::read` plaintext API is inlined away and leaves no symbol, and release
+/// binaries are fully stripped, so a prologue scan is the only handle left.
+///
+/// Each pattern is the first 24 bytes of the function: the callee-saved register
+/// block, the frame setup, and the argument shuffle. The length is not arbitrary
+/// — the register-save prefix these functions share also matches dozens of
+/// unrelated Rust functions (40 hits for one of them in a real binary), while 24
+/// bytes was verified to match exactly once. A pattern hitting more than once is
+/// discarded rather than guessed at, because attaching a uprobe to the wrong
+/// function would sample unrelated memory.
+///
+/// Because these bytes encode rustc's register allocation and frame sizes, they
+/// are tied to a given rustls + toolchain combination and must be re-verified
+/// when either moves. A miss is safe: the caller reports the binary as
+/// untraceable, which is exactly the behaviour before rustls was supported.
+fn find_rustls_offsets(path: &str) -> Option<RustlsOffsets> {
+    /// `CommonState::buffer_plaintext`: push block, `sub $0x78,%rsp`, then
+    /// `mov %rdx,%r15; mov %rsi,%r14; mov 0x308(%rdi),%rbp` — the tail also
+    /// pins rdi as the `&mut CommonState` this probe reports as the connection.
+    const WRITE_PAT: &[u8] = &[
+        0x55, 0x41, 0x57, 0x41, 0x56, 0x41, 0x55, 0x41, 0x54, 0x53, 0x48, 0x83, 0xec, 0x78, 0x49,
+        0x89, 0xd7, 0x49, 0x89, 0xf6, 0x48, 0x8b, 0xaf, 0x08,
+    ];
+    /// `CommonState::take_received_plaintext`: push block, `mov %rdi,%r14`, the
+    /// inlined `temper_counters.received_app_data()` store `movb $0x20,0x32e(%rdi)`,
+    /// then `mov (%rsi),%r12` loading the first eightbyte of the `Payload`.
+    const READ_PAT: &[u8] = &[
+        0x41, 0x57, 0x41, 0x56, 0x41, 0x54, 0x53, 0x50, 0x49, 0x89, 0xfe, 0xc6, 0x87, 0x2e, 0x03,
+        0x00, 0x00, 0x20, 0x4c, 0x8b, 0x26, 0x48, 0x8b, 0x5e,
+    ];
+
+    let mut hits = scan_file_patterns(path, &[WRITE_PAT, READ_PAT])?;
+    // scan_file_patterns returns one Vec<usize> per pattern, in order.
+    let read_hits = hits.pop().unwrap_or_default();
+    let write_hits = hits.pop().unwrap_or_default();
+    let mut found = RustlsOffsets::default();
+
+    for (label, offsets, is_write) in [
+        ("CommonState::buffer_plaintext", &write_hits, true),
+        ("CommonState::take_received_plaintext", &read_hits, false),
+    ] {
+        match offsets.len() {
+            0 => log::debug!("rustls: {label} pattern not found in {path}"),
+            1 => {
+                log::debug!("rustls: {label} at {:#x} in {path}", offsets[0]);
+                if is_write {
+                    found.write = Some(offsets[0]);
+                } else {
+                    found.read = Some(offsets[0]);
+                }
+            }
+            n => log::debug!("rustls: {label} pattern has {n} matches in {path}, skipping"),
+        }
+    }
+
+    if !found.is_usable() {
+        return None;
+    }
+    Some(found)
+}
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /// SSL library kind detected from `/proc/<pid>/maps`.
@@ -936,6 +1051,10 @@ enum SslLibKind {
     Nss,
     /// Statically-linked SSL (BoringSSL or OpenSSL, e.g. Node.js, Chrome, Codex CLI)
     Static,
+    /// Statically-linked rustls (pure Rust TLS, e.g. cosh-ng). Distinct from
+    /// `Static` because there is no SSL_* API to hook at all: the probes go on
+    /// rustls' AEAD layer instead, with a different calling convention.
+    Rustls,
 }
 
 /// Classify a mapped file path into an `SslLibKind`, if it is an SSL library.
@@ -973,6 +1092,14 @@ fn classify_ssl_lib(path: &str) -> Option<SslLibKind> {
     // Codex CLI statically links OpenSSL 3.x (via openssl-sys / native-tls).
     if name.starts_with("codex") && !name.contains('.') {
         return Some(SslLibKind::Static);
+    }
+    // cosh-ng links rustls, so nothing SSL-shaped appears in its maps at all
+    // and there is no library name to key off -- only the binary itself (#3042).
+    if matches!(
+        name.as_ref(),
+        "cosh-core" | "cosh-shell" | "cosh-cli" | "cosh-gateway"
+    ) {
+        return Some(SslLibKind::Rustls);
     }
     // uv Python statically links OpenSSL into the binary. The ELF .symtab contains
     // SSL_write/SSL_read/SSL_do_handshake as LOCAL symbols, so attach_openssl()
@@ -1053,8 +1180,8 @@ fn ssl_libs_from_maps(pid: i32) -> Result<Vec<(String, u64, SslLibKind)>> {
             // `<pid>` entry itself comes from a bind-mounted host procfs.
             let attach_path = if path_str.ends_with(" (deleted)") {
                 proc_pid_entry(pid, "exe")
-            } else if matches!(kind, SslLibKind::Static) {
-                // Statically-linked SSL binary (codex, node, etc).
+            } else if matches!(kind, SslLibKind::Static | SslLibKind::Rustls) {
+                // Statically-linked SSL binary (codex, node, cosh-core, etc).
                 // <pid>/exe is a kernel-maintained symlink that stays valid
                 // even when the backing file has been replaced or unlinked,
                 // which is common for npm-installed binaries that get updated
@@ -1315,6 +1442,48 @@ fn attach_static_ssl_by_offset(
             pid,
             lib,
             off.ssl_do_handshake
+        )?);
+    }
+    Ok(links)
+}
+
+/// Attach the rustls plaintext probes at the offsets found by
+/// `find_rustls_offsets`.
+///
+/// Both probes fire at function entry, where the plaintext is an argument, so
+/// neither direction needs a uretprobe. There is no handshake probe either:
+/// these hooks sit above the record layer and only ever see application data,
+/// so a rustls process reports no handshake timings.
+fn attach_rustls(
+    skel: &mut SslsniffSkel<'_>,
+    lib: &str,
+    off: &RustlsOffsets,
+    pid: i32,
+) -> Result<Vec<Link>> {
+    // A one-sided attach still yields data, but HTTP/2 request/response
+    // correlation needs both halves of the connection, so say so loudly.
+    if off.write.is_none() || off.read.is_none() {
+        log::warn!(
+            "rustls: only the {} direction was located in {lib}; HTTP/2 streams will not complete",
+            if off.write.is_some() { "write" } else { "read" }
+        );
+    }
+
+    let mut links = Vec::new();
+    if let Some(w) = off.write {
+        links.push(up_off!(
+            skel.progs_mut().probe_rustls_write_plaintext(),
+            pid,
+            lib,
+            w
+        )?);
+    }
+    if let Some(r) = off.read {
+        links.push(up_off!(
+            skel.progs_mut().probe_rustls_read_plaintext(),
+            pid,
+            lib,
+            r
         )?);
     }
     Ok(links)
@@ -1737,5 +1906,118 @@ mod tests {
         // Not a maps line at all.
         assert_eq!(parse_maps_line("rubbish"), None);
         assert_eq!(parse_maps_line(""), None);
+    }
+
+    // ─── rustls detection tests (#3042) ─────────────────────────────────────
+    // Prologue literals mirror the ones inside find_rustls_offsets, for the same
+    // reason as the static-SSL fixtures above: editing a production pattern
+    // without updating these makes detection on the synthetic image fail.
+    const RUSTLS_WRITE_PAT: &[u8] = &[
+        0x55, 0x41, 0x57, 0x41, 0x56, 0x41, 0x55, 0x41, 0x54, 0x53, 0x48, 0x83, 0xec, 0x78, 0x49,
+        0x89, 0xd7, 0x49, 0x89, 0xf6, 0x48, 0x8b, 0xaf, 0x08,
+    ];
+    const RUSTLS_READ_PAT: &[u8] = &[
+        0x41, 0x57, 0x41, 0x56, 0x41, 0x54, 0x53, 0x50, 0x49, 0x89, 0xfe, 0xc6, 0x87, 0x2e, 0x03,
+        0x00, 0x00, 0x20, 0x4c, 0x8b, 0x26, 0x48, 0x8b, 0x5e,
+    ];
+
+    /// Zero-filled synthetic binary with rustls prologues planted at the given
+    /// file offsets; zeros cannot match a pattern, so matches are unambiguous.
+    fn build_rustls_image(planted: &[(usize, &[u8])]) -> Vec<u8> {
+        let mut img = vec![0u8; 0x5000];
+        for (off, pat) in planted {
+            img[*off..*off + pat.len()].copy_from_slice(pat);
+        }
+        img
+    }
+
+    #[test]
+    fn classify_recognises_cosh_binaries_as_rustls() {
+        for path in [
+            "/usr/libexec/anolisa/cosh-ng/cosh-core",
+            "/usr/libexec/anolisa/cosh-ng/cosh-shell",
+            "/usr/bin/cosh-cli",
+            "/usr/libexec/anolisa/cosh-ng/cosh-gateway",
+        ] {
+            assert_eq!(
+                classify_ssl_lib(path),
+                Some(SslLibKind::Rustls),
+                "{path} must be probed through rustls' plaintext chokepoints"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_keeps_existing_kinds_unchanged() {
+        // Guards against the rustls arm shadowing an established classification.
+        assert_eq!(
+            classify_ssl_lib("/usr/lib64/libssl.so.3"),
+            Some(SslLibKind::OpenSsl)
+        );
+        assert_eq!(
+            classify_ssl_lib("/usr/lib64/libgnutls.so.30"),
+            Some(SslLibKind::GnuTls)
+        );
+        assert_eq!(classify_ssl_lib("/usr/bin/node"), Some(SslLibKind::Static));
+        assert_eq!(classify_ssl_lib("/usr/bin/codex"), Some(SslLibKind::Static));
+        // `/usr/bin/cosh` is a symlink; maps always reports the resolved target,
+        // so the bare name is deliberately NOT matched.
+        assert_eq!(classify_ssl_lib("/usr/bin/cosh"), None);
+        assert_eq!(classify_ssl_lib("/usr/lib64/libc.so.6"), None);
+    }
+
+    #[test]
+    fn rustls_offsets_locates_both_directions() {
+        let img = build_rustls_image(&[(0x400, RUSTLS_WRITE_PAT), (0x1200, RUSTLS_READ_PAT)]);
+        with_static_ssl_fixture("rustls-both", &img, |path| {
+            let off = find_rustls_offsets(path).expect("planted prologues must be detected");
+            assert_eq!(off.write, Some(0x400));
+            assert_eq!(off.read, Some(0x1200));
+        });
+    }
+
+    #[test]
+    fn rustls_offsets_usable_with_one_direction() {
+        // Half a connection is still attached (and warned about): losing it
+        // outright would mean capturing nothing at all from the process.
+        let img = build_rustls_image(&[(0x800, RUSTLS_READ_PAT)]);
+        with_static_ssl_fixture("rustls-read-only", &img, |path| {
+            let off = find_rustls_offsets(path).expect("read-only image must be usable");
+            assert_eq!(off.read, Some(0x800));
+            assert!(off.write.is_none());
+            assert!(off.is_usable());
+        });
+    }
+
+    #[test]
+    fn rustls_offsets_discards_ambiguous_pattern() {
+        // Two hits for one function means the prologue is no longer unique after
+        // a toolchain change. Guessing could point a uprobe at unrelated code and
+        // sample arbitrary memory as if it were plaintext, so the pattern is
+        // dropped instead of resolved by heuristic.
+        let img = build_rustls_image(&[
+            (0x400, RUSTLS_READ_PAT),
+            (0x2400, RUSTLS_READ_PAT),
+            (0x3000, RUSTLS_WRITE_PAT),
+        ]);
+        with_static_ssl_fixture("rustls-ambiguous", &img, |path| {
+            let off = find_rustls_offsets(path).expect("the unique write match still stands");
+            assert!(
+                off.read.is_none(),
+                "ambiguous read pattern must be discarded, got {:x?}",
+                off.read
+            );
+            assert_eq!(off.write, Some(0x3000));
+        });
+    }
+
+    #[test]
+    fn rustls_offsets_absent_yields_none() {
+        // A non-rustls binary must report nothing so the caller marks it
+        // untraceable instead of attaching probes to arbitrary offsets.
+        let img = vec![0u8; 0x5000];
+        with_static_ssl_fixture("rustls-absent", &img, |path| {
+            assert!(find_rustls_offsets(path).is_none());
+        });
     }
 }


### PR DESCRIPTION
## Why

cosh-ng switched its TLS backend to rustls in 524dbd6d. rustls exports no
`SSL_read`/`SSL_write`, so every uprobe in `sslsniff` became unattachable on
cosh-ng processes — the journal filled with `no SSL libraries found in maps` and
`token_records` held zero `CoshNG` rows, breaking the token-recording contract
from #2031.

While fixing that, a second and independent gap surfaced: an HTTP/2 stream only
completed on the `END_STREAM` flag, which never arrives when a client treats
`data: [DONE]` as the end of the answer and exits before reading the server's
final empty DATA frame. Any HTTP/2 agent hits this, OpenSSL ones included; the
agents that do produce token records today happen to use HTTP/1.1, where a done
marker is already synthesised from the chunked terminator.

## What changed

Two commits, each independently useful:

1. **`fix(sight): complete h2 stream on SSE terminator`** — close an HTTP/2
   stream when a response DATA frame carries the OpenAI-style SSE terminator,
   mirroring the existing HTTP/1.1 behaviour.
2. **`feat(sight): capture rustls plaintext for cosh-ng`** — hook rustls'
   `CommonState::buffer_plaintext` (writes) and
   `CommonState::take_received_plaintext` (reads).

The key decision in (2) is *which* layer to hook. The AEAD layer
(`MessageEncrypter/Decrypter::encrypt`) is also reachable and was tried first,
but its encrypter and decrypter are separate heap objects, so the two directions
report different `ssl_ptr` values, land on different connections, and the HTTP/2
aggregator can never pair a request with its response. Both `CommonState` hooks
take the same `&mut CommonState`, which keeps one connection under one
`ssl_ptr`. Sitting above the record layer additionally means application data
only, one probe per direction instead of one per cipher suite, and no uretprobe
because the plaintext is an argument.

## Related issue

closes #3042

## User / Agent impact

cosh-ng LLM calls become observable: `token_records` and `genai_events` now carry
`agent='CoshNG'` rows with model, provider, token counts, prompt and response.

HTTP/2 agents that previously stalled without `END_STREAM` now complete, so their
token usage is recorded too. No CLI, API, or configuration surface changed.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk, but two points deserve review attention.

**The SSE completion path is deliberately narrow.** Only the literal
OpenAI-style terminator counts. No body bytes follow it by protocol, so the
aggregated frames match what a later `END_STREAM` would have produced. Anthropic's
`message_stop` and the DashScope native terminator are *not* recognised, so those
already-working streams keep completing exactly where they do today — a test
pins this. A time-based fallback was rejected because it would alter the timing
semantics of every HTTP/2 connection rather than only the stuck ones.

**The rustls offsets are internals, not a stable API.** `OutboundChunks` is
niche-encoded and `Payload` keeps its pointer and length at the same offsets in
both variants; neither is visible in the type declaration, so both were measured
on a real build with `offset_of!` and cross-checked against the disassembly.
Every BPF-side read is range-checked, so a layout change degrades to capturing
nothing rather than emitting garbage. The 24-byte prologue patterns are likewise
tied to a rustls + toolchain combination and must be re-verified when either
moves; a miss reports the binary as untraceable, which is the pre-existing
behaviour.

Known limits, all intentional and documented in code:

- Detection is keyed on the cosh-ng binary names, so this does not yet cover
  arbitrary rustls processes. Generalising it wants the bounded scan from
  `fix(sight): stream the static SSL pattern scan` first, so an unknown binary is
  not read whole. `find_rustls_offsets` still uses `fs::read`; it only reads the
  cosh-ng binaries (14.6 MiB at most, not the hundreds of megabytes that motivated
  the streaming work), and switching it to `scan_file_patterns` is a follow-up
  once that lands. Verified by cherry-pick that the two changes do not conflict.
- Gather writes are capped: more than 4 chunks, a chunk over 16 KiB, or a total
  over 128 KiB is dropped whole and counted in `rustls_gather_skips`. Dropping
  rather than truncating is deliberate — a short copy desynchronises the frame
  stream and yields garbage instead of partial data.
- x86_64 only, matching agentsight's existing `requires_arch`.

## Validation

Gates, on Alibaba Cloud Linux 4 (kernel 6.6.102, x86_64):

```
cargo fmt --all -- --check                               clean
cargo clippy -p agentsight --all-targets -- -D warnings   clean
cargo test -p agentsight                                  1897 passed, 0 failed
cargo test --test bpf_load -- --ignored                   10 passed (kernel verifier)
```

Ten new tests: five for the SSE completion path (including three that pin the
pre-existing behaviour — plain JSON still completes only on `END_STREAM`, a body
with neither marker stays open, and `message_stop` does not complete early) and
five for rustls detection (both directions located, one-direction still usable,
an ambiguous pattern discarded rather than guessed, absent patterns yielding
`None`, and terminator boundary cases).

End-to-end on a host running cosh-ng 0.23.0 (rustls, `ldd` shows no libssl) with
the service under its normal 350 MiB `MemoryMax`:

```
before:  token_records = []               genai_events = []
after:   token_records = [('CoshNG', 3)]  genai_events = [('CoshNG', 3)]

latest row: model=qwen-plus provider=openai
            input_tokens=4505 output_tokens=34 total_tokens=4539
            http_path=/compatible-mode/v1/chat/completions status=200
            is_sse=1 sse_event_count=9 finish_reasons=["stop"]
            user_query / output_messages / system_instructions all populated

memory: 46 MiB / 350 MiB, oom_kill = 0
```

The frame sequence confirms the intended behaviour: h2 preface, SETTINGS, request
HEADERS, request body as `DATA len=16384` + `DATA END_STREAM len=1828`, then the
state machine advancing `WaitingRequestData` to `RequestComplete` to
`ReceivingResponse`, with every response frame on the same `ConnectionId`.

Not covered: only `cosh-core` was exercised, not `cosh-shell` / `cosh-cli` /
`cosh-gateway`; only DashScope compatible-mode over HTTP/2 and TLS 1.3; and
`cache_read_tokens` stayed 0 because DashScope itself reported `cached_tokens: 0`,
so the #2033 prompt-cache contract could not be confirmed from this run.

## Documentation and rollback

No documentation changes: no CLI, API, or configuration surface moved. The
reasoning that would otherwise live in a design note is in the code — the module
comment in `sslsniff.bpf.c` records why `CommonState` rather than the AEAD layer,
and `response_sse_stream_ended` records why only the literal terminator counts.

Rollback is reverting either commit independently. Neither adds state, a
migration, or a configuration key, so a revert needs no cleanup. Reverting only
the rustls commit leaves the HTTP/2 completion fix in place, which is still
useful on its own.
