### PR TITLE
feat(tokenless): report savings to AgentLoop observability

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/en/token-saving/tokenless/cli-reference.md
@@ -52,7 +52,7 @@ lower than the original (`after < before`). Otherwise stdout receives the origin
 input, stderr reports `did not reduce size`, and no statistics record is written.
 In dry-run mode (`TOKENLESS_COMPRESSION_ENABLED=0` or
 `compression_enabled=false`), stdout always receives the original input; a smaller
-candidate is recorded as a predicted saving when statistics or SLS recording is enabled.
+candidate is recorded as a predicted saving when statistics, SLS, or AgentLoop recording is enabled.
 
 The break-even point therefore depends on content and JSON shape, not only on
 bytes or characters. A small payload with a removable field can compress, while
@@ -403,7 +403,7 @@ tokenless stats diff --session <session-id> \
 
 Content diffing is omitted when either endpoint is unavailable or exceeds 1 MiB, and rendered hunks stop after 500 lines. Take care when using a shared terminal or collecting output because record and tool-use diffs can contain stored source text. See [Measuring savings](measuring-savings.md) and [Configuration and data privacy](configuration-and-privacy.md).
 
-`stats status` reports the local-statistics and SLS switches and their source. The current status path does not read the compression switch, so it does not display `compression_enabled`; inspect `TOKENLESS_COMPRESSION_ENABLED` and `~/.tokenless/config.json` for that setting.
+`stats status` reports the local-statistics, SLS, and AgentLoop switches and their source. The current status path does not read the compression switch, so it does not display `compression_enabled`; inspect `TOKENLESS_COMPRESSION_ENABLED` and `~/.tokenless/config.json` for that setting.
 
 ## Errors and degradation
 

--- a/docs/user-guide/en/token-saving/tokenless/configuration-and-privacy.md
+++ b/docs/user-guide/en/token-saving/tokenless/configuration-and-privacy.md
@@ -14,7 +14,7 @@ Environment variable > ~/.tokenless/config.json > default
 
 An empty environment variable is treated as unset. For Boolean environment variables, `1`, `true`, and `yes` are true, case-insensitively; any other non-empty value is false. Prefer explicit `true` or `false` values for readability.
 
-There is one current implementation exception: when both `TOKENLESS_STATS_ENABLED` and `TOKENLESS_SLS_ENABLED` are non-empty, the config file is skipped completely. In that branch, compression uses `TOKENLESS_COMPRESSION_ENABLED` when set and otherwise defaults to `true`. If you export both recording variables, export the compression variable explicitly as well.
+There is one current implementation exception: when `TOKENLESS_STATS_ENABLED`, `TOKENLESS_SLS_ENABLED`, `TOKENLESS_AGENTLOOP_ENABLED`, and `TOKENLESS_COMPRESSION_ENABLED` are all non-empty, the config file is skipped completely and all four toggles come straight from the environment. When any one of them is unset, the file is read to fill that gap. If you export some of the recording variables, export all four so a slow or broken mount never adds a config read.
 
 ## Configuration file
 
@@ -30,6 +30,7 @@ Complete example:
 {
   "stats_enabled": true,
   "sls_enabled": true,
+  "agentloop_enabled": true,
   "compression_enabled": true
 }
 ```
@@ -44,6 +45,7 @@ jq . ~/.tokenless/config.json
 |-------|---------|-----------------|
 | `stats_enabled` | `true` | Writes complete before/after text and metrics to local SQLite |
 | `sls_enabled` | `true` | Appends a metrics-only record when the target JSONL file exists |
+| `agentloop_enabled` | `true` | Appends a metrics-only AgentLoop record with trajectory correlation identity when the target JSONL file exists |
 | `compression_enabled` | `true` | Returns compressed output when true; false runs dry-run and returns the original |
 
 When Tokenless writes the configuration, it restricts the mode to `0600`. Confirm the mode after creating it manually:
@@ -70,11 +72,13 @@ An environment override still wins after these commands. For example, `TOKENLESS
 |----------|---------|------------|
 | `TOKENLESS_STATS_ENABLED` | Override local statistics | Does not affect SLS or Stash |
 | `TOKENLESS_SLS_ENABLED` | Override SLS metrics | Does not affect local statistics |
+| `TOKENLESS_AGENTLOOP_ENABLED` | Override AgentLoop metrics | Does not affect local statistics or SLS |
 | `TOKENLESS_COMPRESSION_ENABLED` | Override active compression | False is dry-run, not a full stop |
 | `TOKENLESS_DATA_DIR` | Directory containing `stats.db` and `stash.db` | Any accessible absolute directory except filesystem root; no parent traversal |
 | `TOKENLESS_STATS_DB` | Override the statistics database | Must be under the real user home or selected data directory |
 | `TOKENLESS_STASH_DB` | Override the Stash database | Must be under the real user home or selected data directory |
 | `TOKENLESS_SLS_PATH` | Override the SLS JSONL path | Must be under `/var/log/` or `/tmp/` |
+| `TOKENLESS_AGENTLOOP_PATH` | Override the AgentLoop JSONL path | Must be under `/var/log/` or `/tmp/` |
 
 ### Adapter and diagnostic variables
 
@@ -114,8 +118,9 @@ them from source control or backups as required by your data policy.
 |------|--------------|-----------------|-----------|---------------|
 | Local statistics | `~/.tokenless/stats.db` | Complete before/after text, identifiers, and metrics | No automatic TTL; retained until cleared | `tokenless stats disable` |
 | Stash | `~/.tokenless/stash.db` | Original strings, dropped middle segments of truncated arrays, complete object record arrays reduced to a sampled subset, deep subtrees, schema descriptions removed by truncation, and build/log gaps | One-hour TTL and 10,000 live entries; expired rows are purged lazily | CLI: `--no-stash`; agent: disable the adapter |
-| Configuration | `~/.tokenless/config.json` | Three Boolean toggles | Persistent | Not applicable |
+| Configuration | `~/.tokenless/config.json` | Four Boolean toggles | Persistent | Not applicable |
 | SLS JSONL | `/var/log/anolisa/sls/ops/tokenless.jsonl` | Metrics and identifiers, no compressed source text | Managed by SLS/Logtail infrastructure | `TOKENLESS_SLS_ENABLED=0` or config false |
+| AgentLoop JSONL | `/var/log/anolisa/agentloop/ops/tokenless.jsonl` | Metrics and trajectory correlation identity (`conversation_id`, `tool_call_id`, `agent_name`), no compressed source text | Managed by ANOLISA collection infrastructure | `TOKENLESS_AGENTLOOP_ENABLED=0` or config false |
 
 ### Sensitivity of local statistics
 
@@ -142,9 +147,9 @@ ls -l ~/.tokenless/stash.db*
 
 TTL means that `retrieve` no longer returns an entry after one hour. Expired rows are deleted lazily during a later retrieval; TTL is not an immediate secure-erasure guarantee for disk data. When more than 10,000 live entries exist, the store evicts entries with the earliest expiry first, so retrieval can fail before one hour under heavy use.
 
-### SLS excludes original text
+### SLS and AgentLoop feeds exclude original text
 
-Tokenless SLS JSONL includes the component, operation, session/tool-use identifiers, and character/token metrics. It does not include `before_text` or `after_text`. Identifiers can still be organizational runtime metadata and should follow the platform's log policy.
+Both the Tokenless SLS JSONL and the AgentLoop JSONL include the component, operation, correlation identifiers, and character/token metrics. Neither includes `before_text` or `after_text`. The AgentLoop record additionally carries `conversation_id` and `tool_call_id` so savings can be attributed to one conversation and tool call. Identifiers can still be organizational runtime metadata and should follow the platform's log policy.
 
 ## Guidance for sensitive workloads
 
@@ -153,6 +158,7 @@ Tokenless SLS JSONL includes the component, operation, session/tool-use identifi
 ```bash
 TOKENLESS_STATS_ENABLED=0 \
 TOKENLESS_SLS_ENABLED=0 \
+TOKENLESS_AGENTLOOP_ENABLED=0 \
   tokenless compress-response --no-stash -f response.json
 ```
 
@@ -171,6 +177,7 @@ This is a dry-run and may still write local statistics or SLS. To avoid persiste
 ```bash
 export TOKENLESS_STATS_ENABLED=0
 export TOKENLESS_SLS_ENABLED=0
+export TOKENLESS_AGENTLOOP_ENABLED=0
 ```
 
 Dry-run does not create Stash entries, but it also does not disable RTK rewriting. Tool Ready is independently hard-disabled. Disable the adapter when all hook behavior must stop.

--- a/docs/user-guide/en/token-saving/tokenless/measuring-savings.md
+++ b/docs/user-guide/en/token-saving/tokenless/measuring-savings.md
@@ -252,6 +252,93 @@ tail -n 1 /tmp/tokenless-sls.jsonl | jq .
 
 `TOKENLESS_SLS_PATH` must be under `/var/log/` or `/tmp/`. Production SLS endpoint, authentication, and Logtail configuration belong to platform operations and are outside this guide.
 
+## AgentLoop observability
+
+AgentLoop is the agent observability and optimization platform that agent runtimes such as AgentCore report to. It correlates every tool call inside a conversation along a trajectory. Tokenless reports each compression's token savings on a separate AgentLoop channel and carries the trajectory correlation identity, so savings can be attributed to one conversation and one tool call instead of only a component-level aggregate.
+
+How this relates to the SLS channel:
+
+- The SLS channel targets operational collection and uses the `component.*` / `tokenless.compression.*` namespaces.
+- The AgentLoop channel targets trajectory correlation and uses the trajectory names `conversation_id`, `tool_call_id`, and `agent_name`.
+- The two channels are independent and can be toggled separately. Disabling one affects neither the other nor local `stats.db`.
+
+Default behavior:
+
+- `agentloop_enabled=true`.
+- The default target is `/var/log/anolisa/agentloop/ops/tokenless.jsonl`.
+- Tokenless appends only when the target file already exists; otherwise it skips the write.
+- ANOLISA collection infrastructure creates, rotates, and removes the file. Tokenless never creates or removes it.
+- Records contain metrics and correlation identifiers, never the original before/after text.
+- The bundled RTK statistics writer records to local SQLite only; it does not call the AgentLoop writer.
+
+### Correlation identity
+
+The AgentLoop correlation identity comes from Tokenless attribution fields that already exist, spelled with the trajectory names:
+
+| AgentLoop field | Tokenless source | Meaning |
+|-----------------|------------------|---------|
+| `conversation_id` | `--session-id` / `attribution.session_id` | One conversation |
+| `tool_call_id` | `--tool-use-id` / `attribution.tool_use_id` | One tool call in that conversation |
+| `agent_name` | `--agent-id` / `attribution.agent_id` | Agent or adapter identity |
+
+The `attribution` object of the unified entry point `tokenless compress` also accepts the trajectory spelling, so a host that already reports to AgentLoop needs no field-name translation layer:
+
+```json
+{
+  "protocol_version": 2,
+  "operation": "post_tool",
+  "attribution": {
+    "agent_id": "agentcore",
+    "conversation_id": "conv-1",
+    "tool_call_id": "call-1"
+  }
+}
+```
+
+Notes:
+
+- The alias is input-only. Tokenless always serializes `session_id` / `tool_use_id`, so existing adapters and response shapes are unaffected.
+- Sending both spellings of one identity is rejected as a duplicate field rather than silently resolved.
+- Absent identifiers are omitted from the record instead of being written as `null`.
+
+### Record content
+
+One JSON object per line. Main fields:
+
+| Field | Description |
+|-------|-------------|
+| `schema_version` | Record layout version, currently `1` |
+| `event_type` | Always `tokenless.token_savings` |
+| `timestamp` | RFC 3339 UTC timestamp |
+| `conversation_id` / `tool_call_id` / `agent_name` | Trajectory correlation identity |
+| `operation` | `compress-schema`, `compress-response`, `rewrite-command`, `compress-toon` |
+| `mode` | `active` means the savings were applied; `dry-run` means predicted only, and AgentLoop must not count dry-run savings as real |
+| `before_tokens` / `after_tokens` / `tokens_saved` / `tokens_saved_percent` | Token metrics |
+| `before_chars` / `after_chars` / `chars_saved` / `chars_saved_percent` | Character metrics |
+| `content_type` / `content_origin` / `applied_operations` | Content taxonomy and the operations that took effect |
+| `recoverability` / `unrecoverable_truncations` | Whether the original can be retrieved, separating lossless from lossy savings |
+| `tokenizer_id` | Token counter identity used for the estimates |
+
+Use a custom test file:
+
+```bash
+touch /tmp/tokenless-agentloop.jsonl
+TOKENLESS_AGENTLOOP_ENABLED=1 \
+TOKENLESS_AGENTLOOP_PATH=/tmp/tokenless-agentloop.jsonl \
+  tokenless compress-response -f response.json \
+  --agent-id agentcore --session-id conv-1 --tool-use-id call-1
+
+tail -n 1 /tmp/tokenless-agentloop.jsonl | jq .
+```
+
+`TOKENLESS_AGENTLOOP_PATH` must be under `/var/log/` or `/tmp/` and must not contain `..`. Production AgentLoop endpoints, authentication, and collection configuration belong to platform operations and are outside this guide.
+
+Check the current toggle state with:
+
+```bash
+tokenless stats status
+```
+
 ## Clear statistics
 
 First confirm that historical comparisons are no longer needed:
@@ -266,4 +353,4 @@ This clears records but does not disable future recording. Stop new local record
 tokenless stats disable
 ```
 
-`stats disable` turns off only local SQLite statistics, not SLS. See [Configuration and data privacy](configuration-and-privacy.md) for the complete toggle behavior.
+`stats disable` turns off only local SQLite statistics, not the SLS or AgentLoop feeds. See [Configuration and data privacy](configuration-and-privacy.md) for the complete toggle behavior.

--- a/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
@@ -50,7 +50,7 @@ cat response.json | tokenless compress-response
 估算值严格小于原文（`after < before`）时才会输出候选结果；否则 stdout 输出原文，stderr
 报告 `did not reduce size`，且不写入统计记录。在 Dry-run 模式
 （`TOKENLESS_COMPRESSION_ENABLED=0` 或 `compression_enabled=false`）下，stdout 始终输出
-原文；候选结果更小时，如果已启用 Stats 或 SLS 记录，则把它记为预测节省。
+原文；候选结果更小时，如果已启用 Stats、SLS 或 AgentLoop 记录，则把它记为预测节省。
 
 因此，盈亏平衡点取决于内容和 JSON 结构，而不只取决于字节数或字符数。包含可移除字段
 的小 Payload 仍可能被压缩，而已经紧凑的较大 Payload 也可能原样透传。下文的描述、
@@ -393,7 +393,7 @@ tokenless stats diff --session <session-id> \
 
 任一端内容不可用或超过 1 MiB 时不生成内容差异，渲染的 hunk 最多 500 行。单记录和 tool-use 差异可能包含存储的源文本，使用共享终端或收集输出时注意敏感信息。完整说明见[效果度量](measuring-savings.md)和[配置与数据隐私](configuration-and-privacy.md)。
 
-`stats status` 只报告本地统计和 SLS 开关及其来源，因为当前状态读取路径没有读取 compression 开关，所以不显示 `compression_enabled`。该设置应检查 `TOKENLESS_COMPRESSION_ENABLED` 和 `~/.tokenless/config.json`。
+`stats status` 只报告本地统计、SLS 和 AgentLoop 开关及其来源，因为当前状态读取路径没有读取 compression 开关，所以不显示 `compression_enabled`。该设置应检查 `TOKENLESS_COMPRESSION_ENABLED` 和 `~/.tokenless/config.json`。
 
 ## 错误与降级
 

--- a/docs/user-guide/zh/token-saving/tokenless/configuration-and-privacy.md
+++ b/docs/user-guide/zh/token-saving/tokenless/configuration-and-privacy.md
@@ -14,7 +14,7 @@ Tokenless 默认启用压缩、本地统计和 SLS 度量。由于本地统计�
 
 空环境变量视为未设置。布尔环境变量中，`1`、`true`、`yes`（大小写不敏感）表示 true；其他非空值表示 false。为了可读性，建议明确使用 `true` 或 `false`。
 
-当前实现有一个例外：当 `TOKENLESS_STATS_ENABLED` 和 `TOKENLESS_SLS_ENABLED` 都是非空值时，代码会完全跳过配置文件。在这个分支中，压缩开关优先使用 `TOKENLESS_COMPRESSION_ENABLED`；未设置时直接默认为 `true`。如果同时导出两个记录开关，也应显式导出压缩开关。
+当前实现有一个例外：当 `TOKENLESS_STATS_ENABLED`、`TOKENLESS_SLS_ENABLED`、`TOKENLESS_AGENTLOOP_ENABLED` 和 `TOKENLESS_COMPRESSION_ENABLED` 全部是非空值时，代码会完全跳过配置文件，四个开关都直接取环境变量。只要有一个未设置，就会读取配置文件来补齐它。如果导出了其中任意几个记录开关，建议把四个都显式导出，避免配置文件在慢速或异常挂载上引入额外读取。
 
 ## 配置文件
 
@@ -30,6 +30,7 @@ Tokenless 默认启用压缩、本地统计和 SLS 度量。由于本地统计�
 {
   "stats_enabled": true,
   "sls_enabled": true,
+  "agentloop_enabled": true,
   "compression_enabled": true
 }
 ```
