### PR TITLE
fix(memory): sync catalog contract to 0.2.6

### DIFF
--- a/scripts/check-component-versions.py
+++ b/scripts/check-component-versions.py
@@ -19,6 +19,7 @@ VERSION_RE = re.compile(
     r'^\s*(?:"version"|version)\s*[:=]\s*"([^"]+)"\s*,?\s*$', re.MULTILINE
 )
 TOML_CONTRACTS = (
+    ("src/agent-memory/Cargo.toml", "src/anolisa/manifests/components/agent-memory/component.toml"),
     ("src/agent-sec-core/openclaw-plugin/package.json", "src/agent-sec-core/.anolisa/component.toml"),
     ("src/agentsight/Cargo.toml", "src/agentsight/component.toml"),
     ("src/agentsight/Cargo.toml", "src/agentsight/.anolisa/component.toml"),

--- a/src/anolisa/manifests/components/agent-memory/component.toml
+++ b/src/anolisa/manifests/components/agent-memory/component.toml
@@ -1,6 +1,6 @@
 [component]
 name = "agent-memory"
-version = "0.2.3"
+version = "0.2.6"
 layer = "runtime"
 domain = "state"
 display_name = "Agent Memory"


### PR DESCRIPTION
## What

`src/anolisa/manifests/components/agent-memory/component.toml` — the repo-side (bundled) copy of the agent-memory component contract — still declared `version = "0.2.3"` while `src/agent-memory/Cargo.toml` ships **0.2.6**.

This PR:

1. bumps that catalog copy to `0.2.6`;
2. adds `("src/agent-memory/Cargo.toml", "src/anolisa/manifests/components/agent-memory/component.toml")` to `TOML_CONTRACTS` in `scripts/check-component-versions.py`, so the `Check component versions` CI job now fails when the two disagree.

## Why it matters

That file is the **bundled layer** of the ANOLISA component catalog (`anolisa-core/src/catalog.rs`: *"Real component contracts extracted from the OSS release artifacts, shipped under `manifests/components/<name>/component.toml`"*, loaded behind the system and user layers). Catalog-resolved metadata for agent-memory therefore advertised `0.2.3` on surfaces such as `anolisa doctor` (`version: component.version`), alongside the layout / adapters / services / health-check declarations read from the same file.

The invariant is already repo policy: `scripts/check-component-versions.py` (added in `c87d4a44`, *fix(ci): prevent component version drift*) pins exactly this for the **tokenless** and **ws-ckpt** catalog copies — and those are the only two catalog copies currently in sync with their components. agent-memory was simply missing from `TOML_CONTRACTS`, so the 0.2.4 / 0.2.5 / 0.2.6 bumps (which did synchronize Cargo, the generated `.anolisa/component.toml`, adapter/MCP/npm metadata, the RPM spec and both changelogs) never tripped a check. `scripts/build-all.sh` also resolves `memory` to this same manifest path.

## What is deliberately NOT changed

- `src/anolisa/manifests/components/index.toml` keeps agent-memory's newest raw entry at `0.2.3`. That index records **published artifacts** with concrete `sha256` / `size` / SBOM references, and there is no 0.2.6 raw tarball to point at. The raw install path does not compare this catalog copy against the index either: `validate_manifest_contract_header()` validates the contract **embedded in the downloaded artifact** (`InstallContractSource::EmbeddedArtifact`) or its **sidecar metadata** (`SidecarMeta`) against the resolved index entry. So bumping the catalog cannot break `install --backend raw`.
- Other components' catalog copies drift the same way and belong to their owners: agentsight `0.8.0` vs `0.12.0`, cosh-ng `0.12.0` vs `0.23.0`, skillfs `0.3.3` vs `0.4.2`, cosh `2.7.0` vs `2.8.0`. Extending `TOML_CONTRACTS` to them would fail CI immediately, so each needs its own bump first — happy to file follow-up issues if maintainers want that.

## Verification

```console
$ python3 scripts/check-component-versions.py
Component version metadata is synchronized.

# negative control — catalog version set back to 0.2.3:
$ python3 scripts/check-component-versions.py
Component version check failed:
- src/anolisa/manifests/components/agent-memory/component.toml: expected 0.2.6, found 0.2.3 (source: src/agent-memory/Cargo.toml)

$ bash tests/test-check-component-versions.sh
Component version metadata is synchronized.
Component version metadata is synchronized.
Tokenless catalog version regression tests passed
```

Diff is 2 files, `+2 / -1`. No Rust code changed, and no test asserts the bundled agent-memory version (`catalog.rs` tests stage the real contracts and assert names/layer precedence only).

Related to AGE-6599 (internal Multica tracking)
