### PR TITLE
feat(tokenless): correlate SLS records with the host trace context

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/configuration-and-privacy.md
+++ b/docs/user-guide/en/token-saving/tokenless/configuration-and-privacy.md
@@ -83,11 +83,15 @@ An environment override still wins after these commands. For example, `TOKENLESS
 | `TOKENLESS_AGENT_ID` | Agent identifier injected by an adapter |
 | `TOKENLESS_SESSION_ID` | Session identifier injected by an adapter |
 | `TOKENLESS_TOOL_USE_ID` | Tool-call identifier injected by an adapter |
+| `TOKENLESS_TRACEPARENT` | W3C trace context override stamped onto SLS records |
+| `TRACEPARENT` | Standard W3C trace context exported by an instrumented host |
 | `TOKENLESS_TOOL_READY_SPEC` | Override the Tool Ready dependency specification |
 | `TOKENLESS_ENV_FIX_SCRIPT` | Override the environment repair script |
 | `TOKENLESS_PACKAGE_MANAGER` | Override package-manager detection, mainly for tests |
 
 Tool Ready is hard-disabled in this build. Its specification and repair-script overrides are retained for the dormant legacy implementation but have no runtime effect. They are subject to trusted-path validation and are not recommended for normal users.
+
+`TOKENLESS_TRACEPARENT` and the standard `TRACEPARENT` carry a W3C trace context for SLS records. The override is read first, and an empty or unparsable override falls back to the standard variable so one typo cannot drop correlation for a whole session. Both are optional: a host that exports no trace context keeps the previous record shape, and the identity is stamped only onto the SLS JSONL — the local statistics database does not store it.
 
 Database path priority is:
 
@@ -144,7 +148,7 @@ TTL means that `retrieve` no longer returns an entry after one hour. Expired row
 
 ### SLS excludes original text
 
-Tokenless SLS JSONL includes the component, operation, session/tool-use identifiers, and character/token metrics. It does not include `before_text` or `after_text`. Identifiers can still be organizational runtime metadata and should follow the platform's log policy.
+Tokenless SLS JSONL includes the component, operation, session/tool-use identifiers, the host trace identity when one was propagated, and character/token metrics. It does not include `before_text` or `after_text`. Identifiers can still be organizational runtime metadata and should follow the platform's log policy.
 
 ## Guidance for sensitive workloads
 

--- a/docs/user-guide/en/token-saving/tokenless/configuration-and-privacy.md
+++ b/docs/user-guide/en/token-saving/tokenless/configuration-and-privacy.md
@@ -84,14 +84,14 @@ An environment override still wins after these commands. For example, `TOKENLESS
 | `TOKENLESS_SESSION_ID` | Session identifier injected by an adapter |
 | `TOKENLESS_TOOL_USE_ID` | Tool-call identifier injected by an adapter |
 | `TOKENLESS_TRACEPARENT` | W3C trace context override stamped onto SLS records |
-| `TRACEPARENT` | Standard W3C trace context exported by an instrumented host |
+| `TRACEPARENT` | Standard W3C trace context variable, injected by the launching host or adapter |
 | `TOKENLESS_TOOL_READY_SPEC` | Override the Tool Ready dependency specification |
 | `TOKENLESS_ENV_FIX_SCRIPT` | Override the environment repair script |
 | `TOKENLESS_PACKAGE_MANAGER` | Override package-manager detection, mainly for tests |
 
 Tool Ready is hard-disabled in this build. Its specification and repair-script overrides are retained for the dormant legacy implementation but have no runtime effect. They are subject to trusted-path validation and are not recommended for normal users.
 
-`TOKENLESS_TRACEPARENT` and the standard `TRACEPARENT` carry a W3C trace context for SLS records. The override is read first, and an empty or unparsable override falls back to the standard variable so one typo cannot drop correlation for a whole session. Both are optional: a host that exports no trace context keeps the previous record shape, and the identity is stamped only onto the SLS JSONL — the local statistics database does not store it.
+`TOKENLESS_TRACEPARENT` and the standard `TRACEPARENT` carry a W3C trace context for SLS records. Injecting one is the launcher's job: OpenTelemetry propagates W3C context through in-process carriers and does not export the active span as a process variable, so a host or adapter that wants correlation has to set one of these two variables in the environment it spawns Tokenless with. Tokenless only reads them. The override is read first, and an empty or unparsable override falls back to the standard variable so one typo cannot drop correlation for a whole session. Both are optional: when neither carries a usable context, records keep the previous shape and are written uncorrelated. The identity is stamped only onto the SLS JSONL — the local statistics database does not store it.
 
 Database path priority is:
 

--- a/docs/user-guide/en/token-saving/tokenless/measuring-savings.md
+++ b/docs/user-guide/en/token-saving/tokenless/measuring-savings.md
@@ -237,7 +237,7 @@ Default behavior:
 - Tokenless appends only when the target file already exists; otherwise it skips the write.
 - ANOLISA SLS/Logtail infrastructure creates, rotates, and removes the file.
 - SLS records contain metrics and identifiers, never the original before/after text.
-- When the agent host exports a W3C `traceparent`, records also carry `tokenless.trace_id` and `tokenless.span_id` so an observability backend such as AgentLoop can attribute the savings to the trace that produced them. Both keys are omitted when no context was propagated.
+- When the agent host or adapter injects a W3C `traceparent` into the environment Tokenless runs in, records also carry `tokenless.trace_id` and `tokenless.span_id` so an observability backend such as AgentLoop can attribute the savings to the trace that produced them. Nothing sets that variable automatically — OpenTelemetry keeps the active span in an in-process carrier — so both keys are omitted unless the launcher injected a usable context.
 - The bundled RTK statistics writer records `rewrite-command` rows only in local SQLite; it does not call the SLS writer.
 
 Use a custom test file:
@@ -251,7 +251,7 @@ TOKENLESS_SLS_PATH=/tmp/tokenless-sls.jsonl \
 tail -n 1 /tmp/tokenless-sls.jsonl | jq .
 ```
 
-Correlate one run with the trace the host is in:
+Correlate one run with the trace the launcher is in. The example sets the variable inline, which is exactly what a host or adapter has to do before spawning Tokenless:
 
 ```bash
 touch /tmp/tokenless-sls.jsonl

--- a/docs/user-guide/en/token-saving/tokenless/measuring-savings.md
+++ b/docs/user-guide/en/token-saving/tokenless/measuring-savings.md
@@ -237,6 +237,7 @@ Default behavior:
 - Tokenless appends only when the target file already exists; otherwise it skips the write.
 - ANOLISA SLS/Logtail infrastructure creates, rotates, and removes the file.
 - SLS records contain metrics and identifiers, never the original before/after text.
+- When the agent host exports a W3C `traceparent`, records also carry `tokenless.trace_id` and `tokenless.span_id` so an observability backend such as AgentLoop can attribute the savings to the trace that produced them. Both keys are omitted when no context was propagated.
 - The bundled RTK statistics writer records `rewrite-command` rows only in local SQLite; it does not call the SLS writer.
 
 Use a custom test file:
@@ -248,6 +249,18 @@ TOKENLESS_SLS_PATH=/tmp/tokenless-sls.jsonl \
   tokenless compress-response -f response.json
 
 tail -n 1 /tmp/tokenless-sls.jsonl | jq .