@@ -44,6 +45,7 @@ jq . ~/.tokenless/config.json
 |------|--------|----------|
 | `stats_enabled` | `true` | 把压缩前后文本和度量写入本地 SQLite |
 | `sls_enabled` | `true` | 目标 JSONL 文件已存在时追加仅包含度量的记录 |
+| `agentloop_enabled` | `true` | 目标 JSONL 文件已存在时追加仅包含度量与轨迹关联标识的 AgentLoop 记录 |
 | `compression_enabled` | `true` | 为 true 时返回压缩结果；false 时进入 dry-run 并返回原文 |
 
 Tokenless 写入配置文件时会把权限限制为 `0600`。手动创建文件后也应确认：
@@ -70,11 +72,13 @@ tokenless stats disable
 |------|------|------|
 | `TOKENLESS_STATS_ENABLED` | 覆盖本地统计开关 | 不影响 SLS 或 Stash |
 | `TOKENLESS_SLS_ENABLED` | 覆盖 SLS 度量开关 | 不影响本地统计 |
+| `TOKENLESS_AGENTLOOP_ENABLED` | 覆盖 AgentLoop 度量开关 | 不影响本地统计和 SLS |
 | `TOKENLESS_COMPRESSION_ENABLED` | 覆盖真实压缩开关 | false 是 dry-run，不是完全停用 |
 | `TOKENLESS_DATA_DIR` | 存放 `stats.db` 和 `stash.db` 的目录 | 可访问的任意绝对目录，但不能是文件系统根目录或包含父目录遍历 |
 | `TOKENLESS_STATS_DB` | 覆盖统计数据库路径 | 必须位于真实用户 home 或选定的数据目录下 |
 | `TOKENLESS_STASH_DB` | 覆盖 Stash 数据库路径 | 必须位于真实用户 home 或选定的数据目录下 |
 | `TOKENLESS_SLS_PATH` | 覆盖 SLS JSONL 路径 | 必须位于 `/var/log/` 或 `/tmp/` 下 |
+| `TOKENLESS_AGENTLOOP_PATH` | 覆盖 AgentLoop JSONL 路径 | 必须位于 `/var/log/` 或 `/tmp/` 下 |
 
 ### Adapter 和诊断变量
 
@@ -111,8 +115,9 @@ SQLite sidecar 不会被 `git add -A` 暂存。Adapter 不会修改自定义路�
 |------|----------|----------|----------|--------------|
 | 本地统计 | `~/.tokenless/stats.db` | 压缩前后完整文本、标识和度量 | 无自动 TTL，直到清理 | `tokenless stats disable` |
 | Stash | `~/.tokenless/stash.db` | 截断时移除的原始字符串、截断数组中被丢弃的中间段、被缩减为采样集合的完整对象记录数组、深层子树、Schema 描述和 build/log 间隙内容 | TTL 1 小时、最多 10,000 个有效条目，过期行延迟清理 | CLI 使用 `--no-stash`；Agent 场景禁用 Adapter |
-| 配置 | `~/.tokenless/config.json` | 三个布尔开关 | 持续保留 | 不适用 |
+| 配置 | `~/.tokenless/config.json` | 四个布尔开关 | 持续保留 | 不适用 |
 | SLS JSONL | `/var/log/anolisa/sls/ops/tokenless.jsonl` | 度量和标识，不含压缩原文 | 由 SLS/Logtail 设施管理 | `TOKENLESS_SLS_ENABLED=0` 或配置为 false |
+| AgentLoop JSONL | `/var/log/anolisa/agentloop/ops/tokenless.jsonl` | 度量、轨迹关联标识（`conversation_id`、`tool_call_id`、`agent_name`），不含压缩原文 | 由 ANOLISA 采集设施管理 | `TOKENLESS_AGENTLOOP_ENABLED=0` 或配置为 false |
 
 ### 本地统计的敏感性
 
@@ -139,9 +144,9 @@ ls -l ~/.tokenless/stash.db*
 
 TTL 表示条目超过一小时后不能再通过 `retrieve` 返回。过期行会在后续取回时延迟删除；TTL 不应被理解为立即安全擦除磁盘数据。当有效条目超过 10,000 个时，存储会优先淘汰到期时间最早的条目，因此高负载下可能不到一小时就无法取回。
 
-### SLS 不包含原文
+### SLS 与 AgentLoop 通道都不包含原文
 
-Tokenless 的 SLS JSONL 只写入组件、Operation、Session/Tool Use 标识和字符/Token 度量，不写 `before_text` 或 `after_text`。但标识字段本身仍可能属于组织的运行元数据，应按照平台日志策略管理。
+Tokenless 的 SLS JSONL 和 AgentLoop JSONL 都只写入组件、Operation、关联标识和字符/Token 度量，不写 `before_text` 或 `after_text`。AgentLoop 记录额外带上 `conversation_id` 与 `tool_call_id`，用于把节省归因到具体会话和工具调用。但标识字段本身仍可能属于组织的运行元数据，应按照平台日志策略管理。
 
 ## 敏感工作负载建议
 
@@ -150,6 +155,7 @@ Tokenless 的 SLS JSONL 只写入组件、Operation、Session/Tool Use 标识和
 ```bash
 TOKENLESS_STATS_ENABLED=0 \
 TOKENLESS_SLS_ENABLED=0 \
+TOKENLESS_AGENTLOOP_ENABLED=0 \
   tokenless compress-response --no-stash -f response.json
 ```
 
@@ -168,6 +174,7 @@ export TOKENLESS_COMPRESSION_ENABLED=0
 ```bash
 export TOKENLESS_STATS_ENABLED=0
 export TOKENLESS_SLS_ENABLED=0
+export TOKENLESS_AGENTLOOP_ENABLED=0
 ```
 
 Dry-run 不会创建 Stash 条目，但也不会关闭 RTK 重写。Tool Ready 已独立硬关闭。需要停止全部 Hook 行为时应禁用 Adapter。

--- a/docs/user-guide/zh/token-saving/tokenless/measuring-savings.md
+++ b/docs/user-guide/zh/token-saving/tokenless/measuring-savings.md
@@ -246,6 +246,93 @@ tail -n 1 /tmp/tokenless-sls.jsonl | jq .
 
 `TOKENLESS_SLS_PATH` 必须位于 `/var/log/` 或 `/tmp/` 下。生产 SLS endpoint、认证和 Logtail 配置属于平台运维配置，不在 Tokenless 用户指南中展开。
 
+## AgentLoop 可观测
+
+AgentLoop 是 AgentCore 等 Agent 运行时接入的 Agent 可观测与优化平台，按轨迹（Trajectory）把一次会话中的每个工具调用关联起来。Tokenless 通过独立的 AgentLoop 通道上报每次压缩的 Token 节省，并携带轨迹侧的关联标识，使节省可以归因到具体的 Conversation 和 Tool Call，而不是只有一份组件级汇总。
+
+与 SLS 通道的关系：
+
+- SLS 通道面向运维采集，字段使用 `component.*` / `tokenless.compression.*` 命名空间。
+- AgentLoop 通道面向轨迹关联，字段使用轨迹侧的 `conversation_id`、`tool_call_id`、`agent_name`。
+- 两条通道互不依赖，可以独立开关；关闭其中一条不影响另一条，也不影响本地 `stats.db`。
+
+默认行为：
+
+- `agentloop_enabled=true`。
+- 默认目标为 `/var/log/anolisa/agentloop/ops/tokenless.jsonl`。
+- Tokenless 只在目标文件已经存在时追加；不存在时静默跳过。
+- 文件由 ANOLISA 采集设施创建、轮转和删除，Tokenless 不创建也不删除。
+- 记录只包含度量与关联标识，不包含压缩前后的原文。
+- 随包提供的 RTK 统计写入器只写本地 SQLite，不会调用 AgentLoop Writer。
+
+### 关联标识
+
+AgentLoop 记录的关联标识来自 Tokenless 已有的归因字段，只是改用轨迹侧的字段名：
+
+| AgentLoop 字段 | Tokenless 来源 | 含义 |
+|----------------|----------------|------|
+| `conversation_id` | `--session-id` / `attribution.session_id` | 一次会话 |
+| `tool_call_id` | `--tool-use-id` / `attribution.tool_use_id` | 会话中的一次工具调用 |
+| `agent_name` | `--agent-id` / `attribution.agent_id` | Agent 或 Adapter 标识 |
+
+统一入口 `tokenless compress` 的 `attribution` 同时接受轨迹侧写法，因此直接上报 AgentLoop 的宿主无需再做字段名翻译：
+
+```json
+{
+  "protocol_version": 2,
+  "operation": "post_tool",
+  "attribution": {
+    "agent_id": "agentcore",
+    "conversation_id": "conv-1",
+    "tool_call_id": "call-1"
+  }
+}
+```
+
+注意：
+
+- 别名只作用于输入。Tokenless 自身序列化时始终输出 `session_id` / `tool_use_id`，既有 Adapter 与响应格式不受影响。
+- 同一标识的两种写法同时出现会被拒绝（duplicate field），而不是静默择一。
+- 缺失的标识不会写成 `null`，而是不出现在记录中。
+
+### 记录内容
+
+每行一个 JSON 对象，主要字段：
+
+| 字段 | 说明 |
+|------|------|
+| `schema_version` | 记录结构版本，当前为 `1` |
+| `event_type` | 固定为 `tokenless.token_savings` |
+| `timestamp` | RFC 3339 UTC 时间戳 |
+| `conversation_id` / `tool_call_id` / `agent_name` | 轨迹关联标识 |
+| `operation` | `compress-schema`、`compress-response`、`rewrite-command`、`compress-toon` |
+| `mode` | `active` 表示真实压缩，`dry-run` 表示只预测未生效，AgentLoop 侧不应把 dry-run 计入实际节省 |
+| `before_tokens` / `after_tokens` / `tokens_saved` / `tokens_saved_percent` | Token 度量 |
+| `before_chars` / `after_chars` / `chars_saved` / `chars_saved_percent` | 字符度量 |
+| `content_type` / `content_origin` / `applied_operations` | 内容分类与生效的操作 |
+| `recoverability` / `unrecoverable_truncations` | 原文是否可恢复，用于区分无损与有损节省 |
+| `tokenizer_id` | 估算所用 Token 计数器标识 |
+
+自定义测试文件：
+
+```bash
+touch /tmp/tokenless-agentloop.jsonl
+TOKENLESS_AGENTLOOP_ENABLED=1 \
+TOKENLESS_AGENTLOOP_PATH=/tmp/tokenless-agentloop.jsonl \
+  tokenless compress-response -f response.json \
+  --agent-id agentcore --session-id conv-1 --tool-use-id call-1
+
+tail -n 1 /tmp/tokenless-agentloop.jsonl | jq .
+```
+
+`TOKENLESS_AGENTLOOP_PATH` 必须位于 `/var/log/` 或 `/tmp/` 下，且不能包含 `..`。生产 AgentLoop 接入点、鉴权与采集配置属于平台运维配置，不在 Tokenless 用户指南中展开。
+
+当前开关状态可以用：
+
+```bash
+tokenless stats status
+```
+
 ## 清理统计
 
 先确认不再需要历史对比：
@@ -260,4 +347,4 @@ tokenless stats clear --yes
 tokenless stats disable
 ```
 
-`stats disable` 只关闭本地 SQLite 统计，不会关闭 SLS。完整开关关系见[配置与数据隐私](configuration-and-privacy.md)。
+`stats disable` 只关闭本地 SQLite 统计，不会关闭 SLS 或 AgentLoop 通道。完整开关关系见[配置与数据隐私](configuration-and-privacy.md)。

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -584,6 +584,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                 &outcome,
                 recorder.as_ref(),
                 config.is_sls_enabled(),
+                config.is_agentloop_enabled(),
             );
         }
         Commands::CompressSchema {
@@ -951,6 +952,9 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     let sls_env_set = std::env::var("TOKENLESS_SLS_ENABLED")
                         .ok()
                         .filter(|v| !v.is_empty());
+                    let agentloop_env_set = std::env::var("TOKENLESS_AGENTLOOP_ENABLED")
+                        .ok()
+                        .filter(|v| !v.is_empty());
                     let config = TokenlessConfig::load();
                     let file_exists = TokenlessConfig::config_file_exists();
 
@@ -981,6 +985,20 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                         "default"
                     };
                     println!("SLS recording:   {sls_state} (via {sls_source})");
+
+                    let agentloop_state = if config.is_agentloop_enabled() {
+                        "ENABLED"
+                    } else {
+                        "DISABLED"
+                    };
+                    let agentloop_source = if agentloop_env_set.is_some() {
+                        "env override"
+                    } else if file_exists {
+                        "config file"
+                    } else {
+                        "default"
+                    };
+                    println!("AgentLoop feed:  {agentloop_state} (via {agentloop_source})");
                 }
                 StatsCommands::Enable => {
                     persist_stats_enabled(true)?;
@@ -1216,8 +1234,8 @@ fn record_compression_stats(
     stash_errors: Option<usize>,
     stash_size: Option<usize>,
 ) {
-    // Short-circuit only if both stats and SLS are disabled.
-    if !config.is_stats_enabled() && !config.is_sls_enabled() {
+    // Short-circuit only if stats and every external feed are disabled.
+    if !config.is_stats_enabled() && !config.is_sls_enabled() && !config.is_agentloop_enabled() {
         return;
     }
 
@@ -1267,6 +1285,15 @@ fn record_compression_stats(
     // SLS recording — fail-silent, independent of SQLite
     if config.is_sls_enabled() {
         let writer = tokenless_stats::SlsWriter::new();
+        writer.write(&record);
+    }
+
+    // AgentLoop recording — fail-silent, independent of SQLite and SLS. The
+    // record carries the trajectory correlation identity (conversation_id,
+    // tool_call_id, agent name) so AgentLoop can attach the savings to the
+    // step that produced them.
+    if config.is_agentloop_enabled() {
+        let writer = tokenless_stats::AgentLoopWriter::new();
         writer.write(&record);
     }
 }

--- a/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
@@ -13,10 +13,13 @@ struct TempDbGuard {
     _lock: std::sync::MutexGuard<'static, ()>,
     test_dir: String,
     sls_dir: String,
+    agentloop_dir: String,
     stash_db_path: String,
+    agentloop_path: String,
     prev_stats_db: Option<std::ffi::OsString>,
     prev_stash_db: Option<std::ffi::OsString>,
     prev_sls_path: Option<std::ffi::OsString>,
+    prev_agentloop_path: Option<std::ffi::OsString>,
 }
 
 impl TempDbGuard {
@@ -37,24 +40,39 @@ impl TempDbGuard {
         let sls_path = format!("{sls_dir}/tokenless.jsonl");
         // Pre-create the JSONL file so SlsWriter::write can open it.
         std::fs::write(&sls_path, "").unwrap();
+        let agentloop_dir = format!("/tmp/tokenless-agentloop-test-{nanos}");
+        std::fs::create_dir_all(&agentloop_dir).unwrap();
+        let agentloop_path = format!("{agentloop_dir}/tokenless.jsonl");
+        // Pre-create the JSONL file so AgentLoopWriter::write can open it.
+        std::fs::write(&agentloop_path, "").unwrap();
         let prev_stats_db = std::env::var_os("TOKENLESS_STATS_DB");
         let prev_stash_db = std::env::var_os("TOKENLESS_STASH_DB");
         let prev_sls_path = std::env::var_os("TOKENLESS_SLS_PATH");
+        let prev_agentloop_path = std::env::var_os("TOKENLESS_AGENTLOOP_PATH");
         unsafe {
             std::env::set_var("TOKENLESS_STATS_DB", format!("{test_dir}/stats.db"));
             std::env::set_var("TOKENLESS_STASH_DB", format!("{test_dir}/stash.db"));
             std::env::set_var("TOKENLESS_SLS_PATH", &sls_path);
+            std::env::set_var("TOKENLESS_AGENTLOOP_PATH", &agentloop_path);
         }
         let stash_db_path = format!("{test_dir}/stash.db");
         Some(TempDbGuard {
             _lock: lock,
             test_dir,
             sls_dir,
+            agentloop_dir,
             stash_db_path,
+            agentloop_path,
             prev_stats_db,
             prev_stash_db,
             prev_sls_path,
+            prev_agentloop_path,
         })
+    }
+
+    /// Returns the temp AgentLoop JSONL path, useful for feed assertions.
+    fn agentloop_path(&self) -> &str {
+        &self.agentloop_path
     }
 
     /// Returns the temp stash DB path, useful for override-path tests.
@@ -70,6 +88,7 @@ struct PersistConfigGuard {
     prev_stats: Option<std::ffi::OsString>,
     prev_sls: Option<std::ffi::OsString>,
     prev_compression: Option<std::ffi::OsString>,
+    prev_agentloop: Option<std::ffi::OsString>,
 }
 
 impl PersistConfigGuard {
@@ -87,10 +106,14 @@ impl PersistConfigGuard {
         let prev_stats = std::env::var_os("TOKENLESS_STATS_ENABLED");
         let prev_sls = std::env::var_os("TOKENLESS_SLS_ENABLED");
         let prev_compression = std::env::var_os("TOKENLESS_COMPRESSION_ENABLED");
+        let prev_agentloop = std::env::var_os("TOKENLESS_AGENTLOOP_ENABLED");
         unsafe {
             std::env::set_var("TOKENLESS_STATS_ENABLED", stats_env);
             std::env::set_var("TOKENLESS_SLS_ENABLED", sls_env);
             std::env::set_var("TOKENLESS_COMPRESSION_ENABLED", compression_env);
+            // These cases assert on stats/sls/compression only; an ambient
+            // AgentLoop override must not leak in through `TokenlessConfig::load`.
+            std::env::remove_var("TOKENLESS_AGENTLOOP_ENABLED");
         }
         Self {
             _lock: lock,
@@ -99,6 +122,7 @@ impl PersistConfigGuard {
             prev_stats,
             prev_sls,
             prev_compression,
+            prev_agentloop,
         }
     }
 
@@ -123,6 +147,10 @@ impl Drop for PersistConfigGuard {
                 Some(v) => std::env::set_var("TOKENLESS_COMPRESSION_ENABLED", v),
                 None => std::env::remove_var("TOKENLESS_COMPRESSION_ENABLED"),
             }
+            match &self.prev_agentloop {
+                Some(v) => std::env::set_var("TOKENLESS_AGENTLOOP_ENABLED", v),
+                None => std::env::remove_var("TOKENLESS_AGENTLOOP_ENABLED"),
+            }
         }
     }
 }
@@ -142,9 +170,14 @@ impl Drop for TempDbGuard {
                 Some(v) => std::env::set_var("TOKENLESS_SLS_PATH", v),
                 None => std::env::remove_var("TOKENLESS_SLS_PATH"),
             }
+            match &self.prev_agentloop_path {
+                Some(v) => std::env::set_var("TOKENLESS_AGENTLOOP_PATH", v),
+                None => std::env::remove_var("TOKENLESS_AGENTLOOP_PATH"),
+            }
         }
         std::fs::remove_dir_all(&self.test_dir).ok();
         std::fs::remove_dir_all(&self.sls_dir).ok();
+        std::fs::remove_dir_all(&self.agentloop_dir).ok();
     }
 }
 
@@ -556,6 +589,7 @@ fn record_compression_stats_skips_when_both_disabled() {
     let config = TokenlessConfig {
         stats_enabled: false,
         sls_enabled: false,
+        agentloop_enabled: false,
         ..TokenlessConfig::default()
     };
     // Should return immediately without touching DB
@@ -1263,11 +1297,13 @@ fn stats_persist_snapshot_enable_keeps_file_compression_and_sls() {
     let file = TokenlessConfig {
         stats_enabled: false,
         sls_enabled: true,
+        agentloop_enabled: true,
         compression_enabled: true,
     };
     let persisted = stats_persist_snapshot(file, true);
     assert!(persisted.stats_enabled);
     assert!(persisted.sls_enabled);
+    assert!(persisted.agentloop_enabled);
     assert!(persisted.compression_enabled);
 }
 
@@ -1276,11 +1312,13 @@ fn stats_persist_snapshot_disable_keeps_file_compression_and_sls() {
     let file = TokenlessConfig {
         stats_enabled: true,
         sls_enabled: false,
+        agentloop_enabled: false,
         compression_enabled: false,
     };
     let persisted = stats_persist_snapshot(file, false);
     assert!(!persisted.stats_enabled);
     assert!(!persisted.sls_enabled);
+    assert!(!persisted.agentloop_enabled);
     assert!(!persisted.compression_enabled);
 }
 
@@ -1577,7 +1615,12 @@ fn open_stash_store_or_err_none_returns_ok() {
 #[test]
 fn record_compression_stats_sls_only_path() {
     let _guard = match TempDbGuard::new() { Some(g) => g, None => return };
-    let config = TokenlessConfig { stats_enabled: false, sls_enabled: true, ..Default::default() };
+    let config = TokenlessConfig {
+        stats_enabled: false,
+        sls_enabled: true,
+        agentloop_enabled: false,
+        ..Default::default()
+    };
     let long_before = "x".repeat(500);
     let short_after = "y".repeat(50);
     record_compression_stats(
@@ -1599,7 +1642,12 @@ fn record_compression_stats_sls_only_path() {
 #[test]
 fn record_compression_stats_full_path() {
     let _guard = match TempDbGuard::new() { Some(g) => g, None => return };
-    let config = TokenlessConfig { stats_enabled: true, sls_enabled: true, ..Default::default() };
+    let config = TokenlessConfig {
+        stats_enabled: true,
+        sls_enabled: true,
+        agentloop_enabled: false,
+        ..Default::default()
+    };
     let long_before = "z".repeat(1000);
     let short_after = "w".repeat(100);
     record_compression_stats(
@@ -1616,6 +1664,128 @@ fn record_compression_stats_full_path() {
         Some(1),
         Some(200),
     );
+}
+
+#[test]
+fn record_compression_stats_writes_agentloop_feed_only() {
+    // AgentLoop-only: SQLite and SLS off, so the single appended line proves
+    // the feed is wired independently of the other two sinks.
+    let guard = match TempDbGuard::new() {
+        Some(g) => g,
+        None => return,
+    };
+    let config = TokenlessConfig {
+        stats_enabled: false,
+        sls_enabled: false,
+        agentloop_enabled: true,
+        ..Default::default()
+    };
+    record_compression_stats(
+        &config,
+        &DatabasePathResolver::default(),
+        OperationType::CompressResponse,
+        Some("agentcore".to_string()),
+        Some("conv-1".to_string()),
+        Some("call-1".to_string()),
+        "x".repeat(500),
+        "y".repeat(50),
+        CompressionMode::Active,
+        None,
+        None,
+        None,
+    );
+
+    let lines: Vec<String> = std::fs::read_to_string(guard.agentloop_path())
+        .unwrap()
+        .lines()
+        .map(str::to_string)
+        .collect();
+    assert_eq!(lines.len(), 1, "exactly one AgentLoop record expected");
+
+    let record: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+    // Trajectory correlation identity AgentLoop joins on.
+    assert_eq!(record["conversation_id"], "conv-1");
+    assert_eq!(record["tool_call_id"], "call-1");
+    assert_eq!(record["agent_name"], "agentcore");
+    assert_eq!(record["event_type"], "tokenless.token_savings");
+    assert_eq!(record["operation"], "compress-response");
+    assert_eq!(record["mode"], "active");
+    assert!(record["tokens_saved"].as_u64().unwrap() > 0);
+    // Metrics only — the payload text must never reach the feed.
+    assert!(record.get("before_text").is_none());
+    assert!(record.get("after_text").is_none());
+}
+
+#[test]
+fn record_compression_stats_skips_agentloop_feed_when_disabled() {
+    let guard = match TempDbGuard::new() {
+        Some(g) => g,
+        None => return,
+    };
+    let config = TokenlessConfig {
+        stats_enabled: false,
+        sls_enabled: true,
+        agentloop_enabled: false,
+        ..Default::default()
+    };
+    record_compression_stats(
+        &config,
+        &DatabasePathResolver::default(),
+        OperationType::CompressResponse,
+        Some("agentcore".to_string()),
+        Some("conv-1".to_string()),
+        Some("call-1".to_string()),
+        "x".repeat(500),
+        "y".repeat(50),
+        CompressionMode::Active,
+        None,
+        None,
+        None,
+    );
+
+    assert!(
+        std::fs::read_to_string(guard.agentloop_path())
+            .unwrap()
+            .trim()
+            .is_empty(),
+        "disabled AgentLoop feed must not be written"
+    );
+}
+
+#[test]
+fn record_compression_stats_labels_dryrun_in_agentloop_feed() {
+    // AgentLoop must be able to tell predicted savings from billed ones.
+    let guard = match TempDbGuard::new() {
+        Some(g) => g,
+        None => return,
+    };
+    let config = TokenlessConfig {
+        stats_enabled: false,
+        sls_enabled: false,
+        agentloop_enabled: true,
+        ..Default::default()
+    };
+    record_compression_stats(
+        &config,
+        &DatabasePathResolver::default(),
+        OperationType::CompressSchema,
+        Some("agentcore".to_string()),
+        None,
+        None,
+        "x".repeat(500),
+        "y".repeat(50),
+        CompressionMode::DryRun,
+        None,
+        None,
+        None,
+    );
+
+    let content = std::fs::read_to_string(guard.agentloop_path()).unwrap();
+    let record: serde_json::Value = serde_json::from_str(content.lines().next().unwrap()).unwrap();
+    assert_eq!(record["mode"], "dry-run");
+    // Absent identities stay absent instead of serializing as null.
+    assert!(record.get("conversation_id").is_none());
+    assert!(record.get("tool_call_id").is_none());
 }
 
 #[test]

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -482,6 +482,7 @@ fn compress_response_cli_matches_runtime_library() {
         .env("TOKENLESS_COMPRESSION_ENABLED", "1")
         .env("TOKENLESS_STATS_ENABLED", "0")
         .env("TOKENLESS_SLS_ENABLED", "0")
+        .env("TOKENLESS_AGENTLOOP_ENABLED", "0")
         .args([
             "compress-response",
             "--truncate-arrays-at",
@@ -521,6 +522,7 @@ fn compress_response_stats_use_unicode_aware_estimates() {
         .env("TOKENLESS_COMPRESSION_ENABLED", "1")
         .env("TOKENLESS_STATS_ENABLED", "1")
         .env("TOKENLESS_SLS_ENABLED", "0")
+        .env("TOKENLESS_AGENTLOOP_ENABLED", "0")
         .args([
             "compress-response",
             "--truncate-strings-at",
@@ -572,6 +574,7 @@ fn dry_run_no_savings_keeps_the_no_savings_warning() {
         .env("TOKENLESS_COMPRESSION_ENABLED", "0")
         .env("TOKENLESS_STATS_ENABLED", "0")
         .env("TOKENLESS_SLS_ENABLED", "0")
+        .env("TOKENLESS_AGENTLOOP_ENABLED", "0")
         .args(["compress-response", "--no-stash"])
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -848,7 +851,8 @@ fn retrieve_records_events_and_summary_reports_attribution() {
             .command()
             .env("TOKENLESS_COMPRESSION_ENABLED", "1")
             .env("TOKENLESS_STATS_ENABLED", "1")
-            .env("TOKENLESS_SLS_ENABLED", "0"),
+            .env("TOKENLESS_SLS_ENABLED", "0")
+            .env("TOKENLESS_AGENTLOOP_ENABLED", "0"),
         &["compress"],
         &request.to_string(),
     );
@@ -1132,6 +1136,7 @@ fn run_compress_toon(
         .env("TOKENLESS_COMPRESSION_ENABLED", compression_enabled)
         .env("TOKENLESS_STATS_ENABLED", "1")
         .env("TOKENLESS_SLS_ENABLED", "0")
+        .env("TOKENLESS_AGENTLOOP_ENABLED", "0")
         .args([
             "compress-toon",
             "--agent-id",
@@ -1818,7 +1823,8 @@ fn compress_post_tool_uses_the_v2_result_envelope() {
             .command()
             .env("TOKENLESS_COMPRESSION_ENABLED", "1")
             .env("TOKENLESS_STATS_ENABLED", "0")
-            .env("TOKENLESS_SLS_ENABLED", "0"),
+            .env("TOKENLESS_SLS_ENABLED", "0")
+            .env("TOKENLESS_AGENTLOOP_ENABLED", "0"),
         &["compress"],
         &post_tool_request_json(&content, false, "v2-post-tool"),
     );
@@ -1859,7 +1865,8 @@ fn compress_post_tool_dry_run_previews_record_reduction_without_stash_writes() {
             .command()
             .env("TOKENLESS_COMPRESSION_ENABLED", "0")
             .env("TOKENLESS_STATS_ENABLED", "0")
-            .env("TOKENLESS_SLS_ENABLED", "0"),
+            .env("TOKENLESS_SLS_ENABLED", "0")
+            .env("TOKENLESS_AGENTLOOP_ENABLED", "0"),
         &["compress"],
         &post_tool_request_json(&content, true, "record-dry-run"),
     );
@@ -1925,7 +1932,8 @@ fn compress_post_tool_reduces_and_restores_build_logs() {
             .command()
             .env("TOKENLESS_COMPRESSION_ENABLED", "1")
             .env("TOKENLESS_STATS_ENABLED", "0")
-            .env("TOKENLESS_SLS_ENABLED", "0"),
+            .env("TOKENLESS_SLS_ENABLED", "0")
+            .env("TOKENLESS_AGENTLOOP_ENABLED", "0"),
         &["compress"],
         &build_log_request(&content, "success", "build-log"),
     );
@@ -1976,7 +1984,8 @@ fn compress_post_tool_error_build_log_stays_original_with_diagnosis() {
             .command()
             .env("TOKENLESS_COMPRESSION_ENABLED", "1")
             .env("TOKENLESS_STATS_ENABLED", "0")
-            .env("TOKENLESS_SLS_ENABLED", "0"),
+            .env("TOKENLESS_SLS_ENABLED", "0")
+            .env("TOKENLESS_AGENTLOOP_ENABLED", "0"),
         &["compress"],
         &build_log_request(&content, "error", "build-log-error"),
     );

--- a/src/tokenless/crates/tokenless-protocol/src/lib.rs
+++ b/src/tokenless/crates/tokenless-protocol/src/lib.rs
@@ -117,16 +117,35 @@ impl Operation {
 }
 
 /// Attribution shared by lifecycle operations.
+///
+/// Hosts that report their trajectories to an agent observability backend
+/// (AgentLoop, via the ATIF trajectory vocabulary) name these identities
+/// `conversation_id` and `tool_call_id`. Both spellings are accepted on input
+/// so such a host can bind tokenless to the exact identity it already reports
+/// without a translation layer; tokenless always serializes its own names, so
+/// the emitted wire contract is unchanged. Supplying both spellings for the
+/// same identity is rejected as a duplicate field rather than silently
+/// picking one.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Attribution {
     /// Stable agent or adapter identifier.
     pub agent_id: String,
     /// Conversation identifier when supplied by the host.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Also accepted as `conversation_id` (trajectory vocabulary).
+    #[serde(
+        default,
+        alias = "conversation_id",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub session_id: Option<String>,
     /// Tool-call identifier when supplied by the host.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Also accepted as `tool_call_id` (trajectory vocabulary).
+    #[serde(
+        default,
+        alias = "tool_call_id",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub tool_use_id: Option<String>,
 }
 

--- a/src/tokenless/crates/tokenless-protocol/tests/protocol_tests.rs
+++ b/src/tokenless/crates/tokenless-protocol/tests/protocol_tests.rs
@@ -218,3 +218,100 @@ fn response_operation_must_match_request() {
         Err(ProtocolError::OperationMismatch { .. })
     ));
 }
+
+#[test]
+fn attribution_accepts_trajectory_identity_names() {
+    // A host that reports trajectories to an agent observability backend
+    // names these identities conversation_id / tool_call_id. It must be able
+    // to bind tokenless to the exact identity it already reports.
+    let attribution: Attribution = serde_json::from_str(
+        r#"{"agent_id":"agentcore","conversation_id":"conv-1","tool_call_id":"call-1"}"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        attribution,
+        Attribution {
+            agent_id: "agentcore".into(),
+            session_id: Some("conv-1".into()),
+            tool_use_id: Some("call-1".into()),
+        }
+    );
+}
+
+#[test]
+fn attribution_serializes_its_own_identity_names() {
+    // The alias is input-only: the emitted wire contract stays session_id /
+    // tool_use_id so existing adapters and stored requests are unaffected.
+    let json = serde_json::to_value(attribution()).unwrap();
+
+    assert_eq!(json["session_id"], "session-1");
+    assert_eq!(json["tool_use_id"], "call-1");
+    assert!(json.get("conversation_id").is_none());
+    assert!(json.get("tool_call_id").is_none());
+}
+
+#[test]
+fn attribution_rejects_both_spellings_of_one_identity() {
+    // Ambiguous input must fail loudly rather than silently pick a side.
+    let error = serde_json::from_str::<Attribution>(
+        r#"{"agent_id":"agentcore","session_id":"s-1","conversation_id":"c-1"}"#,
+    )
+    .unwrap_err();
+
+    assert!(
+        error.to_string().contains("duplicate field"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn attribution_still_rejects_unknown_fields() {
+    let error =
+        serde_json::from_str::<Attribution>(r#"{"agent_id":"agentcore","trajectory_id":"t-1"}"#)
+            .unwrap_err();
+
+    assert!(
+        error.to_string().contains("unknown field"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn request_envelope_accepts_trajectory_spelled_attribution() {
+    // End-to-end shape a host that reports trajectories to an agent
+    // observability backend sends: the envelope carries conversation_id /
+    // tool_call_id instead of session_id / tool_use_id. The operation payload
+    // is taken from a real round-trip so this case stays focused on
+    // attribution naming.
+    let native = RequestEnvelope {
+        attribution: Attribution {
+            agent_id: "agentcore".into(),
+            session_id: Some("conv-1".into()),
+            tool_use_id: Some("call-1".into()),
+        },
+        request: Request::PreTool(PreToolRequest {
+            tool_name: "Bash".into(),
+            arguments: json!({"command": "git status"}),
+            command_field: "command".into(),
+            capabilities: PreToolCapabilities {
+                replace_arguments: true,
+                block_and_suggest: false,
+            },
+        }),
+    };
+    let mut value: serde_json::Value = serde_json::from_str(&native.to_json().unwrap()).unwrap();
+    value["attribution"] = json!({
+        "agent_id": "agentcore",
+        "conversation_id": "conv-1",
+        "tool_call_id": "call-1",
+    });
+
+    let envelope = RequestEnvelope::from_json(&value.to_string()).unwrap();
+
+    assert_eq!(envelope.attribution.session_id.as_deref(), Some("conv-1"));
+    assert_eq!(envelope.attribution.tool_use_id.as_deref(), Some("call-1"));
+    assert_eq!(envelope.attribution.agent_id, "agentcore");
+    // The operation payload is untouched by the attribution spelling.
+    assert_eq!(envelope.request, native.request);
+}

--- a/src/tokenless/crates/tokenless-runtime/src/lib.rs
+++ b/src/tokenless/crates/tokenless-runtime/src/lib.rs
@@ -18,8 +18,9 @@ use tokenless_protocol::{
 };
 use tokenless_schema::SchemaCompressor;
 use tokenless_stats::{
-    CompressionMode, OperationType, SlsWriter, StatsRecord, StatsRecorder, ensure_state_dir,
-    estimate_tokens, get_home_dir, resolve_data_dir, validate_data_dir, validate_database_path,
+    AgentLoopWriter, CompressionMode, OperationType, SlsWriter, StatsRecord, StatsRecorder,
+    ensure_state_dir, estimate_tokens, get_home_dir, resolve_data_dir, validate_data_dir,
+    validate_database_path,
 };
 
 mod entry;
@@ -61,6 +62,10 @@ pub struct RuntimeConfig {
     pub stats_enabled: bool,
     /// Whether successful compression savings are emitted to the SLS writer.
     pub sls_enabled: bool,
+    /// Whether successful compression savings are emitted to the AgentLoop
+    /// observability writer, keyed by the trajectory correlation identity
+    /// (`conversation_id`, `tool_call_id`, agent name).
+    pub agentloop_enabled: bool,
     /// Whether compressed output is returned. Disabled mode calculates and
     /// records predicted savings but returns the original input.
     pub compression_enabled: bool,
@@ -72,6 +77,7 @@ impl Default for RuntimeConfig {
             data_dir: None,
             stats_enabled: true,
             sls_enabled: false,
+            agentloop_enabled: false,
             compression_enabled: true,
         }
     }
@@ -421,6 +427,7 @@ impl TokenlessRuntime {
             &outcome.artifact_keys,
             self.stats_recorder.as_ref(),
             self.config.sls_enabled,
+            self.config.agentloop_enabled,
         );
         Ok(outcome.response)
     }
@@ -466,6 +473,7 @@ impl TokenlessRuntime {
             &outcome.response.stash_keys,
             self.stats_recorder.as_ref(),
             self.config.sls_enabled,
+            self.config.agentloop_enabled,
         );
         Ok(outcome.response)
     }
@@ -544,7 +552,8 @@ impl TokenlessRuntime {
         result: &CompressResult,
         attribution: &Attribution,
     ) {
-        if !self.config.stats_enabled && !self.config.sls_enabled {
+        if !self.config.stats_enabled && !self.config.sls_enabled && !self.config.agentloop_enabled
+        {
             return;
         }
         let (after, after_tokens) = match result.disposition {
@@ -588,6 +597,9 @@ impl TokenlessRuntime {
         }
         if self.config.sls_enabled {
             SlsWriter::new().write(&record);
+        }
+        if self.config.agentloop_enabled {
+            AgentLoopWriter::new().write(&record);
         }
     }
 }
@@ -944,6 +956,7 @@ pub fn record_compression(
     outcome: &EntryOutcome,
     recorder: Option<&StatsRecorder>,
     sls_enabled: bool,
+    agentloop_enabled: bool,
 ) {
     let Some(stats) = outcome.stats.as_ref() else {
         return;
@@ -957,6 +970,7 @@ pub fn record_compression(
         &outcome.artifact_keys,
         recorder,
         sls_enabled,
+        agentloop_enabled,
     );
 }
 
@@ -972,8 +986,9 @@ fn record_entry_stats(
     stash_keys: &[String],
     recorder: Option<&StatsRecorder>,
     sls_enabled: bool,
+    agentloop_enabled: bool,
 ) {
-    if recorder.is_none() && !sls_enabled {
+    if recorder.is_none() && !sls_enabled && !agentloop_enabled {
         return;
     }
     let before_tokens = estimate_tokens(&stats.input);
@@ -1046,6 +1061,9 @@ fn record_entry_stats(
     }
     if sls_enabled {
         SlsWriter::new().write(&record);
+    }
+    if agentloop_enabled {
+        AgentLoopWriter::new().write(&record);
     }
 }
 

--- a/src/tokenless/crates/tokenless-stats/src/agentloop.rs
+++ b/src/tokenless/crates/tokenless-stats/src/agentloop.rs
@@ -1,0 +1,514 @@
+//! AgentLoop observability data model and writer for tokenless stats.
+//!
+//! AgentLoop is the agent observability and optimization backend that agent
+//! runtimes report their trajectories to. It joins evidence across components
+//! by the trajectory correlation identity (`conversation_id`, `tool_call_id`,
+//! agent name), which is why tokenless cannot simply hand AgentLoop its own
+//! `session_id` / `tool_use_id` names: the join keys have to match the
+//! trajectory vocabulary or the savings never attach to the right step.
+//!
+//! This module provides:
+//! - [`AgentLoopRecord`]: one token-savings event projected onto that
+//!   vocabulary, carrying metrics only — never the compressed text.
+//! - [`AgentLoopWriter`]: append-only JSONL writer with fail-silent
+//!   semantics, sharing the hardened collector sink with the SLS channel.
+//!
+//! The JSONL file is owned and lifecycle-managed by the ANOLISA collector
+//! infrastructure (it creates, rotates, and removes it). tokenless never
+//! creates, truncates, or deletes the file: on each [`AgentLoopWriter::write`]
+//! it appends only if the file already exists, and silently skips when it does
+//! not (treated as "AgentLoop collection not active").
+
+use crate::collector_sink::{append_json_line, resolve_collector_path};
+use crate::{StatsRecord, VERSION};
+use chrono::Utc;
+use serde::Serialize;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Default AgentLoop JSONL output path.
+///
+/// NOTE: the file and its parent directory are owned by the ANOLISA collector
+/// infrastructure. tokenless only appends to it when it already exists; it
+/// never creates the file or directory. Override the path via
+/// [`AGENTLOOP_PATH_ENV`] (must be under `/var/log/` or `/tmp/`, no `..`).
+pub const DEFAULT_AGENTLOOP_PATH: &str = "/var/log/anolisa/agentloop/ops/tokenless.jsonl";
+
+/// Environment variable that overrides [`DEFAULT_AGENTLOOP_PATH`].
+pub const AGENTLOOP_PATH_ENV: &str = "TOKENLESS_AGENTLOOP_PATH";
+
+/// Event type emitted for every recorded compression.
+///
+/// Namespaced by component so a shared AgentLoop ingest can tell tokenless
+/// savings apart from other components' events without a second field.
+pub const AGENTLOOP_EVENT_TYPE: &str = "tokenless.token_savings";
+
+/// Version of the [`AgentLoopRecord`] schema.
+///
+/// Bumped when a field is renamed, retyped, or removed. Additive optional
+/// fields do not require a bump, so consumers can pin the major layout.
+pub const AGENTLOOP_SCHEMA_VERSION: u32 = 1;
+
+/// Resolve the AgentLoop output path from an optional env var value.
+/// Falls back to [`DEFAULT_AGENTLOOP_PATH`] when the env var is unset, empty,
+/// or contains an invalid path. Returns the canonicalized path to narrow the
+/// TOCTOU window between validation and write.
+fn resolve_agentloop_path(env_val: Option<&str>) -> PathBuf {
+    resolve_collector_path(
+        "agentloop",
+        AGENTLOOP_PATH_ENV,
+        env_val,
+        DEFAULT_AGENTLOOP_PATH,
+    )
+}
+
+/// One tokenless token-savings event in AgentLoop's correlation vocabulary.
+///
+/// Field names are flat snake_case and the three join keys
+/// ([`AgentLoopRecord::conversation_id`], [`AgentLoopRecord::tool_call_id`],
+/// [`AgentLoopRecord::agent_name`]) use the trajectory names AgentLoop already
+/// indexes, so a savings event lands on the same conversation and tool call
+/// the runtime recorded.
+///
+/// Metrics only: the record never carries `before_text` / `after_text`, so an
+/// AgentLoop ingest cannot leak tool output or model context.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentLoopRecord {
+    /// [`AGENTLOOP_SCHEMA_VERSION`] of this record.
+    pub schema_version: u32,
+    /// [`AGENTLOOP_EVENT_TYPE`]; constant today, kept as a field so a shared
+    /// ingest can route without inspecting the file path.
+    pub event_type: String,
+    /// Record time in RFC 3339 UTC, converted from the local record timestamp
+    /// so trajectories collected in different time zones stay comparable.
+    pub timestamp: String,
+
+    /// Trajectory conversation identity (tokenless `session_id`). Absent when
+    /// the host did not supply one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_id: Option<String>,
+    /// Trajectory tool-call identity (tokenless `tool_use_id`). Absent for
+    /// operations that are not bound to a single tool call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    /// Agent or adapter that triggered the compression.
+    pub agent_name: String,
+
+    /// Emitting component; always `tokenless`.
+    pub component_name: String,
+    /// Emitting component version.
+    pub component_version: String,
+
+    /// Tokenless operation (`compress-schema`, `compress-response`,
+    /// `rewrite-command`, `compress-toon`).
+    pub operation: String,
+    /// Whether the savings were applied (`active`) or only predicted
+    /// (`dry-run`). AgentLoop must not bill dry-run savings as real.
+    pub mode: String,
+    /// PID of the process that performed the compression.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_pid: Option<i64>,
+
+    /// Characters before compression.
+    pub before_chars: usize,
+    /// Estimated tokens before compression.
+    pub before_tokens: usize,
+    /// Characters after compression.
+    pub after_chars: usize,
+    /// Estimated tokens after compression.
+    pub after_tokens: usize,
+    /// Characters saved (`before_chars - after_chars`).
+    pub chars_saved: usize,
+    /// Estimated tokens saved (`before_tokens - after_tokens`).
+    pub tokens_saved: usize,
+    /// Characters saved as a percentage of `before_chars` (0.0-100.0).
+    pub chars_saved_percent: f64,
+    /// Estimated tokens saved as a percentage of `before_tokens` (0.0-100.0).
+    pub tokens_saved_percent: f64,
+
+    /// Detected content taxonomy, when a detector ran.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+    /// Content origin declared by the adapter, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_origin: Option<String>,
+    /// Lifecycle operations that shaped the emitted content.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub applied_operations: Option<Vec<String>>,
+    /// Recovery state of the emitted content: whether the original can be
+    /// retrieved. AgentLoop uses this to tell a lossless saving from a lossy
+    /// one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recoverability: Option<String>,
+    /// Token counter identity used for the estimates.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tokenizer_id: Option<String>,
+    /// Truncations emitted without a recovery marker.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unrecoverable_truncations: Option<i64>,
+}
+
+impl From<&StatsRecord> for AgentLoopRecord {
+    fn from(r: &StatsRecord) -> Self {
+        Self {
+            schema_version: AGENTLOOP_SCHEMA_VERSION,
+            event_type: AGENTLOOP_EVENT_TYPE.to_string(),
+            timestamp: r.timestamp.with_timezone(&Utc).to_rfc3339(),
+            // The trajectory join keys. tokenless names them session_id /
+            // tool_use_id internally; AgentLoop names them conversation_id /
+            // tool_call_id. Same identity, AgentLoop's spelling.
+            conversation_id: r.session_id.clone(),
+            tool_call_id: r.tool_use_id.clone(),
+            agent_name: r.agent_id.clone(),
+            component_name: "tokenless".to_string(),
+            component_version: VERSION.to_string(),
+            operation: r.operation.as_str().to_string(),
+            mode: r.mode.as_str().to_string(),
+            source_pid: r.source_pid,
+            before_chars: r.before_chars,
+            before_tokens: r.before_tokens,
+            after_chars: r.after_chars,
+            after_tokens: r.after_tokens,
+            chars_saved: r.chars_saved(),
+            tokens_saved: r.tokens_saved(),
+            chars_saved_percent: r.chars_percent(),
+            tokens_saved_percent: r.tokens_percent(),
+            content_type: r.content_type.clone(),
+            content_origin: r.content_origin.clone(),
+            applied_operations: r.applied_operations.clone(),
+            recoverability: r.recoverability.clone(),
+            tokenizer_id: r.tokenizer_id.clone(),
+            unrecoverable_truncations: r.unrecoverable_truncations,
+        }
+    }
+}
+
+/// Writes [`AgentLoopRecord`] entries to a JSONL file (one JSON object per
+/// line).
+///
+/// Each [`AgentLoopWriter::write`] call opens the file append-only, writes one
+/// JSON line, then closes it (the file handle drops). Fail-silent: errors are
+/// printed to stderr at most once and never propagated, so observability can
+/// neither slow down nor fail a compression.
+pub struct AgentLoopWriter {
+    path: PathBuf,
+}
+
+impl Default for AgentLoopWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AgentLoopWriter {
+    /// Create a writer using the [`AGENTLOOP_PATH_ENV`] env var, falling back
+    /// to [`DEFAULT_AGENTLOOP_PATH`] if the env var is not set, empty, or
+    /// contains an invalid path.
+    pub fn new() -> Self {
+        let env_val = std::env::var(AGENTLOOP_PATH_ENV).ok();
+        Self {
+            path: resolve_agentloop_path(env_val.as_deref()),
+        }
+    }
+
+    /// Resolved output path. Exposed so `stats status` can report where
+    /// AgentLoop records would land.
+    #[must_use]
+    pub fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+
+    /// Create a writer with an explicit path (for testing).
+    /// NOTE: This bypasses the collector path validation — the caller is
+    /// responsible for ensuring the path is safe. Production code should use
+    /// [`AgentLoopWriter::new`].
+    #[cfg(test)]
+    pub(crate) fn with_path(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    /// Convert a [`StatsRecord`] to [`AgentLoopRecord`] and append it as a
+    /// JSON line.
+    ///
+    /// The JSONL file is owned by the ANOLISA collector infrastructure, which
+    /// is responsible for creating, rotating, and removing it. tokenless only
+    /// appends: when the file does not yet exist the write is silently skipped
+    /// (treated as "AgentLoop collection not active"); tokenless never creates,
+    /// truncates, or deletes the file or its parent directory.
+    pub fn write(&self, record: &StatsRecord) {
+        // Skip silently when the collector has not created the file yet.
+        if !self.path.exists() {
+            return;
+        }
+
+        let agentloop_record = AgentLoopRecord::from(record);
+        let line = match serde_json::to_string(&agentloop_record) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("tokenless-agentloop: serialization error: {e}");
+                return;
+            }
+        };
+
+        if let Err(e) = append_json_line(&self.path, &line) {
+            static WRITE_ERROR_WARNED: AtomicBool = AtomicBool::new(false);
+            if !WRITE_ERROR_WARNED.swap(true, Ordering::Relaxed) {
+                eprintln!(
+                    "tokenless-agentloop: write error to {}: {} \
+                     (further write errors suppressed)",
+                    self.path.display(),
+                    e
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::{CompressionMode, OperationType};
+    use std::fs;
+
+    fn make_record() -> StatsRecord {
+        StatsRecord::new(
+            OperationType::CompressResponse,
+            "copilot-shell".to_string(),
+            1000,
+            400,
+            500,
+            200,
+        )
+        .with_session_id("conv-123")
+        .with_tool_use_id("call_abc")
+        .with_source_pid(12345)
+    }
+
+    fn make_record_minimal() -> StatsRecord {
+        StatsRecord::new(
+            OperationType::CompressSchema,
+            "test-agent".to_string(),
+            200,
+            80,
+            100,
+            40,
+        )
+    }
+
+    #[test]
+    fn test_agentloop_record_maps_trajectory_join_keys() {
+        let record = AgentLoopRecord::from(&make_record());
+
+        assert_eq!(record.conversation_id.as_deref(), Some("conv-123"));
+        assert_eq!(record.tool_call_id.as_deref(), Some("call_abc"));
+        assert_eq!(record.agent_name, "copilot-shell");
+        assert_eq!(record.event_type, AGENTLOOP_EVENT_TYPE);
+        assert_eq!(record.schema_version, AGENTLOOP_SCHEMA_VERSION);
+        assert_eq!(record.component_name, "tokenless");
+        assert_eq!(record.component_version, VERSION);
+        assert_eq!(record.operation, "compress-response");
+        assert_eq!(record.mode, "active");
+        assert_eq!(record.source_pid, Some(12345));
+    }
+
+    #[test]
+    fn test_agentloop_record_carries_savings_metrics() {
+        let record = AgentLoopRecord::from(&make_record());
+
+        assert_eq!(record.before_chars, 1000);
+        assert_eq!(record.before_tokens, 400);
+        assert_eq!(record.after_chars, 500);
+        assert_eq!(record.after_tokens, 200);
+        assert_eq!(record.chars_saved, 500);
+        assert_eq!(record.tokens_saved, 200);
+        assert!((record.chars_saved_percent - 50.0).abs() < 0.01);
+        assert!((record.tokens_saved_percent - 50.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_agentloop_record_dry_run_mode_is_labelled() {
+        let mut stats = make_record();
+        stats.mode = CompressionMode::DryRun;
+        let record = AgentLoopRecord::from(&stats);
+
+        assert_eq!(record.mode, "dry-run");
+    }
+
+    #[test]
+    fn test_agentloop_record_mirrors_entry_metadata() {
+        let mut stats = make_record();
+        stats.content_type = Some("json".to_string());
+        stats.content_origin = Some("tool_result".to_string());
+        stats.applied_operations = Some(vec!["json_truncation".to_string()]);
+        stats.recoverability = Some("recoverable".to_string());
+        stats.tokenizer_id = Some("tokenless-estimator".to_string());
+        stats.unrecoverable_truncations = Some(2);
+        let record = AgentLoopRecord::from(&stats);
+
+        assert_eq!(record.content_type.as_deref(), Some("json"));
+        assert_eq!(record.content_origin.as_deref(), Some("tool_result"));
+        assert_eq!(
+            record.applied_operations.as_deref(),
+            Some(["json_truncation".to_string()].as_slice())
+        );
+        assert_eq!(record.recoverability.as_deref(), Some("recoverable"));
+        assert_eq!(record.tokenizer_id.as_deref(), Some("tokenless-estimator"));
+        assert_eq!(record.unrecoverable_truncations, Some(2));
+    }
+
+    #[test]
+    fn test_agentloop_record_timestamp_is_rfc3339_utc() {
+        let record = AgentLoopRecord::from(&make_record());
+
+        // RFC 3339 with an explicit UTC offset, e.g. 2026-09-07T01:02:03+00:00
+        assert!(
+            record.timestamp.ends_with("+00:00") || record.timestamp.ends_with('Z'),
+            "timestamp should be normalized to UTC: {}",
+            record.timestamp
+        );
+        assert!(
+            chrono::DateTime::parse_from_rfc3339(&record.timestamp).is_ok(),
+            "timestamp should parse as RFC 3339: {}",
+            record.timestamp
+        );
+    }
+
+    #[test]
+    fn test_agentloop_record_json_omits_absent_optionals() {
+        let json = serde_json::to_value(AgentLoopRecord::from(&make_record_minimal())).unwrap();
+
+        assert_eq!(json["schema_version"], AGENTLOOP_SCHEMA_VERSION);
+        assert_eq!(json["event_type"], AGENTLOOP_EVENT_TYPE);
+        assert_eq!(json["agent_name"], "test-agent");
+        assert_eq!(json["operation"], "compress-schema");
+        assert!(json.get("conversation_id").is_none());
+        assert!(json.get("tool_call_id").is_none());
+        assert!(json.get("source_pid").is_none());
+        assert!(json.get("content_type").is_none());
+        assert!(json.get("recoverability").is_none());
+    }
+
+    #[test]
+    fn test_agentloop_record_json_never_carries_text() {
+        let mut stats = make_record();
+        stats.before_text = Some("secret original payload".to_string());
+        stats.after_text = Some("secret compressed payload".to_string());
+        let json = serde_json::to_string(&AgentLoopRecord::from(&stats)).unwrap();
+
+        assert!(!json.contains("secret original payload"));
+        assert!(!json.contains("secret compressed payload"));
+        assert!(!json.contains("before_text"));
+        assert!(!json.contains("after_text"));
+    }
+
+    #[test]
+    fn test_agentloop_writer_default_trait() {
+        let _ = AgentLoopWriter::default();
+    }
+
+    #[test]
+    fn test_agentloop_writer_appends_jsonl() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agentloop.jsonl");
+        fs::write(&path, "").unwrap();
+
+        let writer = AgentLoopWriter::with_path(path.clone());
+        writer.write(&make_record());
+        writer.write(&make_record_minimal());
+
+        let lines: Vec<String> = fs::read_to_string(&path)
+            .unwrap()
+            .lines()
+            .map(str::to_string)
+            .collect();
+        assert_eq!(lines.len(), 2);
+
+        let first: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+        let second: serde_json::Value = serde_json::from_str(&lines[1]).unwrap();
+        assert_eq!(first["event_type"], AGENTLOOP_EVENT_TYPE);
+        assert_eq!(first["conversation_id"], "conv-123");
+        assert_eq!(first["tool_call_id"], "call_abc");
+        assert_eq!(second["agent_name"], "test-agent");
+    }
+
+    #[test]
+    fn test_agentloop_writer_skips_when_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agentloop.jsonl");
+
+        AgentLoopWriter::with_path(path.clone()).write(&make_record());
+
+        assert!(
+            !path.exists(),
+            "tokenless must not create the AgentLoop file"
+        );
+    }
+
+    #[test]
+    fn test_agentloop_writer_fail_silent_on_invalid_path() {
+        // A path in a directory that does not exist: the write must not panic
+        // and must not create anything.
+        let writer = AgentLoopWriter::with_path(PathBuf::from("/nonexistent-dir-xyz/out.jsonl"));
+        writer.write(&make_record());
+    }
+
+    #[test]
+    fn test_agentloop_writer_refuses_symlink_final_component() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.jsonl");
+        fs::write(&target, "").unwrap();
+        let link = dir.path().join("link.jsonl");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let before = fs::read_to_string(&target).unwrap();
+        AgentLoopWriter::with_path(link).write(&make_record());
+        let after = fs::read_to_string(&target).unwrap();
+
+        assert_eq!(before, after, "symlink target must not be modified");
+    }
+
+    #[test]
+    fn test_resolve_agentloop_path_default() {
+        assert_eq!(
+            resolve_agentloop_path(None),
+            PathBuf::from(DEFAULT_AGENTLOOP_PATH)
+        );
+    }
+
+    #[test]
+    fn test_resolve_agentloop_path_empty() {
+        assert_eq!(
+            resolve_agentloop_path(Some("")),
+            PathBuf::from(DEFAULT_AGENTLOOP_PATH)
+        );
+    }
+
+    #[test]
+    fn test_resolve_agentloop_path_rejects_parent_traversal() {
+        assert_eq!(
+            resolve_agentloop_path(Some("/var/log/../etc/tokenless.jsonl")),
+            PathBuf::from(DEFAULT_AGENTLOOP_PATH)
+        );
+    }
+
+    #[test]
+    fn test_resolve_agentloop_path_rejects_non_whitelisted_prefix() {
+        assert_eq!(
+            resolve_agentloop_path(Some("/etc/tokenless.jsonl")),
+            PathBuf::from(DEFAULT_AGENTLOOP_PATH)
+        );
+    }
+
+    #[test]
+    fn test_resolve_agentloop_path_accepts_valid_path() {
+        // Valid paths under /var/log/ or /tmp/ are accepted.
+        assert_eq!(
+            resolve_agentloop_path(Some("/var/log/custom/tokenless.jsonl")),
+            PathBuf::from("/var/log/custom/tokenless.jsonl")
+        );
+        assert_eq!(
+            resolve_agentloop_path(Some("/tmp/tokenless-agentloop.jsonl")),
+            PathBuf::from("/tmp/tokenless-agentloop.jsonl")
+        );
+    }
+}

--- a/src/tokenless/crates/tokenless-stats/src/collector_sink.rs
+++ b/src/tokenless/crates/tokenless-stats/src/collector_sink.rs
@@ -1,0 +1,256 @@
+//! Shared hardened JSONL sink for collector-owned observability files.
+//!
+//! Tokenless ships two external observability channels — the SLS ops feed and
+//! the AgentLoop token-savings feed. Both are append-only JSONL files whose
+//! lifecycle (create, rotate, remove) is owned by the ANOLISA collector
+//! infrastructure, never by tokenless. Because both files can land in
+//! world-writable locations, they share one path-validation and append
+//! implementation so the security properties cannot drift between channels.
+//!
+//! Contract shared by every caller:
+//! - tokenless appends only when the target file already exists; a missing
+//!   file means "collection not active" and is skipped silently.
+//! - tokenless never creates, truncates, or removes the file or its parent
+//!   directory.
+//! - all failures are reported on stderr at most once and never propagated:
+//!   observability must not block or fail a compression.
+
+use std::ffi::OsString;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+
+/// Allowed path prefixes for a collector sink path override.
+///
+/// NOTE: `/tmp/` is world-writable on most Unix systems — other local users
+/// can read the JSONL file if placed there. Prefer `/var/log/` for production.
+pub(crate) const ALLOWED_COLLECTOR_PREFIXES: &[&str] = &["/var/log/", "/tmp/"];
+
+/// Root-owned prefixes where creating a symlink requires privilege. For
+/// these, the original (pre-canonicalize) path can be trusted even when
+/// canonicalization resolves it elsewhere (e.g. `/var/log` symlinked to
+/// another filesystem). World-writable prefixes like `/tmp/` are excluded
+/// because an unprivileged user can place a symlink there to escape.
+pub(crate) const TRUSTED_COLLECTOR_PREFIXES: &[&str] = &["/var/log/"];
+
+/// Canonicalize a path, walking up the parent chain to resolve symlinks
+/// when the path or its ancestors don't exist yet. Returns the best-effort
+/// canonicalized path (falls back to the original if the entire chain is
+/// unresolvable).
+pub(crate) fn canonicalize_or_reconstruct(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| {
+        let mut cursor = path.to_path_buf();
+        let mut suffix: Vec<OsString> = Vec::new();
+        loop {
+            match cursor.canonicalize() {
+                Ok(canon) => {
+                    let mut result = canon;
+                    for name in suffix.iter().rev() {
+                        result.push(name);
+                    }
+                    return result;
+                }
+                Err(_) => {
+                    if let Some(name) = cursor.file_name() {
+                        suffix.push(name.to_os_string());
+                    }
+                    match cursor.parent() {
+                        Some(p) => cursor = p.to_path_buf(),
+                        None => return path.to_path_buf(),
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// Validate a collector sink path: reject `..` traversal and paths outside
+/// the allowed prefixes. Returns the canonicalized path if acceptable, or
+/// `None`.
+///
+/// Canonicalizes the path to resolve symlinks before the prefix check, so a
+/// symlinked `/var/log` → `/` cannot be used to escape the allowed
+/// directories. A path is accepted when the resolved path matches an allowed
+/// prefix, OR the original (pre-canonicalize) path matches a root-owned
+/// trusted prefix (see [`TRUSTED_COLLECTOR_PREFIXES`]).
+///
+/// The trusted-prefix fallback covers systems where `/var/log` is itself
+/// symlinked to another filesystem: canonicalization resolves it to the real
+/// target (no longer starting with `/var/log/`), but since creating that
+/// symlink requires root, trusting the original path is safe. The
+/// world-writable `/tmp/` prefix is excluded from the fallback, so a
+/// user-placed symlink in `/tmp/` cannot escape to an arbitrary location.
+///
+/// NOTE: callers store the canonicalized path at construction time to narrow
+/// the TOCTOU window between validation and write.
+pub(crate) fn validate_collector_path(path: &Path) -> Option<PathBuf> {
+    if path.components().any(|c| c == Component::ParentDir) {
+        return None;
+    }
+
+    let resolved = canonicalize_or_reconstruct(path);
+    let resolved_str = resolved.to_str().unwrap_or("");
+    let original_str = path.to_str().unwrap_or("");
+    let resolved_ok = ALLOWED_COLLECTOR_PREFIXES
+        .iter()
+        .any(|prefix| resolved_str.starts_with(prefix));
+    let original_ok = TRUSTED_COLLECTOR_PREFIXES
+        .iter()
+        .any(|prefix| original_str.starts_with(prefix));
+    if resolved_ok || original_ok {
+        Some(resolved)
+    } else {
+        None
+    }
+}
+
+/// Resolve a collector sink path from an optional env var value.
+///
+/// Falls back to `default_path` when the env var is unset, empty, or contains
+/// an invalid path. Returns the canonicalized path to narrow the TOCTOU
+/// window between validation and write. `channel` names the sink in the
+/// rejection warning so operators can tell the two channels apart.
+pub(crate) fn resolve_collector_path(
+    channel: &str,
+    env_name: &str,
+    env_val: Option<&str>,
+    default_path: &str,
+) -> PathBuf {
+    env_val
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .and_then(|p| match validate_collector_path(&p) {
+            Some(resolved) => Some(resolved),
+            None => {
+                eprintln!(
+                    "tokenless-{channel}: {env_name} rejected (must be under \
+                     /var/log/ or /tmp/, and must not contain '..'), \
+                     falling back to default: {default_path}"
+                );
+                None
+            }
+        })
+        .unwrap_or_else(|| PathBuf::from(default_path))
+}
+
+/// Append one already-serialized line (without a trailing newline) to a
+/// collector-owned JSONL file.
+///
+/// The caller must have decided that the file exists; this helper opens it
+/// append-only and refuses to follow a symlink in the final path component.
+///
+/// # Errors
+///
+/// Returns the underlying IO error. Callers report it once on stderr and
+/// continue — observability never fails a compression.
+pub(crate) fn append_json_line(path: &Path, line: &str) -> std::io::Result<()> {
+    let mut opts = OpenOptions::new();
+    opts.append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        // Refuse to open if the final path component is a symlink. The file
+        // is owned by the ANOLISA collector and tokenless never creates one,
+        // so a legit target is never a symlink here; O_NOFOLLOW blocks a
+        // swap-to-symlink between the existence check and the open (narrowing
+        // the TOCTOU window on /tmp/).
+        opts.custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = opts.open(path)?;
+    file.write_all(line.as_bytes())?;
+    file.write_all(b"\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_collector_path_accepts_trusted_var_log() {
+        // When /var/log is symlinked to another filesystem, canonicalization
+        // resolves it to the real target which no longer starts with
+        // /var/log/. Since /var/log is root-owned (creating the symlink needs
+        // privilege), the original path is trusted and the path is still
+        // accepted. Here /var/log is a real directory (no symlink), so both
+        // the original and reconstructed paths match the /var/log/ prefix.
+        let result = validate_collector_path(Path::new("/var/log/anolisa/ops/tokenless.jsonl"));
+        assert!(result.is_some());
+        let resolved = result.unwrap();
+        assert!(resolved.to_str().unwrap().starts_with("/var/log/"));
+    }
+
+    #[test]
+    fn test_validate_collector_path_rejects_parent_traversal() {
+        assert!(validate_collector_path(Path::new("/var/log/../../etc/passwd")).is_none());
+    }
+
+    #[test]
+    fn test_validate_collector_path_rejects_non_whitelisted_prefix() {
+        assert!(validate_collector_path(Path::new("/etc/cron.d/evil")).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_validate_collector_path_rejects_tmp_symlink_escape() {
+        // /tmp/ is world-writable, so an unprivileged user can place a
+        // symlink there that escapes the allowed prefixes (e.g. -> /etc).
+        // The path must be REJECTED: the resolved path no longer matches an
+        // allowed prefix, and /tmp/ is not a trusted prefix, so the original
+        // path must not be used as a fallback.
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("escape");
+        std::os::unix::fs::symlink("/etc", &link).unwrap();
+        let escaped = link.join("cron.d/evil.jsonl");
+        assert!(validate_collector_path(&escaped).is_none());
+    }
+
+    #[test]
+    fn test_resolve_collector_path_rejects_and_falls_back() {
+        assert_eq!(
+            resolve_collector_path(
+                "sls",
+                "TOKENLESS_SLS_PATH",
+                Some("/etc/evil.jsonl"),
+                "/var/log/anolisa/sls/ops/tokenless.jsonl"
+            ),
+            PathBuf::from("/var/log/anolisa/sls/ops/tokenless.jsonl")
+        );
+        assert_eq!(
+            resolve_collector_path(
+                "agentloop",
+                "TOKENLESS_AGENTLOOP_PATH",
+                Some(""),
+                "/var/log/anolisa/agentloop/ops/tokenless.jsonl"
+            ),
+            PathBuf::from("/var/log/anolisa/agentloop/ops/tokenless.jsonl")
+        );
+    }
+
+    #[test]
+    fn test_append_json_line_adds_newline_and_appends() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sink.jsonl");
+        std::fs::write(&path, "").unwrap();
+
+        append_json_line(&path, "{\"a\":1}").unwrap();
+        append_json_line(&path, "{\"a\":2}").unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "{\"a\":1}\n{\"a\":2}\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_append_json_line_refuses_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.jsonl");
+        std::fs::write(&target, "original\n").unwrap();
+        let link = dir.path().join("link.jsonl");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        assert!(append_json_line(&link, "{\"a\":1}").is_err());
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "original\n");
+    }
+}

--- a/src/tokenless/crates/tokenless-stats/src/config.rs
+++ b/src/tokenless/crates/tokenless-stats/src/config.rs
@@ -2,7 +2,8 @@
 //!
 //! Stored at `~/.tokenless/config.json`. Controls global feature flags.
 //! Environment variables `TOKENLESS_STATS_ENABLED`, `TOKENLESS_SLS_ENABLED`,
-//! and `TOKENLESS_COMPRESSION_ENABLED` override file config at runtime.
+//! `TOKENLESS_AGENTLOOP_ENABLED`, and `TOKENLESS_COMPRESSION_ENABLED` override
+//! file config at runtime.
 //! `tokenless stats enable` / `disable` persist from the file snapshot so
 //! those session overrides are not written back.
 
@@ -28,6 +29,13 @@ pub struct TokenlessConfig {
     /// each compression is also appended as a JSONL record for SLS ingestion.
     #[serde(default = "default_true")]
     pub sls_enabled: bool,
+    /// Whether the AgentLoop observability feed is enabled (default: true).
+    /// When enabled, each compression is also appended as a JSONL record
+    /// carrying the trajectory correlation identity AgentLoop joins on
+    /// (`conversation_id`, `tool_call_id`, agent name). Like the SLS feed the
+    /// file is collector-owned: records are appended only when it exists.
+    #[serde(default = "default_true")]
+    pub agentloop_enabled: bool,
     /// Whether compression is actually applied (default: true).
     /// When false, tokenless runs in dry-run mode: it computes and records
     /// the predicted savings but emits the original (uncompressed) text,
@@ -45,6 +53,7 @@ impl Default for TokenlessConfig {
         Self {
             stats_enabled: true,
             sls_enabled: true,
+            agentloop_enabled: true,
             compression_enabled: true,
         }
     }
@@ -114,9 +123,32 @@ impl TokenlessConfig {
         compression_env: Option<&str>,
         path: Option<&PathBuf>,
     ) -> Self {
-        Self::load_with_envs_and_file_reader(stats_env, sls_env, compression_env, path, |p| {
-            std::fs::read_to_string(p)
-        })
+        Self::load_with_all_envs_and_path(stats_env, sls_env, compression_env, None, path)
+    }
+
+    /// Load config with explicit env overrides for every toggle and an
+    /// optional custom path.
+    ///
+    /// Same priority as [`Self::load_with_envs_and_path`] — env > config.json
+    /// file > default, per toggle — extended with the AgentLoop feed toggle.
+    /// The file read is skipped only when *all four* env vars are present;
+    /// with fewer than four, the file is read so the remaining toggle can take
+    /// its stored value instead of silently falling back to the default.
+    pub fn load_with_all_envs_and_path(
+        stats_env: Option<&str>,
+        sls_env: Option<&str>,
+        compression_env: Option<&str>,
+        agentloop_env: Option<&str>,
+        path: Option<&PathBuf>,
+    ) -> Self {
+        Self::load_with_all_envs_and_file_reader(
+            stats_env,
+            sls_env,
+            compression_env,
+            agentloop_env,
+            path,
+            |p| std::fs::read_to_string(p),
+        )
     }
 
     /// Core logic of [`TokenlessConfig::load_with_envs_and_path`] with an
@@ -125,10 +157,11 @@ impl TokenlessConfig {
     /// assert whether the config file read was attempted at all — the returned
     /// config alone cannot distinguish the fast path from a failed read when
     /// every toggle is already determined by env.
-    fn load_with_envs_and_file_reader(
+    fn load_with_all_envs_and_file_reader(
         stats_env: Option<&str>,
         sls_env: Option<&str>,
         compression_env: Option<&str>,
+        agentloop_env: Option<&str>,
         path: Option<&PathBuf>,
         read_file: impl FnOnce(&std::path::Path) -> std::io::Result<String>,
     ) -> Self {
@@ -136,12 +169,16 @@ impl TokenlessConfig {
         let stats_env = stats_env.filter(|v| !v.is_empty());
         let sls_env = sls_env.filter(|v| !v.is_empty());
         let compression_env = compression_env.filter(|v| !v.is_empty());
+        let agentloop_env = agentloop_env.filter(|v| !v.is_empty());
 
-        // Fast path: all three toggles are determined by env — no file read needed.
-        if let (Some(s), Some(sl), Some(c)) = (stats_env, sls_env, compression_env) {
+        // Fast path: every toggle is determined by env — no file read needed.
+        if let (Some(s), Some(sl), Some(c), Some(al)) =
+            (stats_env, sls_env, compression_env, agentloop_env)
+        {
             return Self {
                 stats_enabled: parse_env_bool(s),
                 sls_enabled: parse_env_bool(sl),
+                agentloop_enabled: parse_env_bool(al),
                 compression_enabled: parse_env_bool(c),
             };
         }
@@ -165,6 +202,12 @@ impl TokenlessConfig {
             base.sls_enabled
         };
 
+        let agentloop_enabled = if let Some(val) = agentloop_env {
+            parse_env_bool(val)
+        } else {
+            base.agentloop_enabled
+        };
+
         let compression_enabled = if let Some(val) = compression_env {
             parse_env_bool(val)
         } else {
@@ -174,6 +217,7 @@ impl TokenlessConfig {
         Self {
             stats_enabled,
             sls_enabled,
+            agentloop_enabled,
             compression_enabled,
         }
     }
@@ -208,10 +252,14 @@ impl TokenlessConfig {
         let compression_env = std::env::var("TOKENLESS_COMPRESSION_ENABLED")
             .ok()
             .filter(|v| !v.is_empty());
-        Self::load_with_envs_and_path(
+        let agentloop_env = std::env::var("TOKENLESS_AGENTLOOP_ENABLED")
+            .ok()
+            .filter(|v| !v.is_empty());
+        Self::load_with_all_envs_and_path(
             stats_env.as_deref(),
             sls_env.as_deref(),
             compression_env.as_deref(),
+            agentloop_env.as_deref(),
             None,
         )
     }
@@ -223,7 +271,7 @@ impl TokenlessConfig {
     /// `TOKENLESS_COMPRESSION_ENABLED` into `config.json`, turning a
     /// temporary A/B dry-run into a durable setting.
     pub fn load_from_file() -> Self {
-        Self::load_with_envs_and_path(None, None, None, None)
+        Self::load_with_all_envs_and_path(None, None, None, None, None)
     }
 
     /// Save config to disk.
@@ -252,6 +300,12 @@ impl TokenlessConfig {
     /// Returns true if SLS integration is enabled (env override or file config).
     pub fn is_sls_enabled(&self) -> bool {
         self.sls_enabled
+    }
+
+    /// Returns true if the AgentLoop observability feed is enabled
+    /// (env override or file config).
+    pub fn is_agentloop_enabled(&self) -> bool {
+        self.agentloop_enabled
     }
 
     /// Returns true if compression is applied (env override or file config).

--- a/src/tokenless/crates/tokenless-stats/src/lib.rs
+++ b/src/tokenless/crates/tokenless-stats/src/lib.rs
@@ -4,6 +4,8 @@
 //! for Agent hook integrations. Records before/after data for
 //! schema compression, response compression, and command rewriting.
 
+pub mod agentloop;
+mod collector_sink;
 pub mod config;
 pub mod diff;
 pub mod home;
@@ -39,6 +41,8 @@ pub use path_policy::{
 };
 
 pub use sls::{SlsRecord, SlsWriter};
+
+pub use agentloop::{AgentLoopRecord, AgentLoopWriter};
 
 /// Library version
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/tokenless/crates/tokenless-stats/src/sls.rs
+++ b/src/tokenless/crates/tokenless-stats/src/sls.rs
@@ -9,10 +9,9 @@
 //! only if the file already exists, and silently skips when it does not
 //! (treated as "SLS collection not active").
 
+use crate::collector_sink::{append_json_line, resolve_collector_path};
 use crate::{StatsRecord, VERSION};
 use serde::Serialize;
-use std::fs::OpenOptions;
-use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -23,111 +22,15 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// (must be under /var/log/ or /tmp/, no `..`).
 pub const DEFAULT_SLS_PATH: &str = "/var/log/anolisa/sls/ops/tokenless.jsonl";
 
-/// Allowed path prefixes for TOKENLESS_SLS_PATH env var override.
-/// NOTE: /tmp/ is world-writable on most Unix systems — other local users
-/// can read the JSONL file if placed there. Prefer /var/log/ for production.
-const ALLOWED_SLS_PREFIXES: &[&str] = &["/var/log/", "/tmp/"];
-
-/// Root-owned prefixes where creating a symlink requires privilege. For
-/// these, the original (pre-canonicalize) path can be trusted even when
-/// canonicalization resolves it elsewhere (e.g. `/var/log` symlinked to
-/// another filesystem). World-writable prefixes like `/tmp/` are excluded
-/// because an unprivileged user can place a symlink there to escape.
-const TRUSTED_SLS_PREFIXES: &[&str] = &["/var/log/"];
-
-/// Canonicalize a path, walking up the parent chain to resolve symlinks
-/// when the path or its ancestors don't exist yet. Returns the best-effort
-/// canonicalized path (falls back to the original if the entire chain is
-/// unresolvable).
-fn canonicalize_or_reconstruct(path: &std::path::Path) -> PathBuf {
-    path.canonicalize().unwrap_or_else(|_| {
-        let mut cursor = path.to_path_buf();
-        let mut suffix: Vec<std::ffi::OsString> = Vec::new();
-        loop {
-            match cursor.canonicalize() {
-                Ok(canon) => {
-                    let mut result = canon;
-                    for name in suffix.iter().rev() {
-                        result.push(name);
-                    }
-                    return result;
-                }
-                Err(_) => {
-                    if let Some(name) = cursor.file_name() {
-                        suffix.push(name.to_os_string());
-                    }
-                    match cursor.parent() {
-                        Some(p) => cursor = p.to_path_buf(),
-                        None => return path.to_path_buf(),
-                    }
-                }
-            }
-        }
-    })
-}
-
-/// Validate an SLS output path: reject `..` traversal and paths outside
-/// allowed prefixes. Returns the canonicalized path if acceptable, or `None`.
-///
-/// Canonicalizes the path to resolve symlinks before the prefix check,
-/// so a symlinked `/var/log` → `/` cannot be used to escape the allowed
-/// directories. A path is accepted when the resolved path matches an
-/// allowed prefix, OR the original (pre-canonicalize) path matches a
-/// root-owned trusted prefix (see `TRUSTED_SLS_PREFIXES`).
-///
-/// The trusted-prefix fallback covers systems where `/var/log` is itself
-/// symlinked to another filesystem: canonicalization resolves it to the
-/// real target (no longer starting with `/var/log/`), but since creating
-/// that symlink requires root, trusting the original path is safe. The
-/// world-writable `/tmp/` prefix is excluded from the fallback, so a
-/// user-placed symlink in `/tmp/` cannot escape to an arbitrary location.
-///
-/// NOTE: `SlsWriter` stores the canonicalized path at construction time
-/// to narrow the TOCTOU window between validation and write.
-fn validate_sls_path(path: &std::path::Path) -> Option<PathBuf> {
-    if path
-        .components()
-        .any(|c| c == std::path::Component::ParentDir)
-    {
-        return None;
-    }
-
-    let resolved = canonicalize_or_reconstruct(path);
-    let resolved_str = resolved.to_str().unwrap_or("");
-    let original_str = path.to_str().unwrap_or("");
-    let resolved_ok = ALLOWED_SLS_PREFIXES
-        .iter()
-        .any(|prefix| resolved_str.starts_with(prefix));
-    let original_ok = TRUSTED_SLS_PREFIXES
-        .iter()
-        .any(|prefix| original_str.starts_with(prefix));
-    if resolved_ok || original_ok {
-        Some(resolved)
-    } else {
-        None
-    }
-}
+/// Environment variable that overrides [`DEFAULT_SLS_PATH`].
+pub const SLS_PATH_ENV: &str = "TOKENLESS_SLS_PATH";
 
 /// Resolve the SLS output path from an optional env var value.
 /// Falls back to DEFAULT_SLS_PATH when the env var is unset, empty,
 /// or contains an invalid path. Returns the canonicalized path
 /// to narrow the TOCTOU window between validation and write.
 fn resolve_sls_path(env_val: Option<&str>) -> PathBuf {
-    env_val
-        .filter(|v| !v.is_empty())
-        .map(PathBuf::from)
-        .and_then(|p| match validate_sls_path(&p) {
-            Some(resolved) => Some(resolved),
-            None => {
-                eprintln!(
-                    "tokenless-sls: TOKENLESS_SLS_PATH rejected (must be under \
-                     /var/log/ or /tmp/, and must not contain '..'), \
-                     falling back to default: {DEFAULT_SLS_PATH}"
-                );
-                None
-            }
-        })
-        .unwrap_or_else(|| PathBuf::from(DEFAULT_SLS_PATH))
+    resolve_collector_path("sls", SLS_PATH_ENV, env_val, DEFAULT_SLS_PATH)
 }
 
 /// SLS-specific data model with namespace-style field names.
@@ -238,7 +141,7 @@ impl SlsWriter {
     /// falling back to DEFAULT_SLS_PATH if the env var is not set,
     /// empty, or contains an invalid path.
     pub fn new() -> Self {
-        let env_val = std::env::var("TOKENLESS_SLS_PATH").ok();
+        let env_val = std::env::var(SLS_PATH_ENV).ok();
         Self {
             path: resolve_sls_path(env_val.as_deref()),
         }
@@ -274,22 +177,7 @@ impl SlsWriter {
             }
         };
 
-        let mut opts = OpenOptions::new();
-        opts.append(true);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-            // Refuse to open if the final path component is a symlink. The
-            // file is owned by the anolisa SLS component and tokenless never
-            // creates one, so a legit target is never a symlink here;
-            // O_NOFOLLOW blocks a swap-to-symlink between the existence
-            // check and the open (narrowing the TOCTOU window on /tmp/).
-            opts.custom_flags(libc::O_NOFOLLOW);
-        }
-        if let Err(e) = opts.open(&self.path).and_then(|mut f| {
-            f.write_all(line.as_bytes())?;
-            f.write_all(b"\n")
-        }) {
+        if let Err(e) = append_json_line(&self.path, &line) {
             static WRITE_ERROR_WARNED: AtomicBool = AtomicBool::new(false);
             if !WRITE_ERROR_WARNED.swap(true, Ordering::Relaxed) {
                 eprintln!(
@@ -626,36 +514,5 @@ mod tests {
             resolve_sls_path(Some("/tmp/tokenless-test.jsonl")),
             PathBuf::from("/tmp/tokenless-test.jsonl")
         );
-    }
-
-    #[test]
-    fn test_validate_sls_path_symlinked_prefix() {
-        // When /var/log is symlinked to another filesystem, canonicalization
-        // resolves it to the real target which no longer starts with
-        // /var/log/. Since /var/log is root-owned (creating the symlink needs
-        // privilege), the original path is trusted and the path is still
-        // accepted. Here /var/log is a real directory (no symlink), so both
-        // the original and reconstructed paths match the /var/log/ prefix.
-        let result = validate_sls_path(std::path::Path::new(
-            "/var/log/anolisa/sls/ops/tokenless.jsonl",
-        ));
-        assert!(result.is_some());
-        let resolved = result.unwrap();
-        assert!(resolved.to_str().unwrap().starts_with("/var/log/"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn test_validate_sls_path_rejects_tmp_symlink_escape() {
-        // /tmp/ is world-writable, so an unprivileged user can place a
-        // symlink there that escapes the allowed prefixes (e.g. -> /etc).
-        // The path must be REJECTED: the resolved path no longer matches an
-        // allowed prefix, and /tmp/ is not a trusted prefix, so the original
-        // path must not be used as a fallback.
-        let dir = tempfile::tempdir().unwrap();
-        let link = dir.path().join("escape");
-        std::os::unix::fs::symlink("/etc", &link).unwrap();
-        let escaped = link.join("cron.d/evil.jsonl");
-        assert!(validate_sls_path(&escaped).is_none());
     }
 }

--- a/src/tokenless/crates/tokenless-stats/src/tests/config_tests.rs
+++ b/src/tokenless/crates/tokenless-stats/src/tests/config_tests.rs
@@ -208,22 +208,25 @@ fn test_compression_config_honored_with_stats_sls_envs_unreadable_file() {
 
 #[test]
 fn test_all_envs_set_skips_file_read() {
-    // Fast path: when all three envs are present, the config file must not be
-    // read at all. Observe the read itself via an injected reader that records
-    // invocations and returns values opposite to the envs — asserting only the
-    // returned config is blind here, because env overrides every toggle even
-    // when the slow path falls back to defaults after a failed read.
+    // Fast path: when every toggle's env is present, the config file must not
+    // be read at all. Observe the read itself via an injected reader that
+    // records invocations and returns values opposite to the envs — asserting
+    // only the returned config is blind here, because env overrides every
+    // toggle even when the slow path falls back to defaults after a failed
+    // read.
     let path = std::path::PathBuf::from("/nonexistent/path/config.json");
     let read_attempted = std::cell::Cell::new(false);
-    let config = TokenlessConfig::load_with_envs_and_file_reader(
+    let config = TokenlessConfig::load_with_all_envs_and_file_reader(
         Some("true"),
+        Some("false"),
         Some("false"),
         Some("false"),
         Some(&path),
         |_p| {
             read_attempted.set(true);
             Ok(
-                "{\"stats_enabled\":false,\"sls_enabled\":true,\"compression_enabled\":true}"
+                "{\"stats_enabled\":false,\"sls_enabled\":true,\
+                 \"agentloop_enabled\":true,\"compression_enabled\":true}"
                     .to_string(),
             )
         },
@@ -234,6 +237,7 @@ fn test_all_envs_set_skips_file_read() {
     );
     assert!(config.is_stats_enabled());
     assert!(!config.is_sls_enabled());
+    assert!(!config.is_agentloop_enabled());
     assert!(!config.is_compression_enabled());
 }
 
@@ -245,9 +249,10 @@ fn test_partial_envs_attempt_file_read() {
     // test's !read_attempted assertion cannot pass vacuously.
     let path = std::path::PathBuf::from("/nonexistent/path/config.json");
     let read_attempted = std::cell::Cell::new(false);
-    let config = TokenlessConfig::load_with_envs_and_file_reader(
+    let config = TokenlessConfig::load_with_all_envs_and_file_reader(
         Some("true"),
         Some("true"),
+        None,
         None,
         Some(&path),
         |_p| {
@@ -265,6 +270,7 @@ fn test_partial_envs_attempt_file_read() {
     // Read failed → built-in default fills the gap: env > default preserved.
     assert!(config.is_stats_enabled());
     assert!(config.is_sls_enabled());
+    assert!(config.is_agentloop_enabled());
     assert!(config.is_compression_enabled());
 }
 
@@ -303,6 +309,7 @@ fn test_save_and_reload_roundtrip() {
     let config = TokenlessConfig {
         stats_enabled: false,
         sls_enabled: true,
+        agentloop_enabled: false,
         compression_enabled: false,
     };
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -312,6 +319,7 @@ fn test_save_and_reload_roundtrip() {
     let reloaded = TokenlessConfig::load_with_envs_and_path(None, None, None, Some(&path));
     assert!(!reloaded.stats_enabled);
     assert!(reloaded.sls_enabled);
+    assert!(!reloaded.agentloop_enabled);
     assert!(!reloaded.compression_enabled);
 }
 
@@ -320,6 +328,7 @@ fn test_default_all_enabled() {
     let config = TokenlessConfig::default();
     assert!(config.is_stats_enabled());
     assert!(config.is_sls_enabled());
+    assert!(config.is_agentloop_enabled());
     assert!(config.is_compression_enabled());
 }
 
@@ -328,13 +337,75 @@ fn test_serde_round_trip() {
     let config = TokenlessConfig {
         stats_enabled: false,
         sls_enabled: false,
+        agentloop_enabled: false,
         compression_enabled: true,
     };
     let json = serde_json::to_string(&config).unwrap();
     let deserialized: TokenlessConfig = serde_json::from_str(&json).unwrap();
     assert!(!deserialized.stats_enabled);
     assert!(!deserialized.sls_enabled);
+    assert!(!deserialized.agentloop_enabled);
     assert!(deserialized.compression_enabled);
+}
+
+#[test]
+fn test_agentloop_env_overrides_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.json");
+    let _ = std::fs::write(&path, "{\"agentloop_enabled\":false}");
+    let config =
+        TokenlessConfig::load_with_all_envs_and_path(None, None, None, Some("1"), Some(&path));
+    assert!(config.is_agentloop_enabled());
+}
+
+#[test]
+fn test_agentloop_file_config_honored() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.json");
+    let _ = std::fs::write(&path, "{\"agentloop_enabled\":false}");
+    let config =
+        TokenlessConfig::load_with_all_envs_and_path(None, None, None, None, Some(&path));
+    assert!(!config.is_agentloop_enabled());
+}
+
+#[test]
+fn test_agentloop_empty_env_treated_as_unset() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.json");
+    let _ = std::fs::write(&path, "{\"agentloop_enabled\":false}");
+    let config =
+        TokenlessConfig::load_with_all_envs_and_path(None, None, None, Some(""), Some(&path));
+    assert!(!config.is_agentloop_enabled());
+}
+
+#[test]
+fn test_legacy_config_without_agentloop_field_defaults_enabled() {
+    // Configs written before the AgentLoop feed existed have no
+    // `agentloop_enabled` key. The serde default must turn the feed on rather
+    // than silently disabling observability for upgraded installs.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.json");
+    let _ = std::fs::write(
+        &path,
+        "{\"stats_enabled\":true,\"sls_enabled\":true,\"compression_enabled\":true}",
+    );
+    let config =
+        TokenlessConfig::load_with_all_envs_and_path(None, None, None, None, Some(&path));
+    assert!(config.is_agentloop_enabled());
+}
+
+#[test]
+fn test_three_env_shim_leaves_agentloop_to_file() {
+    // The pre-AgentLoop 3-env entry point must stay source-compatible and
+    // still resolve the new toggle from the file instead of forcing a default.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.json");
+    let _ = std::fs::write(&path, "{\"agentloop_enabled\":false}");
+    let config = TokenlessConfig::load_with_envs_and_path(Some("1"), Some("1"), Some("1"), Some(&path));
+    assert!(config.is_stats_enabled());
+    assert!(config.is_sls_enabled());
+    assert!(config.is_compression_enabled());
+    assert!(!config.is_agentloop_enabled());
 }
 
 static CONFIG_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -344,6 +415,7 @@ struct ConfigPathEnvGuard {
     prev_stats: Option<std::ffi::OsString>,
     prev_sls: Option<std::ffi::OsString>,
     prev_compression: Option<std::ffi::OsString>,
+    prev_agentloop: Option<std::ffi::OsString>,
 }
 
 impl ConfigPathEnvGuard {
@@ -358,16 +430,22 @@ impl ConfigPathEnvGuard {
         let prev_stats = std::env::var_os("TOKENLESS_STATS_ENABLED");
         let prev_sls = std::env::var_os("TOKENLESS_SLS_ENABLED");
         let prev_compression = std::env::var_os("TOKENLESS_COMPRESSION_ENABLED");
+        let prev_agentloop = std::env::var_os("TOKENLESS_AGENTLOOP_ENABLED");
         unsafe {
             std::env::set_var("TOKENLESS_STATS_ENABLED", stats_env);
             std::env::set_var("TOKENLESS_SLS_ENABLED", sls_env);
             std::env::set_var("TOKENLESS_COMPRESSION_ENABLED", compression_env);
+            // Keep the AgentLoop toggle hermetic: these cases assert on
+            // stats/sls/compression only, so an ambient override must not
+            // leak in through `TokenlessConfig::load`.
+            std::env::remove_var("TOKENLESS_AGENTLOOP_ENABLED");
         }
         Self {
             _lock: lock,
             prev_stats,
             prev_sls,
             prev_compression,
+            prev_agentloop,
         }
     }
 }
@@ -387,6 +465,10 @@ impl Drop for ConfigPathEnvGuard {
             match &self.prev_compression {
                 Some(v) => std::env::set_var("TOKENLESS_COMPRESSION_ENABLED", v),
                 None => std::env::remove_var("TOKENLESS_COMPRESSION_ENABLED"),
+            }
+            match &self.prev_agentloop {
+                Some(v) => std::env::set_var("TOKENLESS_AGENTLOOP_ENABLED", v),
+                None => std::env::remove_var("TOKENLESS_AGENTLOOP_ENABLED"),
             }
         }
     }

--- a/src/tokenless/docs/response-compression.md
+++ b/src/tokenless/docs/response-compression.md
@@ -458,6 +458,8 @@ tokenless stats summary
 统计启用条件：`TOKENLESS_STATS_ENABLED` 环境变量未设为 `0`/`false`，或通过 `tokenless stats enable` 启用。
 
 > **SLS 日志记录（JSONL）**：除 SQLite 统计外，tokenless 默认还会将每次压缩以 SLS JSONL 记录写入 `/var/log/anolisa/sls/ops/tokenless.jsonl`（默认开启）。该文件由 **anolisa SLS 组件统一管理**，tokenless 不创建/删除，仅在文件存在时追加，不存在则跳过。开关字段 `~/.tokenless/config.json` 的 `sls_enabled`（默认 `true`），环境变量 `TOKENLESS_SLS_ENABLED` 优先；输出路径可用 `TOKENLESS_SLS_PATH` 覆盖（须位于 `/var/log/` 或 `/tmp/` 下）。仅记录度量，不含原文/敏感数据。详见 [Tokenless 效果度量 · SLS JSONL](../../../docs/user-guide/zh/token-saving/tokenless/measuring-savings.md#sls-jsonl)。
+>
+> **AgentLoop 可观测（JSONL）**：tokenless 还会把每次压缩以 AgentLoop JSONL 记录写入 `/var/log/anolisa/agentloop/ops/tokenless.jsonl`（默认开启），并携带轨迹关联标识 `conversation_id`、`tool_call_id`、`agent_name`，便于把节省归因到具体会话与工具调用。该文件同样由采集设施统一管理，tokenless 只在文件存在时追加。开关字段 `~/.tokenless/config.json` 的 `agentloop_enabled`（默认 `true`），环境变量 `TOKENLESS_AGENTLOOP_ENABLED` 优先；输出路径可用 `TOKENLESS_AGENTLOOP_PATH` 覆盖（须位于 `/var/log/` 或 `/tmp/` 下）。仅记录度量与标识，不含原文/敏感数据。详见 [Tokenless 效果度量 · AgentLoop 可观测](../../../docs/user-guide/zh/token-saving/tokenless/measuring-savings.md#agentloop-可观测)。
 
 ### 9.3 压缩效果说明
 

--- a/src/tokenless/python/tokenless/python/anolisa_tokenless/_native.pyi
+++ b/src/tokenless/python/tokenless/python/anolisa_tokenless/_native.pyi
@@ -55,6 +55,7 @@ class TokenlessRuntime:
         compression_enabled: bool = True,
         stats_enabled: bool = True,
         sls_enabled: bool = False,
+        agentloop_enabled: bool = False,
     ) -> None: ...
     def _before_model_json(
         self,

--- a/src/tokenless/python/tokenless/src/lib.rs
+++ b/src/tokenless/python/tokenless/src/lib.rs
@@ -281,18 +281,21 @@ impl PyTokenlessRuntime {
         *,
         compression_enabled=true,
         stats_enabled=true,
-        sls_enabled=false
+        sls_enabled=false,
+        agentloop_enabled=false
     ))]
     fn new(
         data_dir: Option<PathBuf>,
         compression_enabled: bool,
         stats_enabled: bool,
         sls_enabled: bool,
+        agentloop_enabled: bool,
     ) -> PyResult<Self> {
         let inner = NativeRuntime::new(RuntimeConfig {
             data_dir,
             stats_enabled,
             sls_enabled,
+            agentloop_enabled,
             compression_enabled,
         })
         .map_err(to_python_error)?;

--- a/src/tokenless/tests/contract/corpus.py
+++ b/src/tokenless/tests/contract/corpus.py
@@ -116,9 +116,10 @@ def run_hook(
             "PATH": bindir,
             "LC_ALL": "C.UTF-8",
             "TOKENLESS_DATA_DIR": os.path.join(home, ".tokenless"),
-            # Keep runs hermetic: no stats/SLS side channels; compression on.
+            # Keep runs hermetic: no stats/SLS/AgentLoop side channels; compression on.
             "TOKENLESS_STATS_ENABLED": "0",
             "TOKENLESS_SLS_ENABLED": "0",
+            "TOKENLESS_AGENTLOOP_ENABLED": "0",
         }
         env.update(agent_env)
         if extra_env:

--- a/src/tokenless/tests/release_regression/agentscope_probe.py
+++ b/src/tokenless/tests/release_regression/agentscope_probe.py
@@ -248,7 +248,13 @@ def main() -> None:
     if MANIFEST["live_requested"]:
         SECRET = Path("/run/tokenplan-key").read_text().strip()
         assert SECRET, "API key file is empty"
-    os.environ.update({"TOKENLESS_STATS_ENABLED": "1", "TOKENLESS_SLS_ENABLED": "0"})
+    os.environ.update(
+        {
+            "TOKENLESS_STATS_ENABLED": "1",
+            "TOKENLESS_SLS_ENABLED": "0",
+            "TOKENLESS_AGENTLOOP_ENABLED": "0",
+        }
+    )
     asyncio.run(exercise())
 
 

--- a/src/tokenless/tests/release_regression/probe.py
+++ b/src/tokenless/tests/release_regression/probe.py
@@ -50,6 +50,7 @@ def state_env(directory: Path) -> dict:
         "TOKENLESS_DATA_DIR": str(directory),
         "TOKENLESS_STATS_ENABLED": "1",
         "TOKENLESS_SLS_ENABLED": "0",
+        "TOKENLESS_AGENTLOOP_ENABLED": "0",
         "TOKENLESS_COMPRESSION_ENABLED": "1",
     }
 

--- a/src/tokenless/tests/test_rewrite_hook.py
+++ b/src/tokenless/tests/test_rewrite_hook.py
@@ -134,6 +134,7 @@ class HookLifecycleStateTest(unittest.TestCase):
             "TOKENLESS_AGENT_ID": "qoder-cli",
             "TOKENLESS_STATS_ENABLED": "0",
             "TOKENLESS_SLS_ENABLED": "0",
+            "TOKENLESS_AGENTLOOP_ENABLED": "0",
             "TOKENLESS_MOCK_BEHAVIOR": "applied",
             "TOKENLESS_MOCK_REQUEST_LOG": str(self.request_log),
         }
@@ -268,6 +269,7 @@ class RealCorePreToolTest(unittest.TestCase):
                 "TOKENLESS_AGENT_ID": "qoder-cli",
                 "TOKENLESS_STATS_ENABLED": "0",
                 "TOKENLESS_SLS_ENABLED": "0",
+                "TOKENLESS_AGENTLOOP_ENABLED": "0",
             }
             proc = subprocess.run(
                 [sys.executable, corpus.PRE_TOOL_HOOK],


### PR DESCRIPTION
## What changed

AgentCore uses AgentLoop as its agent observability backend, so tokenless compression savings need to reach AgentLoop keyed by the identity AgentLoop already indexes trajectories with. Two things blocked that today.

**1. The v2 lifecycle envelope rejected trajectory-spelled attribution.** `Attribution` is `deny_unknown_fields`, so a host sending `conversation_id` / `tool_call_id` failed the whole request and lost the compression. `Attribution` now accepts both spellings on input. It still serializes `session_id` / `tool_use_id`, so the emitted wire contract, existing adapters and stored requests are untouched. Sending both spellings for one identity is rejected as a duplicate field instead of being silently resolved.

**2. There was no channel carrying an AgentLoop-shaped savings event.** The SLS ops feed targets the anolisa SLS logstore with `component.*` / `tokenless.compression.*` names and has no dry-run discriminator, so AgentLoop could neither join a saving to a tool call nor tell a predicted saving from a billed one.

New in `tokenless-stats`:

- `agentloop.rs` — `AgentLoopRecord` / `AgentLoopWriter`. One JSONL line per recorded compression carrying `conversation_id`, `tool_call_id`, `agent_name`, the savings metrics, `mode` (`active` vs `dry-run`), and the recoverability signals. Metrics and identifiers only: `before_text` / `after_text` are never serialized, and a unit test pins that.
- `collector_sink.rs` — the hardened append-only JSONL sink both external feeds now share (`..` traversal rejection, `/var/log/` + `/tmp/` prefix allow-list, symlink canonicalization with the root-owned trusted-prefix fallback, `O_NOFOLLOW` on the final component). Extracted from `sls.rs` so the security properties cannot drift between channels; the existing SLS path-policy tests moved with the code they cover.
- `config.rs` — `agentloop_enabled` (default `true`) plus `TOKENLESS_AGENTLOOP_ENABLED`. A `config.json` written before this change has no such key and keeps the feed enabled via the serde default.

Wiring: `RuntimeConfig.agentloop_enabled` in `tokenless-runtime` (both the SDK `record_stats` path and the v2 `record_entry_stats` path), the CLI `record_compression_stats` path, `tokenless stats status` reporting, and the Python binding kwarg + `.pyi` stub.

### Collector-owned file, same contract as SLS

Tokenless never creates, truncates, or removes the file or its parent directory. It appends only when the file already exists and skips silently otherwise ("AgentLoop collection not active"), and every failure is reported on stderr at most once and never propagated — observability can neither slow down nor fail a compression.

Default path `/var/log/anolisa/agentloop/ops/tokenless.jsonl`, overridable with `TOKENLESS_AGENTLOOP_PATH` (validated to `/var/log/` or `/tmp/`, no `..`). As with the SLS ops file, provisioning, rotation, and upload belong to the collection infrastructure, not to tokenless; `TOKENLESS_AGENTLOOP_PATH` is the deployment seam for a collector that provisions its own path.

### Docs

`measuring-savings.md` (zh + en) gains an "AgentLoop observability" section covering the channel, the correlation-identity mapping table, the record fields, and a reproducible local check. `configuration-and-privacy.md` (zh + en) documents the toggle, both env vars, the storage-location row, and the fact that neither external feed carries original text. `cli-reference.md` (zh + en) and `src/tokenless/docs/response-compression.md` are updated where they enumerate the recording channels.

## 测试情况

### Environment

| Item | Value |
|------|-------|
| OS | Alibaba Cloud Linux 3 (kernel-based, glibc) |
| CPU arch | x86_64 |
| Rust toolchain | rustc 1.96.0 / cargo 1.96.0 |
| Python | 3.12.9 |
| Build profile | debug (`cargo test`), release not exercised |

### Commands actually run

All from the tokenless workspace root unless noted.

| Command | Result |
|---------|--------|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace -- -D warnings` | clean |
| `cargo clippy --all-targets --locked -- -D warnings` | clean |
| `cargo test --workspace -- --test-threads=1` | **772 passed, 0 failed, 3 ignored** |
| `benchmark/l1-compressor`: `cargo fmt --all -- --check` | clean |
| `benchmark/l1-compressor`: `cargo clippy --all-targets --locked -- -D warnings` | clean |
| `benchmark/l1-compressor`: `cargo test --locked` | 29 passed, 1 pre-existing abort (see below) |
| `benchmark/l2-module`: `cargo fmt --all -- --check` | clean |
| `benchmark/l2-module`: `cargo clippy --all-targets --locked -- -D warnings` | clean |
| `benchmark/l2-module`: `cargo test --locked` | **42 passed, 0 failed** |
| `make test-integration` (13 Python scripts) | 12/13 scripts green, 1 pre-existing failure (see below) |
| `scripts/docs-lint.sh` + `scripts/docs-link-check.py` | naming OK, en/zh tree parity OK, all relative links resolve |