+```
+
+Correlate one run with the trace the host is in:
+
+```bash
+touch /tmp/tokenless-sls.jsonl
+TRACEPARENT=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01 \
+TOKENLESS_SLS_ENABLED=1 \
+TOKENLESS_SLS_PATH=/tmp/tokenless-sls.jsonl \
+  tokenless compress-response -f response.json
+
+tail -n 1 /tmp/tokenless-sls.jsonl | jq '."tokenless.trace_id", ."tokenless.span_id"'
 ```
 
 `TOKENLESS_SLS_PATH` must be under `/var/log/` or `/tmp/`. Production SLS endpoint, authentication, and Logtail configuration belong to platform operations and are outside this guide.

--- a/docs/user-guide/zh/token-saving/tokenless/configuration-and-privacy.md
+++ b/docs/user-guide/zh/token-saving/tokenless/configuration-and-privacy.md
@@ -83,11 +83,15 @@ tokenless stats disable
 | `TOKENLESS_AGENT_ID` | Adapter 注入的 Agent 标识 |
 | `TOKENLESS_SESSION_ID` | Adapter 注入的 Session 标识 |
 | `TOKENLESS_TOOL_USE_ID` | Adapter 注入的工具调用标识 |
+| `TOKENLESS_TRACEPARENT` | 覆盖写入 SLS 记录的 W3C trace context |
+| `TRACEPARENT` | 已完成插桩的宿主导出的标准 W3C trace context |
 | `TOKENLESS_TOOL_READY_SPEC` | 覆盖 Tool Ready 依赖规范路径 |
 | `TOKENLESS_ENV_FIX_SCRIPT` | 覆盖环境修复脚本路径 |
 | `TOKENLESS_PACKAGE_MANAGER` | 覆盖包管理器探测，主要用于测试 |
 
 当前构建已硬关闭 Tool Ready。依赖规范和修复脚本覆盖仅为休眠的旧版实现保留，运行时不会生效；这些路径会经过信任校验，也不建议普通用户修改。
+
+`TOKENLESS_TRACEPARENT` 与标准变量 `TRACEPARENT` 用于为 SLS 记录提供 W3C trace context。Tokenless 先读覆盖项，覆盖项为空或无法解析时回退到标准变量，因此一次拼写错误不会让整个会话失去关联能力。两者都是可选的：宿主没有导出 trace context 时，记录结构与之前完全一致；该标识只写入 SLS JSONL，本地统计数据库不保存。
 
 数据库路径优先级如下：
 
@@ -141,7 +145,7 @@ TTL 表示条目超过一小时后不能再通过 `retrieve` 返回。过期行�
 
 ### SLS 不包含原文
 
-Tokenless 的 SLS JSONL 只写入组件、Operation、Session/Tool Use 标识和字符/Token 度量，不写 `before_text` 或 `after_text`。但标识字段本身仍可能属于组织的运行元数据，应按照平台日志策略管理。
+Tokenless 的 SLS JSONL 只写入组件、Operation、Session/Tool Use 标识、宿主传入的 trace 标识（若存在）和字符/Token 度量，不写 `before_text` 或 `after_text`。但标识字段本身仍可能属于组织的运行元数据，应按照平台日志策略管理。
 
 ## 敏感工作负载建议
 

--- a/docs/user-guide/zh/token-saving/tokenless/configuration-and-privacy.md
+++ b/docs/user-guide/zh/token-saving/tokenless/configuration-and-privacy.md
@@ -84,14 +84,14 @@ tokenless stats disable
 | `TOKENLESS_SESSION_ID` | Adapter 注入的 Session 标识 |
 | `TOKENLESS_TOOL_USE_ID` | Adapter 注入的工具调用标识 |
 | `TOKENLESS_TRACEPARENT` | 覆盖写入 SLS 记录的 W3C trace context |
-| `TRACEPARENT` | 已完成插桩的宿主导出的标准 W3C trace context |
+| `TRACEPARENT` | 标准 W3C trace context 变量，由启动方宿主或 Adapter 注入 |
 | `TOKENLESS_TOOL_READY_SPEC` | 覆盖 Tool Ready 依赖规范路径 |
 | `TOKENLESS_ENV_FIX_SCRIPT` | 覆盖环境修复脚本路径 |
 | `TOKENLESS_PACKAGE_MANAGER` | 覆盖包管理器探测，主要用于测试 |
 
 当前构建已硬关闭 Tool Ready。依赖规范和修复脚本覆盖仅为休眠的旧版实现保留，运行时不会生效；这些路径会经过信任校验，也不建议普通用户修改。
 
-`TOKENLESS_TRACEPARENT` 与标准变量 `TRACEPARENT` 用于为 SLS 记录提供 W3C trace context。Tokenless 先读覆盖项，覆盖项为空或无法解析时回退到标准变量，因此一次拼写错误不会让整个会话失去关联能力。两者都是可选的：宿主没有导出 trace context 时，记录结构与之前完全一致；该标识只写入 SLS JSONL，本地统计数据库不保存。
+`TOKENLESS_TRACEPARENT` 与标准变量 `TRACEPARENT` 用于为 SLS 记录提供 W3C trace context。注入是启动方的责任：OpenTelemetry 通过进程内 carrier 传播 W3C context，不会把 active span 导出为进程环境变量，因此需要关联能力的宿主或 Adapter 必须在启动 Tokenless 的环境中显式写入这两个变量之一，Tokenless 只负责读取：先看覆盖项，覆盖项为空或无法解析时回退到标准变量，因此一次拼写错误不会让整个会话失去关联能力。两者都是可选的：两个变量都没有可用上下文时，记录结构与之前完全一致，即以未关联形式写出；该标识只写入 SLS JSONL，本地统计数据库不保存。
 
 数据库路径优先级如下：
 

--- a/docs/user-guide/zh/token-saving/tokenless/measuring-savings.md
+++ b/docs/user-guide/zh/token-saving/tokenless/measuring-savings.md
@@ -231,6 +231,7 @@ SLS 是独立的外部采集通道，不是 AgentSight 读取本地统计的前�
 - Tokenless 只在目标文件已经存在时追加；不存在时静默跳过。
 - 文件由 ANOLISA SLS/Logtail 设施创建、轮转和删除。
 - SLS 记录只包含度量与标识，不包含压缩前后的原文。
+- 当 Agent 宿主导出 W3C `traceparent` 时，记录还会带上 `tokenless.trace_id` 和 `tokenless.span_id`，AgentLoop 这类可观测后端因此可以把节省量归因到产生它的 trace；没有传入 trace context 时这两个字段不会出现。
 - 随包提供的 RTK 统计写入器只把 `rewrite-command` 记录写入本地 SQLite，不会调用 SLS Writer。
 
 自定义测试文件：
@@ -242,6 +243,18 @@ TOKENLESS_SLS_PATH=/tmp/tokenless-sls.jsonl \
   tokenless compress-response -f response.json
 
 tail -n 1 /tmp/tokenless-sls.jsonl | jq .
+```
+
+把一次运行与宿主当前所在的 trace 关联起来：
+
+```bash
+touch /tmp/tokenless-sls.jsonl
+TRACEPARENT=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01 \
+TOKENLESS_SLS_ENABLED=1 \
+TOKENLESS_SLS_PATH=/tmp/tokenless-sls.jsonl \
+  tokenless compress-response -f response.json
+
+tail -n 1 /tmp/tokenless-sls.jsonl | jq '."tokenless.trace_id", ."tokenless.span_id"'
 ```
 
 `TOKENLESS_SLS_PATH` 必须位于 `/var/log/` 或 `/tmp/` 下。生产 SLS endpoint、认证和 Logtail 配置属于平台运维配置，不在 Tokenless 用户指南中展开。