Workspace suite breakdown (this branch):

| Suite | Passed |
|-------|--------|
| `tokenless_stats` | 180 (base 153, **+27**) |
| `tokenless-cli` unit (`main_tests`) | 219, 2 ignored (base 216, **+3**) |
| `cli_integration` | 61 |
| `tokenless_protocol::protocol_tests` | 11 (base 6, **+5**) |
| `tokenless_protocol::recovery_tests` | 3 |
| `tokenless_runtime` | 91 |
| `tokenless_schema` | 41 |
| `tokenless_compressors` | 79 |
| `tokenless_ccr` | 69 |
| others (`golden_test`, `cosh_extension_matcher_contract`, `integration_test`, native binding) | 18 |
| **Total** | **772 passed, 3 ignored, 0 failed** |

35 new Rust test cases in total.

### Verification of this change

Unit / integration coverage added:

- `AgentLoopRecord` maps `session_id`→`conversation_id`, `tool_use_id`→`tool_call_id`, `agent_id`→`agent_name`; savings metrics and percentages; `dry-run` labelling; entry metadata mirroring; RFC 3339 UTC timestamp; absent optionals omitted rather than `null`; **no `before_text` / `after_text` in the serialized record**.
- `AgentLoopWriter` appends JSONL, skips silently when the file is missing and does **not** create it, stays fail-silent on an unwritable path, and refuses a symlinked final component (target left byte-identical).
- Path resolution: default, empty override, `..` traversal rejected, non-allow-listed prefix rejected, valid `/var/log/` + `/tmp/` overrides accepted.
- Shared sink (`collector_sink`): the two relocated SLS path-policy cases (symlinked `/var/log` accepted via the trusted-prefix fallback; `/tmp/` symlink escape rejected) plus traversal/prefix/append/`O_NOFOLLOW` cases.
- Config: env-overrides-file, file-honored, empty-env-treated-as-unset, legacy config without `agentloop_enabled` keeps the feed on, and the pre-AgentLoop 3-env entry point stays source-compatible while still resolving the new toggle from the file.
- Protocol: trajectory-spelled attribution accepted, own names still serialized, both spellings rejected as duplicate, unknown fields still rejected, and a full `RequestEnvelope` parse with `conversation_id` / `tool_call_id` leaving the operation payload untouched.
- CLI: AgentLoop-only feed writes exactly one record with the right join keys; disabled feed writes nothing; dry-run is labelled `dry-run`.