--- a/docs/user-guide/zh/token-saving/tokenless/measuring-savings.md
+++ b/docs/user-guide/zh/token-saving/tokenless/measuring-savings.md
@@ -231,7 +231,7 @@ SLS 是独立的外部采集通道，不是 AgentSight 读取本地统计的前�
 - Tokenless 只在目标文件已经存在时追加；不存在时静默跳过。
 - 文件由 ANOLISA SLS/Logtail 设施创建、轮转和删除。
 - SLS 记录只包含度量与标识，不包含压缩前后的原文。
-- 当 Agent 宿主导出 W3C `traceparent` 时，记录还会带上 `tokenless.trace_id` 和 `tokenless.span_id`，AgentLoop 这类可观测后端因此可以把节省量归因到产生它的 trace；没有传入 trace context 时这两个字段不会出现。
+- 当 Agent 宿主或 Adapter 向 Tokenless 的运行环境注入 W3C `traceparent` 时，记录还会带上 `tokenless.trace_id` 和 `tokenless.span_id`，AgentLoop 这类可观测后端因此可以把节省量归因到产生它的 trace。该变量不会被自动写入 —— OpenTelemetry 只在进程内 carrier 中保存 active span —— 因此启动方没有注入可用 trace context 时这两个字段不会出现。
 - 随包提供的 RTK 统计写入器只把 `rewrite-command` 记录写入本地 SQLite，不会调用 SLS Writer。
 
 自定义测试文件：
@@ -245,7 +245,7 @@ TOKENLESS_SLS_PATH=/tmp/tokenless-sls.jsonl \
 tail -n 1 /tmp/tokenless-sls.jsonl | jq .
 ```
 
-把一次运行与宿主当前所在的 trace 关联起来：
+把一次运行与启动方所在的 trace 关联起来。示例直接在命令行写入该变量，宿主或 Adapter 在启动 Tokenless 前需要做的正是这件事：
 
 ```bash
 touch /tmp/tokenless-sls.jsonl

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -397,6 +397,25 @@ duplicate intermediate token counts. See
 [Measuring Tokenless Savings](../../docs/user-guide/en/token-saving/tokenless/measuring-savings.md)
 for options and measurement limits.
 
+### Trace correlation
+
+Exported SLS records carry the trace identity of the host span they were
+produced under, so an observability backend such as AgentLoop can attribute
+token savings to a trace. Two optional environment variables supply it:
+
+- `TOKENLESS_TRACEPARENT` — adapter-facing override, read first.
+- `TRACEPARENT` — standard W3C variable, used when the override is absent,
+  empty, or unparsable.
+
+Injecting one is the launcher's responsibility: OpenTelemetry keeps the active
+span in an in-process carrier and does not export it to child processes, so a
+host or adapter that wants correlation must set one of them before spawning
+Tokenless. Without a usable context the record shape is unchanged, and the
+identity is written only to the SLS JSONL — never to the local `stats.db`. See
+[Measuring Tokenless Savings](../../docs/user-guide/en/token-saving/tokenless/measuring-savings.md)
+and
+[Configuration and Data Privacy](../../docs/user-guide/en/token-saving/tokenless/configuration-and-privacy.md).
+
 ### Database location
 
 Tokenless stores statistics and reversible-compression data in

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -484,6 +484,23 @@ active 阶段的输出与输入内容完全一致时才会串成一条链，从�
 阶段的 Token。完整选项和度量限制见
 [Tokenless 效果度量](../../docs/user-guide/zh/token-saving/tokenless/measuring-savings.md)。
 
+## Trace 关联
+
+导出的 SLS 记录会带上产生它的宿主 span 的 trace 标识，AgentLoop
+这类可观测后端因此可以把 Token 节省量归因到具体 trace。两个可选
+环境变量负责传入该标识：
+
+- `TOKENLESS_TRACEPARENT` —— 面向 Adapter 的覆盖项，优先读取。
+- `TRACEPARENT` —— 标准 W3C 变量，覆盖项缺失、为空或无法解析时使用。
+
+注入是启动方的责任：OpenTelemetry 只在进程内 carrier 中保存 active
+span，不会导出到子进程，因此需要关联能力的宿主或 Adapter 必须
+在启动 Tokenless 前写入其中一个。没有可用上下文时记录结构不变，
+且该标识只写入 SLS JSONL，不会写入本地 `stats.db`。详见
+[Tokenless 效果度量](../../docs/user-guide/zh/token-saving/tokenless/measuring-savings.md)
+与
+[配置与数据隐私](../../docs/user-guide/zh/token-saving/tokenless/configuration-and-privacy.md)。
+
 ## 数据库位置
 
 Tokenless 默认将统计数据和可逆压缩数据分别存储在

--- a/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
@@ -1596,6 +1596,157 @@ fn record_compression_stats_sls_only_path() {
     );
 }
 
+/// Sets or clears the trace-context variables for one test and restores the
+/// previous values on drop, so a panic cannot leak them into other tests.
+///
+/// Constructed after [`TempDbGuard`], which serializes environment mutation
+/// through `ENV_MUTEX`.
+struct TraceEnvGuard {
+    prev_traceparent: Option<std::ffi::OsString>,
+    prev_override: Option<std::ffi::OsString>,
+}
+
+impl TraceEnvGuard {
+    fn new(traceparent: Option<&str>) -> Self {
+        let prev_traceparent = std::env::var_os("TRACEPARENT");
+        let prev_override = std::env::var_os("TOKENLESS_TRACEPARENT");
+        unsafe {
+            std::env::remove_var("TOKENLESS_TRACEPARENT");
+            match traceparent {
+                Some(value) => std::env::set_var("TRACEPARENT", value),
+                None => std::env::remove_var("TRACEPARENT"),
+            }
+        }
+        Self {
+            prev_traceparent,
+            prev_override,
+        }
+    }
+}
+
+impl Drop for TraceEnvGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.prev_traceparent {
+                Some(v) => std::env::set_var("TRACEPARENT", v),
+                None => std::env::remove_var("TRACEPARENT"),
+            }
+            match &self.prev_override {
+                Some(v) => std::env::set_var("TOKENLESS_TRACEPARENT", v),
+                None => std::env::remove_var("TOKENLESS_TRACEPARENT"),
+            }
+        }
+    }
+}
+
+/// Reads the single JSONL line the SLS writer appended under `TempDbGuard`.
+fn read_sls_line(sls_dir: &str) -> serde_json::Value {
+    let path = PathBuf::from(sls_dir).join("tokenless.jsonl");
+    let content = std::fs::read_to_string(&path).unwrap();
+    let line = content.lines().next_back().expect("the SLS writer must append one line");
+    serde_json::from_str(line).unwrap()
+}
+
+#[test]
+fn record_compression_stats_stamps_host_trace_context() {
+    let guard = match TempDbGuard::new() { Some(g) => g, None => return };
+    let _trace = TraceEnvGuard::new(Some(
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+    ));
+    let config = TokenlessConfig { stats_enabled: false, sls_enabled: true, ..Default::default() };
+
+    record_compression_stats(
+        &config,
+        &DatabasePathResolver::default(),
+        OperationType::CompressResponse,
+        Some("trace-agent".to_string()),
+        Some("trace-session".to_string()),
+        Some("trace-tool".to_string()),
+        "t".repeat(600),
+        "u".repeat(60),
+        CompressionMode::Active,
+        None,
+        None,
+        None,
+    );
+
+    let obj = read_sls_line(&guard.sls_dir);
+    assert_eq!(
+        obj["tokenless.trace_id"],
+        "4bf92f3577b34da6a3ce929d0e0e4736",
+        "the exported record must carry the host trace identity"
+    );
+    assert_eq!(obj["tokenless.span_id"], "00f067aa0ba902b7");
+    // Existing attribution is unchanged by trace stamping.
+    assert_eq!(obj["tokenless.session_id"], "trace-session");
+    assert_eq!(obj["tokenless.tool_use_id"], "trace-tool");
+}
+
+#[test]
+fn record_compression_stats_prefers_traceparent_override() {
+    let guard = match TempDbGuard::new() { Some(g) => g, None => return };
+    let _trace = TraceEnvGuard::new(Some(
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+    ));
+    unsafe {
+        std::env::set_var(
+            "TOKENLESS_TRACEPARENT",
+            "00-11111111111111111111111111111111-2222222222222222-01",
+        );
+    }
+    let config = TokenlessConfig { stats_enabled: false, sls_enabled: true, ..Default::default() };
+
+    record_compression_stats(
+        &config,
+        &DatabasePathResolver::default(),
+        OperationType::CompressResponse,
+        Some("trace-agent".to_string()),
+        None,
+        None,
+        "t".repeat(600),
+        "u".repeat(60),
+        CompressionMode::Active,
+        None,
+        None,
+        None,
+    );
+
+    let obj = read_sls_line(&guard.sls_dir);
+    assert_eq!(
+        obj["tokenless.trace_id"],
+        "11111111111111111111111111111111",
+        "the adapter override must win over the standard host variable"
+    );
+    assert_eq!(obj["tokenless.span_id"], "2222222222222222");
+}
+
+#[test]
+fn record_compression_stats_omits_trace_without_host_context() {
+    let guard = match TempDbGuard::new() { Some(g) => g, None => return };
+    let _trace = TraceEnvGuard::new(None);
+    let config = TokenlessConfig { stats_enabled: false, sls_enabled: true, ..Default::default() };
+
+    record_compression_stats(
+        &config,
+        &DatabasePathResolver::default(),
+        OperationType::CompressResponse,
+        Some("trace-agent".to_string()),
+        None,
+        None,
+        "t".repeat(600),
+        "u".repeat(60),
+        CompressionMode::Active,
+        None,
+        None,
+        None,
+    );
+
+    let obj = read_sls_line(&guard.sls_dir);
+    let keys = obj.as_object().unwrap();
+    assert!(!keys.contains_key("tokenless.trace_id"));
+    assert!(!keys.contains_key("tokenless.span_id"));
+}
+
 #[test]
 fn record_compression_stats_full_path() {
     let _guard = match TempDbGuard::new() { Some(g) => g, None => return };

--- a/src/tokenless/crates/tokenless-stats/src/lib.rs
+++ b/src/tokenless/crates/tokenless-stats/src/lib.rs
@@ -13,6 +13,7 @@ pub mod record;
 pub mod recorder;
 pub mod sls;
 pub mod tokenizer;
+pub mod trace;
 
 pub use record::{CompressionMode, OperationType, StatsRecord};
 
@@ -39,6 +40,8 @@ pub use path_policy::{
 };
 
 pub use sls::{SlsRecord, SlsWriter};
+
+pub use trace::TraceContext;
 
 /// Library version
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/tokenless/crates/tokenless-stats/src/sls.rs
+++ b/src/tokenless/crates/tokenless-stats/src/sls.rs
@@ -3,12 +3,17 @@
 //! Provides SlsRecord (SLS-specific field naming via serde rename) and
 //! SlsWriter (JSONL append-only writer with fail-silent semantics).
 //!
+//! The writer stamps every record with the host trace identity from
+//! [`TraceContext`] so an observability backend can attribute token savings to
+//! the trace that produced them (see [`crate::trace`]).
+//!
 //! The JSONL file is owned and lifecycle-managed by the anolisa SLS
 //! component (it creates, rotates, and removes it). tokenless never
 //! creates, truncates, or deletes the file: on each `write()` it appends
 //! only if the file already exists, and silently skips when it does not
 //! (treated as "SLS collection not active").
 
+use crate::trace::TraceContext;
 use crate::{StatsRecord, VERSION};
 use serde::Serialize;
 use std::fs::OpenOptions;
@@ -151,6 +156,15 @@ pub struct SlsRecord {
     #[serde(rename = "tokenless.tool_use_id")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_use_id: Option<String>,
+    /// W3C trace id of the host span this operation ran under, when the host
+    /// propagated one. `None` for hosts without OpenTelemetry instrumentation.
+    #[serde(rename = "tokenless.trace_id")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    /// Id of the enclosing host span, paired with [`Self::trace_id`].
+    #[serde(rename = "tokenless.span_id")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span_id: Option<String>,
     #[serde(rename = "tokenless.source_pid")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_pid: Option<i64>,
@@ -199,6 +213,10 @@ impl From<&StatsRecord> for SlsRecord {
             operation: r.operation.as_str().to_string(),
             session_id: r.session_id.clone(),
             tool_use_id: r.tool_use_id.clone(),
+            // Filled from the environment by SlsWriter::write — the record
+            // itself carries no trace identity (see crate::trace).
+            trace_id: None,
+            span_id: None,
             source_pid: r.source_pid,
             before_chars: r.before_chars,
             before_tokens: r.before_tokens,
@@ -225,6 +243,7 @@ impl From<&StatsRecord> for SlsRecord {
 /// Fail-silent: errors are printed to stderr but never propagated.
 pub struct SlsWriter {
     path: PathBuf,
+    trace: Option<TraceContext>,
 }
 
 impl Default for SlsWriter {
@@ -237,10 +256,15 @@ impl SlsWriter {
     /// Create a writer using the TOKENLESS_SLS_PATH env var,
     /// falling back to DEFAULT_SLS_PATH if the env var is not set,
     /// empty, or contains an invalid path.
+    ///
+    /// The host trace identity is resolved once here, from the same
+    /// environment: a hook process is short-lived and its `traceparent`
+    /// cannot change between records.
     pub fn new() -> Self {
         let env_val = std::env::var("TOKENLESS_SLS_PATH").ok();
         Self {
             path: resolve_sls_path(env_val.as_deref()),
+            trace: TraceContext::from_env(),
         }
     }
 
@@ -249,7 +273,17 @@ impl SlsWriter {
     /// for ensuring the path is safe. Production code should use `new()`.
     #[cfg(test)]
     pub(crate) fn with_path(path: PathBuf) -> Self {
-        Self { path }
+        Self { path, trace: None }
+    }
+
+    /// Attach an explicit trace context (for testing).
+    ///
+    /// Tests inject the identity instead of mutating `TRACEPARENT`, which
+    /// would race across parallel test threads in the same process.
+    #[cfg(test)]
+    pub(crate) fn with_trace(mut self, trace: Option<TraceContext>) -> Self {
+        self.trace = trace;
+        self
     }
 
     /// Convert a StatsRecord to SlsRecord and append it as a JSON line.
@@ -265,7 +299,11 @@ impl SlsWriter {
             return;
         }
 
-        let sls_record = SlsRecord::from(record);
+        let mut sls_record = SlsRecord::from(record);
+        if let Some(trace) = &self.trace {
+            sls_record.trace_id = Some(trace.trace_id.clone());
+            sls_record.span_id = Some(trace.span_id.clone());
+        }
         let line = match serde_json::to_string(&sls_record) {
             Ok(s) => s,
             Err(e) => {
@@ -642,6 +680,54 @@ mod tests {
         assert!(result.is_some());
         let resolved = result.unwrap();
         assert!(resolved.to_str().unwrap().starts_with("/var/log/"));
+    }
+
+    #[test]
+    fn test_sls_record_conversion_leaves_trace_unset() {
+        // The trace identity comes from the environment, not from StatsRecord,
+        // so the pure conversion must not invent one.
+        let sls = SlsRecord::from(&make_record());
+        assert_eq!(sls.trace_id, None);
+        assert_eq!(sls.span_id, None);
+    }
+
+    #[test]
+    fn test_sls_writer_stamps_host_trace_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("traced.jsonl");
+        // The anolisa SLS component owns the file; tokenless only appends.
+        fs::write(&path, "").unwrap();
+        let trace =
+            TraceContext::parse("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01").unwrap();
+        let writer = SlsWriter::with_path(path.clone()).with_trace(Some(trace));
+
+        writer.write(&make_record());
+
+        let content = fs::read_to_string(&path).unwrap();
+        let obj: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(
+            obj["tokenless.trace_id"],
+            "4bf92f3577b34da6a3ce929d0e0e4736"
+        );
+        assert_eq!(obj["tokenless.span_id"], "00f067aa0ba902b7");
+        // Existing attribution is untouched by trace stamping.
+        assert_eq!(obj["tokenless.session_id"], "session-123");
+    }
+
+    #[test]
+    fn test_sls_writer_omits_trace_keys_without_host_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("untraced.jsonl");
+        fs::write(&path, "").unwrap();
+        let writer = SlsWriter::with_path(path.clone());
+
+        writer.write(&make_record());
+
+        let content = fs::read_to_string(&path).unwrap();
+        let obj: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        let keys = obj.as_object().unwrap();
+        assert!(!keys.contains_key("tokenless.trace_id"));
+        assert!(!keys.contains_key("tokenless.span_id"));
     }
 
     #[cfg(unix)]

--- a/src/tokenless/crates/tokenless-stats/src/tests/trace_tests.rs
+++ b/src/tokenless/crates/tokenless-stats/src/tests/trace_tests.rs
@@ -1,0 +1,143 @@
+/// Canonical W3C example traceparent: version 00, sampled.
+const VALID: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+const TRACE_ID: &str = "4bf92f3577b34da6a3ce929d0e0e4736";
+const SPAN_ID: &str = "00f067aa0ba902b7";
+
+/// Builds an environment lookup over a fixed variable list.
+fn lookup(vars: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+    let owned: Vec<(String, String)> = vars
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+    move |key: &str| {
+        owned
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.clone())
+    }
+}
+
+#[test]
+fn test_parse_valid_version_00() {
+    let context = TraceContext::parse(VALID).expect("canonical traceparent must parse");
+    assert_eq!(context.trace_id, TRACE_ID);
+    assert_eq!(context.span_id, SPAN_ID);
+}
+
+#[test]
+fn test_parse_accepts_unsampled_flags() {
+    // Sampling is the host's decision about span export; tokenless keeps the
+    // identity either way so savings stay attributable.
+    let unsampled = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00";
+    let context = TraceContext::parse(unsampled).expect("unsampled traceparent must parse");
+    assert_eq!(context.trace_id, TRACE_ID);
+}
+
+#[test]
+fn test_parse_higher_version_ignores_trailing_fields() {
+    let future = format!("01-{}-{}-01-vendor-extension", TRACE_ID, SPAN_ID);
+    let context = TraceContext::parse(&future).expect("forward-compatible version must parse");
+    assert_eq!(context.trace_id, TRACE_ID);
+    assert_eq!(context.span_id, SPAN_ID);
+}
+
+#[test]
+fn test_parse_rejects_version_00_with_trailing_field() {
+    // Version 00 is fully specified: extra fields mean the sender disagrees
+    // about the layout.
+    assert!(TraceContext::parse(&format!("{VALID}-extra")).is_none());
+}
+
+#[test]
+fn test_parse_rejects_reserved_version() {
+    let reserved = "ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    assert!(TraceContext::parse(reserved).is_none());
+}
+
+#[test]
+fn test_parse_rejects_uppercase_hex() {
+    let uppercase = "00-4BF92F3577B34DA6A3CE929D0E0E4736-00F067AA0BA902B7-01";
+    assert!(TraceContext::parse(uppercase).is_none());
+}
+
+#[test]
+fn test_parse_rejects_all_zero_ids() {
+    let zero_trace = "00-00000000000000000000000000000000-00f067aa0ba902b7-01";
+    let zero_span = "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01";
+    assert!(TraceContext::parse(zero_trace).is_none());
+    assert!(TraceContext::parse(zero_span).is_none());
+}
+
+#[test]
+fn test_parse_rejects_wrong_field_lengths() {
+    let short_trace = "00-4bf92f3577b34da6a3ce929d0e0e473-00f067aa0ba902b7-01";
+    let long_span = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b70-01";
+    let short_flags = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1";
+    let short_version = "0-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    assert!(TraceContext::parse(short_trace).is_none());
+    assert!(TraceContext::parse(long_span).is_none());
+    assert!(TraceContext::parse(short_flags).is_none());
+    assert!(TraceContext::parse(short_version).is_none());
+}
+
+#[test]
+fn test_parse_rejects_non_hex_characters() {
+    let non_hex = "00-zbf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    let spaced = " 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    assert!(TraceContext::parse(non_hex).is_none());
+    assert!(TraceContext::parse(spaced).is_none());
+}
+
+#[test]
+fn test_parse_rejects_incomplete_values() {
+    assert!(TraceContext::parse("").is_none());
+    assert!(TraceContext::parse("00").is_none());
+    assert!(TraceContext::parse("00-4bf92f3577b34da6a3ce929d0e0e4736").is_none());
+    assert!(
+        TraceContext::parse("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7").is_none(),
+        "trace-flags are mandatory"
+    );
+}
+
+#[test]
+fn test_from_lookup_prefers_tokenless_override() {
+    let override_value = "00-11111111111111111111111111111111-2222222222222222-01";
+    let vars = [
+        (TOKENLESS_TRACEPARENT_ENV, override_value),
+        (STANDARD_TRACEPARENT_ENV, VALID),
+    ];
+    let context = TraceContext::from_lookup(lookup(&vars)).expect("override must win");
+    assert_eq!(context.trace_id, "11111111111111111111111111111111");
+    assert_eq!(context.span_id, "2222222222222222");
+}
+
+#[test]
+fn test_from_lookup_falls_back_when_override_unparsable() {
+    let vars = [
+        (TOKENLESS_TRACEPARENT_ENV, "00-not-a-trace-id"),
+        (STANDARD_TRACEPARENT_ENV, VALID),
+    ];
+    let context = TraceContext::from_lookup(lookup(&vars)).expect("must fall back");
+    assert_eq!(context.trace_id, TRACE_ID);
+}
+
+#[test]
+fn test_from_lookup_treats_empty_as_unset() {
+    let vars = [
+        (TOKENLESS_TRACEPARENT_ENV, ""),
+        (STANDARD_TRACEPARENT_ENV, VALID),
+    ];
+    let context = TraceContext::from_lookup(lookup(&vars)).expect("empty override must be skipped");
+    assert_eq!(context.trace_id, TRACE_ID);
+}
+
+#[test]
+fn test_from_lookup_none_when_absent_or_invalid() {
+    assert!(TraceContext::from_lookup(lookup(&[])).is_none());
+
+    let invalid = [
+        (TOKENLESS_TRACEPARENT_ENV, "garbage"),
+        (STANDARD_TRACEPARENT_ENV, "00-00000000000000000000000000000000-0000000000000000-01"),
+    ];
+    assert!(TraceContext::from_lookup(lookup(&invalid)).is_none());
+}

--- a/src/tokenless/crates/tokenless-stats/src/trace.rs
+++ b/src/tokenless/crates/tokenless-stats/src/trace.rs
@@ -3,10 +3,14 @@
 //! An agent observability backend such as AgentLoop joins component telemetry
 //! by trace identity, but tokenless emits no spans of its own: it runs as a
 //! short-lived hook process spawned by the agent host. The environment is the
-//! propagation channel that needs no host-side protocol change — an
-//! OpenTelemetry-instrumented host exports the `traceparent` of the span it is
-//! currently in, and tokenless stamps that identity onto the observability
-//! records it writes.
+//! propagation channel that needs no host-side protocol change, but it is a
+//! contract the launcher has to fulfil: OpenTelemetry propagates W3C context
+//! through in-process carriers and does not export the active span into a
+//! child environment, so a host or adapter that wants correlation must inject
+//! the `traceparent` of the span it is currently in before spawning tokenless.
+//! tokenless is the receiving end — it stamps the identity it was given onto
+//! the observability records it writes, and writes them uncorrelated when it
+//! was given none.
 //!
 //! Only the exported (SLS) records carry the identity. The local `stats.db`
 //! deliberately does not: nothing reads trace columns back there, and a
@@ -26,7 +30,12 @@ use serde::{Deserialize, Serialize};
 /// the DeepSeek Harness adapter already works around for `TOKENLESS_*`.
 pub const TOKENLESS_TRACEPARENT_ENV: &str = "TOKENLESS_TRACEPARENT";
 
-/// W3C Trace Context environment propagation variable (OpenTelemetry convention).
+/// W3C Trace Context environment propagation variable.
+///
+/// The name follows the W3C/OpenTelemetry convention, but nothing populates it
+/// automatically: an OpenTelemetry SDK keeps the active span in an in-process
+/// carrier, so the launching host or adapter has to inject the current
+/// `traceparent` into the environment it spawns tokenless with.
 pub const STANDARD_TRACEPARENT_ENV: &str = "TRACEPARENT";
 
 /// Length of the `trace-id` field: 16 bytes as lowercase hex.

--- a/src/tokenless/crates/tokenless-stats/src/trace.rs
+++ b/src/tokenless/crates/tokenless-stats/src/trace.rs
@@ -1,0 +1,147 @@
+//! W3C Trace Context correlation for tokenless observability records.
+//!
+//! An agent observability backend such as AgentLoop joins component telemetry
+//! by trace identity, but tokenless emits no spans of its own: it runs as a
+//! short-lived hook process spawned by the agent host. The environment is the
+//! propagation channel that needs no host-side protocol change — an
+//! OpenTelemetry-instrumented host exports the `traceparent` of the span it is
+//! currently in, and tokenless stamps that identity onto the observability
+//! records it writes.
+//!
+//! Only the exported (SLS) records carry the identity. The local `stats.db`
+//! deliberately does not: nothing reads trace columns back there, and a
+//! persisted column would cascade into the database migration, the CLI output,
+//! and the Python SDK record model without a local consumer.
+//!
+//! Parsing is strict and fail-soft — an absent, malformed, or all-zero context
+//! yields `None` and the record is written uncorrelated, matching the rest of
+//! tokenless-stats, which never blocks compression on observability.
+
+use serde::{Deserialize, Serialize};
+
+/// Adapter-facing override, checked before [`STANDARD_TRACEPARENT_ENV`].
+///
+/// Lets an adapter pin the trace identity when the host exports `TRACEPARENT`
+/// for a different span, or when a sandbox strips inherited variables the way
+/// the DeepSeek Harness adapter already works around for `TOKENLESS_*`.
+pub const TOKENLESS_TRACEPARENT_ENV: &str = "TOKENLESS_TRACEPARENT";
+
+/// W3C Trace Context environment propagation variable (OpenTelemetry convention).
+pub const STANDARD_TRACEPARENT_ENV: &str = "TRACEPARENT";
+
+/// Length of the `trace-id` field: 16 bytes as lowercase hex.
+const TRACE_ID_LEN: usize = 32;
+/// Length of the `parent-id` field: 8 bytes as lowercase hex.
+const SPAN_ID_LEN: usize = 16;
+/// Version value reserved by the specification as invalid.
+const INVALID_VERSION: &str = "ff";
+/// Fields in a version `00` `traceparent`; higher versions may append more.
+const V0_FIELD_COUNT: usize = 4;
+
+/// Trace identity of the host span a tokenless operation ran under.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TraceContext {
+    /// W3C trace id: 32 lowercase hex characters, never all zero.
+    pub trace_id: String,
+    /// Id of the enclosing host span: 16 lowercase hex characters, never all zero.
+    ///
+    /// This is the `parent-id` field of `traceparent`. tokenless creates no
+    /// span, so the host span is the one its work belongs to.
+    pub span_id: String,
+}
+
+impl TraceContext {
+    /// Parses a W3C `traceparent` value.
+    ///
+    /// Accepts version `00` plus any higher version except the reserved `ff`;
+    /// above `00` trailing fields are ignored, per the specification's
+    /// forward-compatibility rule. Returns `None` for a malformed value,
+    /// uppercase hex, a short or long field, or an all-zero trace or span id.
+    #[must_use]
+    pub fn parse(traceparent: &str) -> Option<Self> {
+        let fields: Vec<&str> = traceparent.split('-').collect();
+        if fields.len() < V0_FIELD_COUNT {
+            return None;
+        }
+        let (version, trace_id, span_id, flags) = (fields[0], fields[1], fields[2], fields[3]);
+
+        if version.len() != 2 || version == INVALID_VERSION || !is_lower_hex(version) {
+            return None;
+        }
+        // Version 00 is fully specified: a trailing field means the sender
+        // disagrees about the layout, so the value is not trusted.
+        if version == "00" && fields.len() != V0_FIELD_COUNT {
+            return None;
+        }
+        if trace_id.len() != TRACE_ID_LEN || !is_lower_hex(trace_id) || is_all_zero(trace_id) {
+            return None;
+        }
+        if span_id.len() != SPAN_ID_LEN || !is_lower_hex(span_id) || is_all_zero(span_id) {
+            return None;
+        }
+        if flags.len() != 2 || !is_lower_hex(flags) {
+            return None;
+        }
+
+        Some(Self {
+            trace_id: trace_id.to_owned(),
+            span_id: span_id.to_owned(),
+        })
+    }
+
+    /// Reads the trace context from the process environment.
+    ///
+    /// [`TOKENLESS_TRACEPARENT_ENV`] wins when it holds a usable value; an
+    /// empty or unparsable override falls through to
+    /// [`STANDARD_TRACEPARENT_ENV`] so a typo cannot silently drop correlation
+    /// for a whole session. This mirrors how an invalid `TOKENLESS_SLS_PATH`
+    /// falls back to the default target.
+    #[must_use]
+    pub fn from_env() -> Option<Self> {
+        Self::from_lookup(|key| std::env::var(key).ok())
+    }
+
+    /// Environment lookup injection point for [`Self::from_env`].
+    ///
+    /// Production always reads `std::env`; tests inject a map so precedence
+    /// and fallback can be asserted without mutating the shared process
+    /// environment from parallel test threads.
+    #[must_use]
+    pub fn from_lookup(lookup: impl Fn(&str) -> Option<String>) -> Option<Self> {
+        for key in [TOKENLESS_TRACEPARENT_ENV, STANDARD_TRACEPARENT_ENV] {
+            let Some(value) = lookup(key) else {
+                continue;
+            };
+            if value.is_empty() {
+                continue;
+            }
+            if let Some(context) = Self::parse(&value) {
+                return Some(context);
+            }
+        }
+        None
+    }
+}
+
+/// Whether every byte is an ASCII lowercase hex digit.
+///
+/// Uppercase is rejected rather than normalized: the specification requires
+/// lowercase on the wire, and accepting both would let two spellings of the
+/// same trace reach the observability backend as distinct values.
+fn is_lower_hex(value: &str) -> bool {
+    value
+        .as_bytes()
+        .iter()
+        .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(b))
+}
+
+/// Whether an id is the invalid all-zero value.
+fn is_all_zero(value: &str) -> bool {
+    value.bytes().all(|b| b == b'0')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    include!("tests/trace_tests.rs");
+}


### PR DESCRIPTION
## Why

Agent observability backends — AgentLoop, or any OpenTelemetry-based platform — join component telemetry by **trace identity**. The records tokenless exports carried only `session_id` / `tool_use_id`, so token savings could not be attributed to the trace that produced them: an operator looking at one agent trace in AgentLoop had no way to see how much context tokenless removed inside it.

tokenless emits no spans of its own and runs as a short-lived hook process spawned by the agent host, so the environment is the propagation channel that needs **no host-side protocol change**. It is a contract the *launcher* has to fulfil, though: OpenTelemetry propagates W3C context through in-process carriers and does not export the active span into a child environment, so a host or adapter that wants correlation has to inject the `traceparent` of the span it is in before spawning tokenless. tokenless is the receiving end — it stamps the identity it was given and writes records uncorrelated when it was given none.

## What

| Change | Files |
| --- | --- |
| New `trace` module: strict, fail-soft W3C `traceparent` parser producing `TraceContext { trace_id, span_id }` | `src/tokenless/crates/tokenless-stats/src/trace.rs` |
| `SlsWriter` resolves the context once at construction and stamps `tokenless.trace_id` / `tokenless.span_id` onto every exported record | `src/tokenless/crates/tokenless-stats/src/sls.rs` |
| Module re-export | `src/tokenless/crates/tokenless-stats/src/lib.rs` |
| End-to-end CLI coverage of the export path | `src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs` |
| User guide (en + zh): environment table, SLS record content, correlation example | `docs/user-guide/{en,zh}/token-saving/tokenless/{configuration-and-privacy,measuring-savings}.md` |
| Component README summary of the two variables (en + zh) | `src/tokenless/README.md`, `src/tokenless/README_zh.md` |

All three production export paths (`tokenless-cli` recording plus both `tokenless-runtime` recording paths) construct the writer through `SlsWriter::new()`, so no call site needed changing and no adapter/plugin needs an update. Correlation itself still depends on the launcher injecting one of the two variables — nothing in this repo populates them yet, and without one the records are written uncorrelated exactly as before.

### Propagation contract

- `TOKENLESS_TRACEPARENT` — adapter-facing override, read first. Useful where a sandbox strips or rewrites inherited environment (the same reason the DeepSeek Harness adapter already relocates `TOKENLESS_*`).
- `TRACEPARENT` — standard W3C/OpenTelemetry environment propagation, used when the override is absent, empty, or unparsable, so one typo cannot drop correlation for a whole session (mirrors how an invalid `TOKENLESS_SLS_PATH` falls back to the default target).
- **Who sets them** — the launching host or adapter. The variable name follows the W3C/OpenTelemetry convention, but an OTel SDK keeps the active span in an in-process carrier and does not export it to child processes, so the launcher has to inject the current `traceparent` itself. tokenless emits no spans and is the callee, so it cannot supply the identity; inventing one locally would publish correlation a backend cannot join.

### Parsing rules

Strict, per the W3C Trace Context specification: lowercase hex only (uppercase is rejected rather than normalized, so two spellings of one trace cannot reach the backend as distinct values), 32-char trace id, 16-char parent id, 2-char flags, all-zero ids rejected, reserved version `ff` rejected, version `00` must be fully specified (a trailing field means the sender disagrees about the layout), higher versions may append fields and those are ignored. Sampling flags are accepted but do not gate recording — sampling is the host's decision about span export, not about whether token savings happened.

### Compatibility

- No context propagated → the serialized record is **byte-identical** to before (both keys use `skip_serializing_if = "Option::is_none"`); verified by scenario 2/4 below and by the pre-existing exact-key-count assertion in `test_sls_record_json_field_names`.
- Compression behaviour is untouched: output is byte-identical with and without the trace variables set (`diff` of the two runs).
- The anolisa telemetry uploader parses each JSONL line into a generic map and merges common dimensions, so additional keys ship without a collector-side change.

### Deliberately out of scope

- **No trace columns in local `stats.db`.** Nothing reads trace identity back from the local database, and a persisted column would cascade into the schema migration, the positional row decoder, CLI output, and the Python SDK record model (which asserts field-for-field parity with `StatsRecord`) without a local consumer. The rationale is recorded in the `trace` module docs.
- **No protocol / `Attribution` change.** `Attribution` is `deny_unknown_fields` and version-checked, so carrying trace context in-band would force a protocol version bump and lock-step upgrades of hosts and adapters; environment propagation needs neither.
- **No OTLP exporter.** Endpoint/auth/tenant configuration belongs to the platform telemetry component, not to tokenless.

## Testing

Environment: Alibaba Cloud Linux 3, x86_64; rustc/cargo 1.96.0; `rusqlite 0.31` (bundled SQLite); Python 3.12 for the hook integration suites.

### Added tests (21)

- `trace_tests.rs` (15): canonical parse, unsampled flags, higher-version trailing fields, version `00` with trailing field, reserved `ff`, uppercase hex, all-zero trace/span ids, wrong field lengths, non-hex and whitespace-padded input, incomplete values, override precedence, fallback on unparsable override, empty treated as unset, absent and invalid environments.
- `sls.rs` (3): pure conversion leaves trace unset, writer stamps the identity while existing attribution is unchanged, keys omitted without a host context.
- `main_tests.rs` (3): end-to-end through `record_compression_stats` and the real JSONL file — host `TRACEPARENT` stamped, `TOKENLESS_TRACEPARENT` wins over it, keys absent with no context. Environment mutation is RAII-guarded and serialized behind the existing `ENV_MUTEX`, so a panic cannot leak it into other tests.

### Executed commands and results

| Command (`src/tokenless/`) | Result |
| --- | --- |
| `cargo build -p tokenless-stats` | ok |
| `cargo test --workspace -- --test-threads=1` | **757 passed, 0 failed, 3 ignored** (21 suites) — includes the Rust-side field-parity test in the Python SDK crate |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 errors (only the environment's unrelated `unused config key net.timeout` cargo-config warning) |
| `cargo doc --workspace --no-deps` | ok (public API changed) |
| `cargo build -p tokenless-cli` + `python3 tests/test_hook_parity.py` | 2 passed (golden parity against the real debug binary) |
| `python3.12 tests/test_hook_contract.py` | 17 passed |
| `python3.12 tests/test_compress_response_hook.py` | 30 passed |
| `python3.12 tests/test_compress_schema_hook.py` | 18 passed |
| `python3.12 tests/test_rewrite_hook.py` | 10 passed |
| `python3.12 tests/test_hermes_lifecycle.py` | 13 passed |
| `python3.12 tests/test_agentscope_middleware.py` / `test_agentscope_v1.py` | 10 / 8 passed |
| `python3.12 tests/test_qwenpaw_plugin.py` | 16 passed |
| `python3.12 tests/test_cosh_extension_matcher.py` / `test_codex_response_diagnostics.py` / `test_release_regression_probe.py` / `test_resolve_agent_id.py` | 6 / 4 / 1 / 7 passed |

### Behaviour verification with the built CLI

`tokenless compress-response -f <15.5 KB JSON>` with `TOKENLESS_SLS_PATH` pointing at a pre-created file (the writer only appends to an existing file):

| Scenario | `tokenless.trace_id` | `tokenless.span_id` | keys | compressed output |
| --- | --- | --- | --- | --- |
| 1. `TRACEPARENT=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01` | `4bf92f3577b34da6a3ce929d0e0e4736` | `00f067aa0ba902b7` | 15 | 8008 B |
| 2. no trace variable | absent | absent | 13 | 8008 B |
| 3. override `00-1111…-2222…-01` + standard variable | `11111111111111111111111111111111` | `2222222222222222` | 15 | 8008 B |
| 4. `TRACEPARENT=00-not-a-valid-traceparent` | absent | absent | 13 | 8008 B |

Scenario 1 record (metrics from the constructed sample input, no original text exported):

```json
{
  "component.name": "tokenless",
  "component.version": "0.8.0",
  "component.agent_name": "cli",
  "tokenless.operation": "compress-response",
  "tokenless.trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
  "tokenless.span_id": "00f067aa0ba902b7",
  "tokenless.source_pid": 2567819,
  "tokenless.compression.before_chars": 15479,
  "tokenless.compression.before_tokens": 3870,
  "tokenless.compression.after_chars": 8007,
  "tokenless.compression.after_tokens": 2002,
  "tokenless.compression.chars_saved": 7472,
  "tokenless.compression.tokens_saved": 1868,
  "tokenless.compression.chars_saved_percent": 48.27,
  "tokenless.compression.tokens_saved_percent": 48.27
}
```

Scenarios 1 and 2 produce identical compressed stdout (`diff` clean), confirming the change cannot affect compression.

### Review follow-up (ae3a310)

Review pointed out that the propagation docs read as if an instrumented host exported its active span automatically, and that the new variables were missing from the component READMEs. Both are addressed — comment and documentation changes only, no behaviour change:

- Reworded the propagation claim in the `trace` module docs, the `STANDARD_TRACEPARENT_ENV` doc comment, the user-guide environment table / correlation bullet / example intro (en + zh): injection is the launcher's job, records stay uncorrelated when nothing is injected.
- Added `### Trace correlation` to `src/tokenless/README.md` and the mirrored `## Trace 关联` to `README_zh.md`, summarising both variables, the override precedence, the injection responsibility and the SLS-only scope, each linking to the full user-guide reference (documentation standard §5: new config option → component README summary + user-guide reference).

Re-verified on the follow-up commit:

| Command (`src/tokenless/` unless noted) | Result |
| --- | --- |
| `cargo test --workspace -- --test-threads=1` | **757 passed, 0 failed, 3 ignored** (21 suites) — unchanged, includes the 3 end-to-end trace tests in `tokenless-cli` |
| `cargo clippy -p tokenless-stats --all-targets -- -D warnings` | 0 errors (only the environment's unrelated `unused config key net.timeout` cargo-config warning) |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p tokenless-stats --no-deps` | ok (doc comments changed) |
| `cargo fmt --all -- --check` | clean |
| `bash scripts/docs-lint.sh` (repo root) | naming convention + en/zh tree parity OK |
| `python3 scripts/docs-link-check.py` (repo root) | all relative links resolve |

Real CLI run of the four propagation scenarios (`tokenless compress-response -f <24 KB JSON>`, `TOKENLESS_SLS_PATH` pre-created): standard `TRACEPARENT` → `trace_id=4bf92f35…`, `span_id=00f067aa…`, 15 keys; `TOKENLESS_TRACEPARENT` override + standard → override wins, 15 keys; no variable → keys absent, 13 keys; `TRACEPARENT=00-not-a-valid-traceparent` → keys absent, 13 keys. Compressed stdout was 6101 bytes in all four cases.

### Not run, and pre-existing failures (verified unrelated)

- `tests/test_hermes_plugin_import.py`: 2 failures + 1 error on this machine — the plugin copy imports `hook_utils` from an **already-installed system adapter path** that predates `build_post_tool_request`. Reproduced identically with this change stashed (clean `main`), so it is an environment artifact, not a regression.
- `tests/run-all-tests.sh`: 55/70 both **with and without** this change (verified by stashing) — the failures invoke the installed `tokenless` binary, which does not know the current subcommands.
- `make test-python-runtime` / `test-agentscope-integration`: not run — no `maturin`/`uvx` toolchain here and the default `python3` is 3.8 (the SDK annotations need 3.10+). This PR does not change `StatsRecord` or any Python-visible surface; the Rust-side parity test that guards it is part of the workspace run above and passes.
- `make test-adapters`, `test-raw-package`, `test-npm-package`, `test-toon-cleanup`: not run — plugin/packaging builds unrelated to the stats export path.