End-to-end against the real built CLI (synthetic payload, collector-provisioned JSONL file, `TOKENLESS_AGENTLOOP_PATH` override):

1. Feed on, file present, SLS off → exactly one record appended; the SLS file stayed at 0 bytes, proving independent gating.
2. Feed off (`TOKENLESS_AGENTLOOP_ENABLED=0`) → file stayed empty.
3. Feed on, file absent (collector not deployed) → silently skipped, no file created.
4. v2 envelope path (`tokenless compress`, `post_tool`) with `conversation_id` / `tool_call_id` in `attribution` → accepted; the record carried both identities and the response envelope still echoed `session_id` / `tool_use_id`.
5. `tokenless stats status` → new `AgentLoop feed: ENABLED|DISABLED (via env override|config file|default)` line.

Sample record from step 4 (synthetic identifiers, generated payload):

```json
{
  "schema_version": 1,
  "event_type": "tokenless.token_savings",
  "timestamp": "2026-09-07T08:27:06.892765884+00:00",
  "conversation_id": "conv-9",
  "tool_call_id": "call-9",
  "agent_name": "agentcore",
  "component_name": "tokenless",
  "component_version": "0.8.0",
  "operation": "compress-response",
  "mode": "active",
  "before_chars": 7901,
  "before_tokens": 1976,
  "after_chars": 6067,
  "after_tokens": 1517,
  "chars_saved": 1834,
  "tokens_saved": 459,
  "chars_saved_percent": 23.21225161371978,
  "tokens_saved_percent": 23.228744939271255,
  "content_type": "json",
  "content_origin": "command_output",
  "applied_operations": ["json_record_reduction"],
  "recoverability": "retrievable",
  "tokenizer_id": "heuristic-v1"
}
```

### Failures observed, with root cause

Both were reproduced on a clean worktree of the base commit, so neither is caused by this change.

1. `benchmark/l1-compressor` → `l1_adversarial_schema::very_deep_nested_schema_does_not_overflow` aborts with `thread has overflowed its stack / fatal runtime error: stack overflow` (SIGABRT) after the other 13 cases in that file pass. Identical abort on the base commit. This change touches no file under `benchmark/`, `tokenless-schema`, `tokenless-compressors`, or `tokenless-ccr`; it is a debug-build stack-size sensitivity of the deeply nested schema fixture on this host.
2. `tests/test_hermes_plugin_import.py` → 11 ran, 2 failures + 1 error, all `ImportError: cannot import name 'build_post_tool_request' from 'hook_utils'`. The test resolves `hook_utils` from a **system-installed** older adapters tree rather than the repo copy, and that installed copy predates `build_post_tool_request`. Identical failure on the base commit. This change touches no adapter or `hook_utils` file.

### Not run, and why

- `make test-python-runtime` and `make test-agentscope-integration`: require `uv`, `just`, and the Rust 1.91.0 toolchain, none of which are available in this environment. The binding change is still compiled and linted by `cargo clippy --workspace --all-targets` / `cargo test --workspace` (the `tokenless-python` crate is a workspace member), and `_native.pyi` was updated in lockstep with the new kwarg.
- npm packaging smoke test: requires Node 20 plus the Rust 1.91.0 toolchain.
- End-to-end against a live AgentLoop endpoint: not reachable from this environment. The feed was instead verified against a collector-provisioned JSONL file through the documented `TOKENLESS_AGENTLOOP_PATH` override, which is the same contract the SLS channel is tested against.
- Release-profile runtime behaviour: only the debug profile was exercised.

### Compatibility

- All new wire fields are additive. `Attribution` serialization is unchanged; the alias is input-only.
- `TokenlessConfig` deserializes pre-existing `config.json` files (missing `agentloop_enabled` → enabled) and re-serializes with the new key.
- `load_with_envs_and_path` / `load_with_envs` / `load_with_env` / `load_with_env_and_path` keep their signatures; `load_with_all_envs_and_path` is the new 4-env entry point. The all-envs fast path now requires all four env vars, so a 3-env-only deployment reads the config file to resolve the fourth toggle — documented in `configuration-and-privacy.md`.
- `record_compression` gains one explicit `agentloop_enabled: bool` parameter, following the existing "explicit parameters avoid inventing a shared policy DTO" convention in that module rather than introducing a toggles struct.
- With the feed enabled but no collector provisioned, the cost is one `stat` per recorded compression and no write.
