### PR TITLE
feat(sec-core): v2 cli

### DIFF
--- a/docs/user-guide/en/agent-security/agent-sec-core/policy-cli.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/policy-cli.md
@@ -1,0 +1,117 @@
+# Policy CLI User Guide
+
+[中文版](../../../zh/agent-security/agent-sec-core/policy-cli.md)
+
+Use `agent-sec-cli` to create, inspect, update and delete Policies, Scopes and Bindings
+through `asc-daemon`. A Policy describes the protection, a Scope selects its target,
+and a Binding associates a Policy revision with a Scope revision.
+
+These commands are available in the V2 CLI; the released Python CLI does not yet
+include them. Current Policy records are lost when the daemon restarts, and accepting
+a Binding does not mean protection has taken effect.
+
+## Connect to the daemon
+
+Use the absolute socket path supplied by your deployment administrator. The examples
+below assume `SOCKET` contains that path and your user is authorized to administer Policies.
+An unauthorized caller receives `permission_denied`. The CLI does not start the daemon
+or grant permissions.
+
+```bash
+agent-sec-cli --socket "$SOCKET" policy list
+```
+
+## Manage Policies
+
+Create a JSON template file such as `policy.json`:
+
+```json
+{"kind":"prevent_file_deletion","files":["/workspace/important/**"]}
+```
+
+The currently supported template protects against file/directory entry deletion
+(`unlink`/`rmdir`); it does not cover renaming, moving or modifying file contents.
+
+```bash
+agent-sec-cli --socket "$SOCKET" policy create --name "protect files" --file policy.json
+agent-sec-cli --socket "$SOCKET" policy get --policy-id "$POLICY_ID" --revision 1
+agent-sec-cli --socket "$SOCKET" policy list --limit 100 --offset 0
+agent-sec-cli --socket "$SOCKET" policy update --policy-id "$POLICY_ID" --name "protect files v2" --file policy-v2.json
+agent-sec-cli --socket "$SOCKET" policy delete --policy-id "$POLICY_ID" --revision 2
+```
+
+Use the ID and revision returned by successful commands. These are reference examples,
+not a sequential script: retain a Policy and Scope while creating a Binding that references them.
+Both create and update require a name and a complete template. Update replaces the existing
+Policy; it is not a partial update and cannot create a missing Policy. File paths are resolved
+relative to the CLI working directory. Policy get/delete require the exact current revision;
+an old revision returns `not_found`.
+
+## Manage Scopes
+
+Select exactly one of `--pid` (a positive process ID) or `--cgroup-id` (a positive cgroup ID).
+
+```bash
+agent-sec-cli --socket "$SOCKET" scope create --pid 4242
+agent-sec-cli --socket "$SOCKET" scope get --scope-id "$SCOPE_ID" --revision 1
+agent-sec-cli --socket "$SOCKET" scope list --limit 100 --offset 0
+agent-sec-cli --socket "$SOCKET" scope update --scope-id "$SCOPE_ID" --cgroup-id 99
+agent-sec-cli --socket "$SOCKET" scope delete --scope-id "$SCOPE_ID" --revision 2
+```
+
+Scope update replaces the complete selector. Get/delete require the exact current revision.
+Process IDs and revisions are positive 32-bit unsigned integers; cgroup IDs are positive
+64-bit unsigned integers.
+
+## Manage Bindings
+
+A Binding references an existing Policy revision and Scope revision. All create commands
+return server-generated IDs. Binding get/delete require the Binding ID, without a revision.
+
+```bash
+agent-sec-cli --socket "$SOCKET" binding create --policy-id "$POLICY_ID" --policy-revision 1 --scope-id "$SCOPE_ID" --scope-revision 1
+agent-sec-cli --socket "$SOCKET" binding get --binding-id "$BINDING_ID"
+agent-sec-cli --socket "$SOCKET" binding list --limit 100 --offset 0
+agent-sec-cli --socket "$SOCKET" binding update --binding-id "$BINDING_ID" --policy-id "$POLICY_ID" --policy-revision 2 --scope-id "$SCOPE_ID" --scope-revision 2
+agent-sec-cli --socket "$SOCKET" binding delete --binding-id "$BINDING_ID"
+```
+
+Create/update normally return `PENDING_APPLY`; delete requests `PENDING_DELETE`.
+Repeated or unchanged operations can retain the existing status and revision. These statuses
+record the requested change, not completed protection or deletion. Automatic application and
+`--wait` are not currently available.
+
+## Common options
+
+| Option | Purpose |
+|--------|---------|
+| `--socket PATH` | Required absolute daemon socket path; accepted before or after the subcommand |
+| `--timeout-ms N` | Positive unsigned 32-bit integer, default `5000`; connection, sending and receiving share one time budget |
+| `--limit N` | List page size, `1..=1000`; default `100` |
+| `--offset N` | List offset, unsigned 32-bit integer; default `0` |
+| `--help` | Help at the root, command group or operation level; no daemon connection |
+| `--version` | Root-level version output; no daemon connection |
+
+Options accept `--key value` and `--key=value`. Quote names and paths containing spaces;
+for a value beginning with `--`, use `--key=--value`. Repeated options are rejected.
+List commands return one `{items,total}` page. `total` is the count before pagination;
+request subsequent pages explicitly.
+
+## Output and errors
+
+| Result | Output | Exit status |
+|--------|--------|-------------|
+| Success | Method result as formatted JSON on stdout; stderr is empty | `0` |
+| Daemon rejection | JSON `{requestId,error:{code,message}}` on stderr; stdout is empty | `1` |
+| File, connection, response or output failure | Error explanation on stderr | `1` |
+| Invalid command-line arguments | Usage error on stderr | `2` |
+
+Template files are limited to 4 MiB and must contain valid JSON without unknown or duplicate
+fields. The complete encoded request and response each have a separate 4 MiB limit, including
+the line delimiter. Passing the file-size check does not guarantee the assembled request fits;
+an oversized request is rejected before sending.
+
+The timeout covers daemon communication, including waiting for daemon processing. It excludes
+file reading, request encoding, response decoding and output. The CLI never retries automatically.
+A timeout or invalid/missing response after sending does not prove the request was not executed;
+inspect current state before submitting another change.

--- a/docs/user-guide/zh/agent-security/agent-sec-core/policy-cli.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/policy-cli.md
@@ -1,0 +1,108 @@
+# Policy CLI 使用指南
+
+[English](../../../en/agent-security/agent-sec-core/policy-cli.md)
+
+使用 `agent-sec-cli` 经 `asc-daemon` 创建、查询、更新和删除 Policy、Scope、Binding。
+Policy 描述保护策略，Scope 选择目标，Binding 关联指定版本的 Policy 和 Scope。
+
+这些命令由 V2 CLI 提供，已发布的 Python CLI 尚未包含。当前策略记录在 daemon
+重启后丢失；Binding 请求被受理不代表保护已经生效。
+
+## 连接 daemon
+
+使用部署管理员提供的绝对 socket 路径。以下示例假设 `SOCKET` 已设置为该路径，
+且当前用户已获得策略管理权限。未授权用户会收到 `permission_denied`；CLI 不负责
+启动 daemon 或授予权限。
+
+```bash
+agent-sec-cli --socket "$SOCKET" policy list
+```
+
+## 管理 Policy
+
+准备 JSON 模板文件，例如 `policy.json`：
+
+```json
+{"kind":"prevent_file_deletion","files":["/workspace/important/**"]}
+```
+
+当前支持的模板保护文件或目录项免于删除（`unlink`/`rmdir`），不覆盖重命名、移动或
+文件内容修改。
+
+```bash
+agent-sec-cli --socket "$SOCKET" policy create --name "protect files" --file policy.json
+agent-sec-cli --socket "$SOCKET" policy get --policy-id "$POLICY_ID" --revision 1
+agent-sec-cli --socket "$SOCKET" policy list --limit 100 --offset 0
+agent-sec-cli --socket "$SOCKET" policy update --policy-id "$POLICY_ID" --name "protect files v2" --file policy-v2.json
+agent-sec-cli --socket "$SOCKET" policy delete --policy-id "$POLICY_ID" --revision 2
+```
+
+ID 和 revision 使用成功命令返回的值。这些是命令参考示例，并非顺序执行脚本；
+创建 Binding 时应保留其引用的 Policy 和 Scope。
+create 和 update 均要求名称及完整模板。update 替换已有 Policy，不是部分更新，
+也不会创建不存在的 Policy。文件相对路径按 CLI 工作目录解析。
+get/delete 要求精确的当前 revision，旧 revision 返回 `not_found`。
+
+## 管理 Scope
+
+`--pid`（正进程 ID）和 `--cgroup-id`（正 cgroup ID）必须且只能指定一个。
+
+```bash
+agent-sec-cli --socket "$SOCKET" scope create --pid 4242
+agent-sec-cli --socket "$SOCKET" scope get --scope-id "$SCOPE_ID" --revision 1
+agent-sec-cli --socket "$SOCKET" scope list --limit 100 --offset 0
+agent-sec-cli --socket "$SOCKET" scope update --scope-id "$SCOPE_ID" --cgroup-id 99
+agent-sec-cli --socket "$SOCKET" scope delete --scope-id "$SCOPE_ID" --revision 2
+```
+
+update 替换完整 selector；get/delete 要求精确的当前 revision。
+进程 ID 和 revision 为正 32 位无符号整数，cgroup ID 为正 64 位无符号整数。
+
+## 管理 Binding
+
+Binding 引用已经存在的 Policy revision 和 Scope revision。所有 create 命令均由
+服务端生成 ID。Binding get/delete 只需要 Binding ID，无需 revision。
+
+```bash
+agent-sec-cli --socket "$SOCKET" binding create --policy-id "$POLICY_ID" --policy-revision 1 --scope-id "$SCOPE_ID" --scope-revision 1
+agent-sec-cli --socket "$SOCKET" binding get --binding-id "$BINDING_ID"
+agent-sec-cli --socket "$SOCKET" binding list --limit 100 --offset 0
+agent-sec-cli --socket "$SOCKET" binding update --binding-id "$BINDING_ID" --policy-id "$POLICY_ID" --policy-revision 2 --scope-id "$SCOPE_ID" --scope-revision 2
+agent-sec-cli --socket "$SOCKET" binding delete --binding-id "$BINDING_ID"
+```
+
+create/update 通常返回 `PENDING_APPLY`，delete 请求 `PENDING_DELETE`。
+重复或没有实际变化的操作可能保留原有状态和 revision。这些状态表示已记录变更请求，
+不代表保护生效或删除完成。当前尚不支持自动应用策略或 `--wait`。
+
+## 公共参数
+
+| 参数 | 用途 |
+|------|------|
+| `--socket PATH` | 必填的 daemon 绝对 socket 路径，可放在子命令前后 |
+| `--timeout-ms N` | 正 32 位无符号整数，默认 `5000`；连接、发送、接收共用一次时间预算 |
+| `--limit N` | 列表每页条数，`1..=1000`，默认 `100` |
+| `--offset N` | 列表偏移量，32 位无符号整数，默认 `0` |
+| `--help` | 顶层、命令组和具体操作的帮助，不连接 daemon |
+| `--version` | 顶层版本信息，不连接 daemon |
+
+支持 `--key value` 和 `--key=value`。带空格的名称、路径需使用引号；
+以 `--` 开头的值使用 `--key=--value`。重复参数会被拒绝。
+列表命令每次返回一页 `{items,total}`，`total` 是分页前总数；后续页需显式请求。
+
+## 输出与错误
+
+| 结果 | 输出 | 退出码 |
+|------|------|--------|
+| 成功 | stdout 输出格式化的结果 JSON，stderr 为空 | `0` |
+| daemon 拒绝 | stderr 输出 JSON `{requestId,error:{code,message}}`，stdout 为空 | `1` |
+| 文件、连接、响应或输出失败 | stderr 输出错误说明 | `1` |
+| 命令行参数错误 | stderr 输出用法错误 | `2` |
+
+模板文件最大为 4 MiB，必须是有效 JSON，不能包含未知或重复字段。
+完整编码后的请求和响应各自另有 4 MiB 上限，包含行结束符。文件大小检查通过不保证
+组装后的请求符合上限；请求超限时不会发送。
+
+超时预算覆盖 daemon 通信，包括等待 daemon 处理请求；不包含文件读取、请求编码、
+响应解码和结果输出。CLI 不自动重试。发送后超时、响应缺失或非法，不代表请求没有
+执行；再次提交变更前应先查询当前状态。

--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -39,6 +39,14 @@ systemd **user** unit) provides health, SkillFS notification, and security-query
 RPCs. Prompt scanning runs in-process through the Rust extension; the daemon does
 not preload Prompt Scanner models or serve scan RPCs.
 
+## V2 Policy CLI
+
+The source-built Rust `agent-sec-cli` provides all 15 Policy, Scope and Binding CRUD
+commands through `asc-daemon`. See the [command reference](../../docs/user-guide/en/agent-security/agent-sec-core/policy-cli.md)
+and [V2 workspace](v2/README.md). PAP state is currently process-local; Binding
+acceptance does not imply enforcement. For non-root development and E2E, configure
+the daemon with `--policy-admin-uid <UID>`; default authorization remains root-only.
+
 ## Security Architecture
 
 ```

--- a/src/agent-sec-core/README_zh.md
+++ b/src/agent-sec-core/README_zh.md
@@ -36,6 +36,13 @@
 形式发布）提供健康检查、SkillFS 通知和安全查询 RPC。Prompt Scanner 通过 Rust 扩展
 在进程内执行；daemon 不会预加载 Prompt Scanner 模型，也不提供扫描 RPC。
 
+## V2 Policy CLI
+
+源码构建的 Rust `agent-sec-cli` 经 `asc-daemon` 提供全部 15 条 Policy、Scope、Binding
+CRUD 命令。参阅[命令参考](../../docs/user-guide/zh/agent-security/agent-sec-core/policy-cli.md)
+和 [V2 workspace](v2/README.md)。当前 PAP 状态仅在进程内存中，Binding 受理不代表策略已生效。
+非 root 开发与 E2E 可通过 daemon 的 `--policy-admin-uid <UID>` 配置管理员；默认仍只授权 root。
+
 ## 安全防护架构
 
 ```

--- a/src/agent-sec-core/docs/design/AGENT_SEC_RUST_MIGRATION_zh.md
+++ b/src/agent-sec-core/docs/design/AGENT_SEC_RUST_MIGRATION_zh.md
@@ -7,6 +7,11 @@
 入口。实现、评审和验收只能依赖仓库内可访问的规范；新的架构决策必须直接更新本文及受
 影响的契约，不能依赖未随仓库发布的材料。
 
+**[TARGET V2] CLI 命名：** Rust CLI 的 Cargo package/crate 与源码目录继续使用
+`asc-cli` / `asc_cli` / `v2/apps/asc-cli`，对外编译产物和命令名统一为 `agent-sec-cli`。
+本文其余 `asc-cli` 表示内部组件，不表示另一份可执行文件；当前 PAP slice 与 V1 同名
+不代表已完成 V1 全量命令迁移。
+
 此前文档中的“长期保留 Python CLI、PyO3 NativeExecutor、daemon 不可用时自动本地
 fallback、backend-first/daemon-last、per-user daemon”路线已经被当前 V2 架构取代，不再
 是候选实现或兼容路线。旧路线只保留在 Git 历史中用于审计。
@@ -168,7 +173,7 @@ daemon protocol adapter
 - 升级、状态 owner、回滚和混合版本读取。
 
 兼容不要求保留 Python 内部调用路径。若 agent-sec-cli 是 supported command，V2 可以由
-Rust asc-cli binary、兼容命令名或受控 wrapper 提供同一外部接口，但不能以 Python/PyO3
+Rust agent-sec-cli binary、兼容命令名或受控 wrapper 提供同一外部接口，但不能以 Python/PyO3
 作为 V2 依赖。任何删除、重命名或语义变化都必须先有 versioned replacement、兼容期和批准
 的 change record。
 
@@ -233,7 +238,7 @@ asc-state-migrator 必须定义并验证：
 
 工作包采用本文定义的目标 workspace，至少包括：
 
-- 产品入口：asc-daemon、asc-cli、asc-state-migrator；
+- 产品入口：asc-daemon、agent-sec-cli、asc-state-migrator；
 - daemon：asc-daemon-protocol、asc-daemon-service、asc-daemon-handler、asc-daemon-core；
 - action：asc-action-types、asc-evidence-types、asc-action-runtime 和各 asc-capability-*；
 - policy：asc-policy-types、asc-policy-engine、asc-policy-runtime、asc-pap、asc-pcp；
@@ -251,7 +256,7 @@ composition root 负责注入。
 - **Action Slice**：daemon-core + action-runtime + 一个 capability + security-events；
 - **Policy Slice**：PAP + policy-engine + PCP + AgentSight adapter + persistence；
 - **Query Slice**：security-events + session + observability + persistence + authorization；
-- **Product Slice**：asc-daemon + asc-cli + state-migrator + packaging。
+- **Product Slice**：asc-daemon + agent-sec-cli + state-migrator + packaging。
 
 slice 是集成验收单元，不是让所有 crate 串行等待的开发阶段。
 

--- a/src/agent-sec-core/docs/design/DAEMON_CURRENT_BEHAVIOR_zh.md
+++ b/src/agent-sec-core/docs/design/DAEMON_CURRENT_BEHAVIOR_zh.md
@@ -67,7 +67,7 @@ daemon 当前不承担：
 - 收到 SIGHUP 后重载配置；
 - 以 daemon 内存状态作为安全事件、Skill Ledger 或 observability 的唯一事实来源。
 
-**[TARGET V2]** asc-daemon 是 one daemon per host 的 system-level service；asc-cli 是 Rust
+**[TARGET V2]** asc-daemon 是 one daemon per host 的 system-level service；agent-sec-cli 是 Rust
 daemon client，不拥有 daemon 生命周期，也不提供 PyO3 NativeExecutor 或通用本地 fallback。
 同一 daemon 服务多个 UID/Agent，并通过 trusted Principal、authorization 和 QueryScope
 隔离访问。上述 V2 目标不改写本节记录的 V1 当前事实。
@@ -432,7 +432,7 @@ per-user path、user service 和用户级 singleton 不能直接升级为 V2 PRE
 | ID | 必须验证的行为 |
 | --- | --- |
 | DCB-013 | Rust daemon 对当前 Python oracle 的同一 fixture 输出规范化后等价 |
-| DCB-014 | asc-cli 只通过 daemon 执行；daemon 不可用时返回受控 unavailable/version error，不启动用户 daemon、不使用 PyO3 或本地业务 fallback |
+| DCB-014 | agent-sec-cli 只通过 daemon 执行；daemon 不可用时返回受控 unavailable/version error，不启动用户 daemon、不使用 PyO3 或本地业务 fallback |
 | DCB-015 | 当前 9 个 method 均有 compatibility classification；八个 action method 通过 protocol Definition Review 后才进入 canonical registry |
 | DCB-016 | daemon error 与失败 ActionResult 保持三层分离，并兼容历史 action response projection |
 | DCB-017 | Host 第二实例被拒绝；system-scope service 和每 Node 单 DaemonSet 形态通过验收 |

--- a/src/agent-sec-core/docs/design/DAEMON_PROCESS_DEPLOYMENT_CONTRACT_zh.md
+++ b/src/agent-sec-core/docs/design/DAEMON_PROCESS_DEPLOYMENT_CONTRACT_zh.md
@@ -19,7 +19,7 @@
 - Linux system-scope systemd；
 - Kubernetes 每 Node 一个 DaemonSet；
 - system-owned runtime/state；
-- Rust asc-cli 仅作为 daemon client；
+- Rust agent-sec-cli 仅作为 daemon client；
 - 不保留 Python CLI、PyO3 local fallback 或 per-user daemon。
 
 socket 生命周期见
@@ -93,7 +93,7 @@ kernel/control-group protection、RestrictSUIDSGID 和 LockPersonality。V2 应�
 hardening；需要放宽时提供 syscall/filesystem 证据、最小例外和测试。
 
 上述 user unit、XDG path 和用户级 singleton 只属于 V1。V2 交付物不得继续安装 user-scope
-unit，也不得让 asc-cli 自动创建用户 daemon。
+unit，也不得让 agent-sec-cli 自动创建用户 daemon。
 
 ### 3.3 active 不等于 ready
 
@@ -128,7 +128,7 @@ V1 Type=simple 的 active 不证明 socket 已 bind、Job 已启动或 daemon.he
 
 ### 4.3 CLI 与进程所有权
 
-asc-cli 是 Rust daemon client：
+agent-sec-cli 是 Rust daemon client：
 
 - 不执行 systemctl start；
 - 不创建用户 socket、lock 或 daemon；
@@ -205,7 +205,7 @@ operator-visible semantics 必须进入 compatibility/change record。journald �
 
 ## 8. **[TARGET V2]** Rust 交付要求
 
-1. asc-daemon、asc-cli 和 asc-state-migrator 都是 Rust binary；
+1. asc-daemon、agent-sec-cli 和 asc-state-migrator 都是 Rust binary；
 2. V2 runtime 不依赖 Python interpreter、site-packages、PyO3 extension 或 wheel；
 3. raw/RPM/container/systemd/Helm 安装相互一致；
 4. Linux 只交付 system-scope unit；Kubernetes 交付每 Node 一个 DaemonSet；
@@ -233,8 +233,12 @@ runtime shutdown timeout，避免残留 `spawn_blocking` 让前台进程永久�
 但尚未注册 `daemon.health`。dispatcher 完成 envelope decode、request ID、kernel peer
 credentials 到 trusted Principal 的绑定、method allowlist、authorization 和 response
 encode；PAP 是其中一组显式注册的方法，不增加第二个 service dispatch 层。当前 composition
-root 使用 `RootManagedPrincipalPolicy`：UID 0 默认具有 PAP 管理权限，其它 UID 在未加载
-root-owned delegation 前返回 `permission_denied`，caller-supplied identity 不能覆盖该判断。
+root 使用 `RootManagedPrincipalPolicy`：UID 0 始终具有 PAP 管理权限。部署者可用
+可重复的 `--policy-admin-uid <UID>` 在启动时配置额外管理员；省略时其它 UID 返回
+`permission_denied`。值为十进制 u32，非法值启动失败；重复 UID 去重。启动配置由服务端
+部署者控制，匹配的是内核 peer UID，caller-supplied identity 不能覆盖该判断。名单每次
+启动重新构造，不带参数重启恢复 root-only。被配置的管理员没有继续委派权限；运行中的
+`allow_uid` API 仍要求 root。该选项不改变 OS 权限、socket mode 或 system-level 部署形态。
 
 当前 PAP 由 `PolicyTemplateCompiler` 和过渡性的 process-local Repository 组成。Policy、Scope
 和 Binding CRUD 可在同一 daemon 生命周期内经真实 UDS 执行，但所有状态在进程重启后丢失，
@@ -250,6 +254,33 @@ singleton/stale-socket 判定、日志/OTel 和 health readiness。因此这一 
 DPROC-002/DPROC-003 的 focused process evidence，以及 DPROC-013 中 binary + UDS protocol
 注册、server-side permission 和 signal cleanup 的部分证据；它不能宣称 DPROC-012、完整
 DPROC-013、DPROC-014 或 production process gate 已完成。
+
+### 8.2 **[TARGET V2][PARTIAL]** Rust Policy CLI
+
+`v2/apps/asc-cli` 构建产物为 `agent-sec-cli`（crate 名仍为 `asc-cli`），提供 `policy`、`scope`、`binding` 三组各五条 CRUD 命令，通过
+`asc-daemon-client` 调用现有 15 个 PAP method。它要求显式绝对 `--socket`，不启动或
+重启 daemon，不解析 HOME socket，不读取 Repository，也不执行本地业务 fallback。
+`--help` 和 `--version` 不连接 daemon。
+
+`--timeout-ms` 为正 u32，默认 5000；一次客户端 deadline 覆盖 connect/write/read，
+不向现有 wire envelope 添加 timeout 字段。请求和响应上限均为 4,194,304 字节，包含
+LF；完整 LF response 立即完成读取，也接受非空 EOF frame。客户端保留完整
+`DaemonResponse`；Policy 输出层将 success 的领域 result 输出到 stdout、退出 0，
+daemon error 的 `{requestId,error}` 输出到 stderr、退出 1。本地文件、transport、
+response 和 output failure 退出 1，参数用法错误退出 2。
+
+请求发送后的超时或协议失败不证明业务未执行；CLI 不自动重试，也不把 Binding
+`PENDING_APPLY`/`PENDING_DELETE` 表述为目标生效或删除完成。CREATE identity、current
+revision、授权和领域语义继续由 daemon/PAP 所有。该 Rust binary 与 V1 Python CLI 同名；当前命令范围仅覆盖本节的 PAP
+命令，不代表已替代 V1 全量能力或提供 V1 wire adapter。
+
+DPROC-011 和 DPROC-018 的 focused evidence 为 `asc-cli/tests/commands.rs` 的 binary
+失败测试、`asc-cli/tests/pap_process.rs` 的真实 CLI 进程和 UDS 授权测试，以及客户端
+依赖图。CLI 进程测试使用测试进程内的 daemon service；真实 CLI 与 daemon binary
+共同运行的双进程 E2E 暂缓接入。
+`asc-daemon/tests/bootstrap.rs::dproc_configured_administrator_runs_full_crud_without_root`
+同时为常规 Cargo 测试提供真实 daemon binary 成功场景。完整范围与命令见
+[`POLICY_CLI_ACCEPTANCE_zh.md`](POLICY_CLI_ACCEPTANCE_zh.md)，不扩大其它 DPROC gate。
 
 ## 9. 验收矩阵
 
@@ -274,7 +305,7 @@ DPROC-013、DPROC-014 或 production process gate 已完成。
 | ID | 必须验证的 V2 行为 |
 | --- | --- |
 | DPROC-010 | Rust binaries 不装载 Python/PyO3，supported V1 命令具有兼容或版本化路径 |
-| DPROC-011 | daemon unavailable 时 asc-cli 返回稳定错误，不启动 user daemon、不 local fallback |
+| DPROC-011 | daemon unavailable 时 agent-sec-cli 返回稳定错误，不启动 user daemon、不 local fallback |
 | DPROC-012 | Host lock/socket 拒绝 symlink、非 regular、错误 owner/mode 和 reopen TOCTOU |
 | DPROC-013 | system-scope restart、signal、readiness、permission 和 log 黑盒测试通过 |
 | DPROC-014 | 不安装 user unit；Host 第二实例被拒绝 |

--- a/src/agent-sec-core/docs/design/DAEMON_PROTOCOL_V1_zh.md
+++ b/src/agent-sec-core/docs/design/DAEMON_PROTOCOL_V1_zh.md
@@ -438,8 +438,9 @@ template、Binding 内嵌快照、revision、status 和确定性 digest。daemon
 UUID 使用具名占位符：fixture 不冻结随机值本身，但必须验证 UUID 格式、CREATE 捕获值在后续
 请求/响应中的一致性，以及不同资源 identity 不混用。该 fixture 同时由 protocol 类型测试、
 使用服务端授权测试 Principal 的必跑 UDS integration E2E，以及真实 `asc-daemon` 子进程
-bootstrap E2E 消费。binary 测试在 root 身份下重复完整成功场景，非 root 身份验证默认
-`permission_denied`；不得为测试加入产品授权旁路。
+bootstrap E2E 消费。binary 测试通过服务端启动配置 `--policy-admin-uid <测试 UID>`
+执行完整成功场景，无需 root；另行验证非 root 默认 `permission_denied`。root 环境同时
+验证默认授权成功路径，不使用跳过授权的测试开关。
 `v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-invalid-requests.json` 冻结 method
 params 构造失败时的 `invalid_request` code 和有界、安全 message，并由真实 UDS integration
 fixture 消费。
@@ -450,9 +451,13 @@ Policy Administrator Principal；request 中不得携带可信 UID、role 或 sc
 `PreparedScope`、`BindingView` 以及 foundation 的 `ResourceId`、`Revision`，不得复制
 Policy domain DTO。
 
-当前 bootstrap 的首版策略固定允许 UID 0 管理 Policy；其它 UID 默认拒绝。root 可以向
-process-local allowlist 添加额外管理员 UID，但被授权 UID 不获得继续委派权限。allowlist 的
-持久化、加载和管理 RPC 尚未进入本 slice，在这些能力完成前 daemon 重启后只保留 root 权限。
+当前 bootstrap 始终允许 UID 0 管理 Policy，其它 UID 默认拒绝。部署者可在 daemon
+启动时用可重复的 `--policy-admin-uid <UID>` 配置额外管理员，值为十进制 u32；授权仍
+依据内核 peer UID，不接受请求中的 UID/role。控制启动配置属于服务端部署权限；生产
+服务的启动参数由部署者管理。这不会改变 system-level 部署形态或提升进程 OS 权限，
+也不会修改 socket 文件访问权限。root 仍可通过内部 `allow_uid` API 动态委派，但被授权
+管理员不能继续委派。名单仅存放在进程内存，每次启动需重新提供配置；不带该参数重启
+恢复 root-only。配置文件加载、持久化和管理 RPC 不在本 slice。
 
 | method | params | result |
 | --- | --- | --- |
@@ -585,7 +590,7 @@ handler 与 core 的校验职责必须保持以下三层边界：
 同一 invalid-input fixture 必须同时覆盖 V1 oracle 和 V2 daemon compatibility adapter，确保
 错误不会因语言或入口实现不同而在 `bad_request` 与失败 `ActionResult` 之间漂移。
 
-旧 daemon 对 `action.*` 返回 `unknown_method`，证明该 action 没有被接受执行；V2 asc-cli
+旧 daemon 对 `action.*` 返回 `unknown_method`，证明该 action 没有被接受执行；V2 agent-sec-cli
 必须报告稳定的 version/capability mismatch，不转入 PyO3 或本地业务路径。request 已发送
 后的 timeout、EOF 或协议错误仍然状态不明，不能由 client 重放。
 
@@ -740,7 +745,7 @@ client 读取第一条 response 后忽略同一次 read 已取得的 trailing by
 - auth 模式下握手或 frame authentication 失败。
 
 这类失败不证明 daemon 未执行请求。V2 没有通用本地 fallback；request 是否发送都不得由
-asc-cli 触发 PyO3、Python backend 或第二套本地业务执行。
+agent-sec-cli 触发 PyO3、Python backend 或第二套本地业务执行。
 
 ## 10. 兼容性规则
 
@@ -786,7 +791,7 @@ asc-cli 触发 PyO3、Python backend 或第二套本地业务执行。
 | DPV1-017 | 八个 action method 的 timeout、queue/resource、access-log、blocking 和 cancellation metadata 已冻结并逐项验证 |
 | DPV1-018 | 多 UID 共用 system socket；trusted Principal/QueryScope 隔离 owner，`caller/trace_context` 不参与授权 |
 | DPV1-019 | CLI/TUI 不能用 RPC filter 绕过服务端 QueryScope，也不能直读 SQLite 替代授权查询 |
-| DPV1-020 | 15 个 PAP method 的 strict params、完整请求/响应 CRUD fixture、直接领域 result、错误投影、server-owned Principal；必跑 UDS integration 经 Dispatcher/PapHandler → PapService → Policy Compiler/Repository 执行完整 fixture，真实 `asc-daemon` 子进程 bootstrap 在 root 下重复成功场景、非 root 下验证默认拒绝 |
+| DPV1-020 | 15 个 PAP method 的 strict params、完整请求/响应 CRUD fixture、直接领域 result、错误投影、server-owned Principal；必跑 UDS integration 经 Dispatcher/PapHandler → PapService → Policy Compiler/Repository 执行完整 fixture，真实 `asc-daemon` 子进程通过启动管理员 UID 配置完成非 root 成功场景，同时验证默认拒绝；root 环境验证默认成功 |
 
 协议测试必须使用 socket bytes 和解析后 JSON 比较；只测试某个 Python dataclass 或 Rust
 struct 的构造函数不足以证明 wire compatibility。

--- a/src/agent-sec-core/docs/design/POLICY_CLI_ACCEPTANCE_zh.md
+++ b/src/agent-sec-core/docs/design/POLICY_CLI_ACCEPTANCE_zh.md
@@ -1,0 +1,166 @@
+# V2 Policy CLI 工作包验收记录
+
+| 属性 | 值 |
+| --- | --- |
+| 源码基线 | `main@8bf150c24482de42cf5f4be580b56d8c6bf3a376` |
+| 验收日期 | 2026-09-07 |
+| 当前状态 | CLI/PAP Rust 集成测试与非 root daemon binary CRUD 通过；CLI＋daemon 双进程 E2E 暂缓；不是 release/distribution ready |
+| 产品范围 | Policy、Scope、Binding 各 create/get/list/update/delete，共 15 条命令 |
+| 权威输入 | 当前 `asc-daemon-protocol` 的 `pap-methods.json`、`pap-crud-e2e.json` 和领域类型 |
+
+## 1. 实现边界与直接依赖
+
+`agent-sec-cli` 是对外 binary 名；内部 Cargo package 为 `asc-cli`，源码目录
+仍是 `v2/apps/asc-cli`。`asc-cli` crate 包含命令解析、Policy 输入适配和 Policy 输出层；`asc-daemon-client` 只负责
+一次 UDS 请求、字节上限、deadline、响应解析和 transport 错误。客户端返回完整
+`DaemonResponse`，不将其统一降成 JSON result 或决定 CLI 退出码。未来其它命令可增加
+输入和输出适配，当前不提前实现 Action、Query、TUI、V1 wire adapter 或通用 action RPC。
+
+运行时依赖方向：
+
+```text
+asc-cli -> asc-daemon-client -> asc-daemon-protocol
+        -> asc-daemon-protocol / asc-policy-types / asc-foundation-types
+```
+
+CLI 与 client 不在运行时依赖 PAP、Repository、Compiler、daemon handler/service 或
+Reconciler。CLI 测试依赖服务端组件，仅用于真实 CLI 子进程与 UDS 集成。当前协议 crate
+已经与服务端实现分离，本变更不复制 domain DTO、不修改 PAP 协议。
+
+客户端同步阻塞调用者线程，不创建 Tokio runtime 或后台线程。连接使用 `socket2`
+的有界连接，发送和接收使用标准库 `UnixStream`，每次 I/O 前根据单调时钟计算同一
+deadline 的剩余预算。请求编码及大小检查先于 I/O 计时，收到完整 frame 后再解码。
+`socket2` 复用 lockfile 中已有版本；CLI 的 Tokio 依赖仅用于测试服务端，普通运行时
+依赖树不包含 Tokio。daemon 的异步运行方式不变。
+
+命令入口 `apps/asc-cli/src/commands.rs` 仅声明顶层命令并分派请求构造；
+`commands/policy.rs`、`commands/scope.rs`、`commands/binding.rs` 分别拥有各自
+参数和正式 DTO 映射。`commands/common.rs` 只共享分页、ID/revision 校验和请求编码。
+新增命令族时新增模块并注册到顶层，不在入口堆叠业务参数，也不引入动态插件或通用 CRUD 框架。
+
+直接依赖 revision 是上述基线中的 protocol/types；新增 CLI 与 client 同一变更验收。
+直接消费者证据是 CLI 的 15 method serialized mapping、CLI 子进程经过 daemon
+Dispatcher/PapHandler/PapService 的完整 frozen scenario，以及独立 mock UDS client 测试。
+
+## 2. V1 relationship 与兼容分类
+
+| 项目 | 分类 | 验收方式 |
+| --- | --- | --- |
+| `agent-sec-cli` Policy 命令面 | `GREENFIELD_CONTRACT` | 新增 V2 PAP command mapping 与输出/退出码 fixtures |
+| `asc-daemon-client` | 当前 V2 协议的 `ADAPTER_CONFORMANCE` | 实际 socket bytes、LF/EOF、deadline、limits、typed response |
+| V1 Python CLI | 无修改、未替代 | 不宣称全量命令或 wire 等价；不依赖 Python/PyO3 runtime |
+| POC `poc.*` | 历史参考，不作为产品兼容承诺 | 顶层保留 policy/scope/binding；正式 wire 采用当前 `policy.*` |
+
+服务端生成所有 CREATE ID，不引入 POC 的可选 Binding ID。Policy/Scope get/delete
+要求 exact current revision，Binding get/delete 只需要 ID。UPDATE 是完整更新，不做
+upsert 或 CLI 侧读改写。LIST 默认 100/0、只取一页；返回 `{items,total}`。Scope create/update
+支持正 PID 或 cgroup ID，互斥。Binding intent 不等于实际 enforcement。
+
+V1 支持面今后的迁移仍需逐项兼容分类和对应 oracle；本工作包的扩展能力以依赖/输入/
+transport/输出边界验收，不用尚未实现的 V1 stub 或假设的通用响应模型充数。
+
+## 3. Internal contract change record
+
+| ID | 变更 | 影响 |
+| --- | --- | --- |
+| CCLI-CR-001 | 增加 `asc-cli` 与独立 `asc-daemon-client` | CLI 参数解析采用 clap，版本统一写在 workspace，更新 Cargo.lock；无新增服务端 RPC |
+| CCLI-CR-002 | 固定当前 Policy 输出/退出码 | success result JSON/stdout/0；daemon error envelope JSON/stderr/1；本地执行失败 1；用法错误 2 |
+| CCLI-CR-003 | 一次调用 deadline、LF/EOF、4 MiB wire bounds | 不重试未知结果、不增加 wire timeout 字段；默认 5000 ms，可用正 u32 覆盖 |
+| CCLI-CR-004 | 输入文件读取与完整模板解码属于 CLI | 文件相对 CLI cwd 解析；保留空格和 OS-native 路径；重复键在 Value 之前拒绝；领域编译仍在 PAP |
+| CCLI-CR-005 | daemon 增加可重复 `--policy-admin-uid <UID>` 启动配置 | 默认 root-only 保持；内核 peer UID 匹配部署配置，不跳过授权；运行时委派仍需 root；每次启动重新配置 |
+| CCLI-CR-006 | `asc-daemon-client::call` 从 async API 改为同步 `Result` API | 唯一产品消费者 CLI 直接调用，移除 runtime；库调用者须移除 await；参数、wire、退出码、默认 5000 ms 总 deadline、未知结果与不重试语义保持 |
+| CCLI-CR-007 | 按命令族拆分参数和请求构造模块 | 顶层仅保留注册与分派；现有 15 method fixture、参数验证及进程场景复验，外部命令语法不变 |
+| CCLI-CR-008 | Rust CLI binary 命名为 `agent-sec-cli`，crate 名保留 `asc-cli` | Cargo bin target、help/version、错误前缀与进程测试同步；只改变 V2 产品命令名，不安装或覆盖现有 V1 Python CLI |
+
+## 4. 可执行 pass/fail matrix
+
+下列 Rust 路径相对于 `v2/`；测试函数是可执行门禁，不以文档 ID 代替测试。
+
+| ID | 验收项 | executable evidence | 结果 |
+| --- | --- | --- | --- |
+| CCLI-001 | 全部 15 条命令、默认值与正式 params 一致 | `apps/asc-cli/tests/commands.rs::all_fifteen_commands_match_frozen_wire_parameters`，消费 `pap-methods.json` 并比对 PAP_METHODS 集合 | PASS |
+| CCLI-002 | 参数边界、重复/互斥/缺失、空格与 OS-native 路径、文件/JSON 错误 | `commands.rs` 的参数与文件测试 | PASS |
+| CCLI-003 | 帮助、版本、输出、退出码与 daemon 缺失；DPROC-011 partial | `commands.rs::binary_help_version_and_failures_have_stable_exit_codes`、`result_rendering_keeps_domains_and_errors_separate` | PASS |
+| CCLI-004 | 真实 CLI 子进程执行完整 15 步 CRUD，与 frozen 完整结果及 socket 请求比较 | `apps/asc-cli/tests/pap_process.rs::real_cli_processes_execute_the_complete_frozen_pap_crud_scenario` | PASS；测试服务端 PrincipalPolicy，真实 UDS，process-local Repository |
+| CCLI-005 | 15 method 均经服务端授权拒绝 | `pap_process.rs::unauthorized_cli_cannot_read_or_modify_any_pap_resource` | PASS |
+| CCLI-006 | 领域错误不被 CLI 改写、total 与单页、不隐式读取 | `pap_process.rs::domain_validation_and_pagination_are_owned_by_the_daemon` | PASS |
+| CCLI-007 | 分段 LF、不等待 EOF、EOF frame、typed daemon error、空/非法响应 | `crates/daemon/asc-daemon-client/tests/transport.rs` | PASS |
+| CCLI-008 | 总 deadline 覆盖 blocked write/分段 read、精确 LF-inclusive 边界、不自动重试 | `transport.rs` 的 deadline、frame limit、no replay assertions | PASS |
+| CCLI-009 | 真实 CLI＋daemon 非 root 授权与配置生命周期 | 暂无自动化入口 | DEFERRED：双进程 E2E 暂缓 |
+| CCLI-010 | 真实 CLI＋daemon 非 root 完整 CRUD | 暂无自动化入口 | DEFERRED：双进程 E2E 暂缓 |
+| CCLI-012 | 常规 Cargo 的真实 daemon binary 非 root CRUD | `asc-daemon/tests/bootstrap.rs::dproc_configured_administrator_runs_full_crud_without_root` | PASS |
+| CCLI-013 | startup UID 校验及管理员不可继续委派 | daemon CLI `administrator_uids_are_explicit_repeatable_and_bounded`、core `startup_administrators_are_explicit_and_cannot_delegate` | PASS |
+| CCLI-011 | workspace test、Clippy、fmt、Rustdoc、lockfile 和 diff | 以下命令 | PASS |
+| CCLI-014 | 无 runtime 的同步 UDS 与共享 deadline | `transport.rs` 普通 `#[test]`：LF/EOF、精确 frame 边界、分段读、阻塞写、写后读取共享预算、连接前超时、Linux 满连接队列、不重放；`cargo tree -p asc-cli --edges normal` | PASS：13 个同步 transport 测试；普通依赖树无 Tokio |
+| CCLI-015 | 独立构建对外 binary，不依赖 workspace feature 合并 | `cargo build -p asc-cli --bin agent-sec-cli --locked`；CLI 进程测试通过 `CARGO_BIN_EXE_agent-sec-cli` 启动 | 本地 PASS；未接入 CI 独立构建步骤 |
+| CCLI-016 | 非 UTF-8 内联 socket 路径不能绕过跨层级重复选项检查 | `commands.rs::repeated_socket_options_reject_non_utf8_inline_paths_at_every_level`；覆盖两种选项语法、路径顺序及子命令层级，单一路径保持原始字节 | PASS：解析为 ArgumentConflict，真实 CLI 退出 2 |
+
+## 5. 复现命令
+
+### 开发构建与手动连接
+
+从 `src/agent-sec-core/v2` 构建；package 名与 binary 名有意区分：
+
+```bash
+cargo build -p asc-cli -p asc-daemon --locked
+./target/debug/agent-sec-cli --help
+./target/debug/agent-sec-cli policy update --help
+./target/debug/agent-sec-cli --version
+```
+
+CLI 独立构建也必须通过 `cargo build -p asc-cli --bin agent-sec-cli --locked`，
+不能仅靠 workspace feature 合并通过构建。同步 socket 经 `OwnedFd` 转换为标准库
+`UnixStream`，不依赖 daemon 间接启用的 `socket2/all`。
+
+开发环境可由 daemon 启动者显式配置管理员 UID。`SOCKET` 应设为该环境可用的绝对
+路径；下面两条命令分别在服务端和客户端终端执行：
+
+```bash
+./target/debug/asc-daemon serve --socket "$SOCKET" --policy-admin-uid "$(id -u)"
+./target/debug/agent-sec-cli --socket "$SOCKET" policy list
+```
+
+`--policy-admin-uid` 属于 daemon 启动配置，可重复并支持 `--policy-admin-uid=<UID>`；
+UID 为十进制 u32，重复值去重，非法值在 socket bind 前拒绝。省略时只授权 root，
+root 始终获授权。配置的管理员不能在运行时继续委派，重启时需重新提供名单。
+该配置按内核 peer credentials 授权，不修改 socket 权限或 system-level 部署形态。
+
+构建、启动和 Rust 集成测试步骤集中维护于本节；中英文 Policy 用户指南只维护命令用法、
+参数、输出与当前能力限制。
+
+### 自动化验证
+
+从 `src/agent-sec-core/v2` 执行：
+
+```bash
+cargo build -p asc-cli --bin agent-sec-cli --locked
+cargo test --workspace --locked
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo fmt --all -- --check
+cargo doc --workspace --no-deps --locked
+cargo build --workspace --bins --locked
+./target/debug/agent-sec-cli --version
+cargo tree -p asc-cli --edges normal
+cargo +1.88.0 check --workspace --all-targets --locked
+git diff --check
+```
+
+同步客户端与命令拆分复验：workspace tests、Clippy、fmt、Rustdoc、binary build 和
+Rust 1.88.0 `check --workspace --all-targets --locked` 全部通过。
+此结果不包含性能基准，不据此宣称 CPU、RSS 或启动时间改善幅度。
+
+## 6. 范围限制与回滚
+
+当前保留两条 Rust 集成路径：真实 CLI 子进程连接测试进程内的 daemon service，以及
+真实 daemon binary 接受测试客户端的 UDS 请求。CLI 与 daemon binary 共同运行的
+双进程 E2E 暂缓，不计为现有自动化门禁。存储仍为 process-local，未验证 durable
+persistence、重启恢复、Reconciler、AgentSight/ActPlane 或内核 enforcement。现有
+`TODO(policy-response-bounds)` 保留：提交后的超大 mutation response 可能失败，客户端
+只报告错误与未知结果，不提高上限也不重试。
+
+回滚时停止使用V2 `agent-sec-cli` binary，回退本变更引入的两个 crate、workspace/lockfile
+条目及配套文档/测试。同时撤回新增 daemon 管理员 UID 启动参数及对应 constructor，并从启动配置中移除该参数。
+不需要数据迁移，daemon wire、状态模型和 V1 Python CLI 未被修改。已通过 CLI 提交的 PAP mutation 不随 CLI 回滚自动撤销，需按 PAP 当前状态显式处理。
+
+仅回滚 CCLI-CR-006 时，须同时恢复客户端 async API、CLI runtime 调用及对应 transport
+测试和 Cargo 依赖；无需更改 daemon、协议、启动参数或数据。

--- a/src/agent-sec-core/docs/design/RUST_SECURITY_CORE_EXECUTION_ARCHITECTURE_zh.md
+++ b/src/agent-sec-core/docs/design/RUST_SECURITY_CORE_EXECUTION_ARCHITECTURE_zh.md
@@ -561,9 +561,9 @@ Tokio [`spawn_blocking`](https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocki
 
 ## 10. Adapter 边界
 
-### 10.1 asc-cli 与 protocol client
+### 10.1 agent-sec-cli 与 protocol client
 
-asc-cli 是 Rust daemon client，只负责：
+agent-sec-cli 是 Rust daemon client，只负责：
 
 1. 解析 CLI 参数和终端输入；
 2. 构造版本化 RPC request 和 trace carrier；
@@ -571,7 +571,7 @@ asc-cli 是 Rust daemon client，只负责：
 4. 把 response 映射为 supported CLI 输出和 exit code；
 5. 在 daemon unavailable/version mismatch 时返回稳定错误。
 
-asc-cli 不构造 Principal、不直读 SQLite、不启动 daemon、不安装 event writer，也不通过
+agent-sec-cli 不构造 Principal、不直读 SQLite、不启动 daemon、不安装 event writer，也不通过
 PyO3、Python backend 或另一套 local executor 执行业务 action。
 
 ### 10.2 asc-daemon-handler inbound adapter
@@ -679,7 +679,7 @@ daemon handler 只接已冻结的 ActionSpec/MethodSpec，并验证 timeout、di
 | RSCE-013 | transport/binding、action schema 和 domain validation 的责任及 error layer 与 oracle 一致 |
 | RSCE-014 | V2 只接受标准 `traceparent/tracestate`；不存在 AgentSec 自定义 trace ID 生成、fallback 或解析路径 |
 | RSCE-015 | daemon request、security invocation 和 capability span 都有有效 OTel TraceId/SpanId，父子关系可验证 |
-| RSCE-020 | asc-cli 不执行 local fallback、不直读 SQLite、不构造自报 Principal；daemon unavailable 返回稳定错误 |
+| RSCE-020 | agent-sec-cli 不执行 local fallback、不直读 SQLite、不构造自报 Principal；daemon unavailable 返回稳定错误 |
 | RSCE-021 | Action Slice 在 system daemon 上以两个 UID 验证 owner isolation 和服务端 QueryScope |
 | RSCE-016 | session/run/call/tool-call/action/backend/policy/verdict 只作为有界 AgentSec semantic attributes，不替代 OTel identity |
 | RSCE-017 | sampling、无 exporter、Collector/export failure 不改变 ActionResult，且每次已路由 invocation 的 SecurityEvent 仍按契约尝试落盘 |

--- a/src/agent-sec-core/docs/design/SECURITY_ACTIONS_REFERENCE_zh.md
+++ b/src/agent-sec-core/docs/design/SECURITY_ACTIONS_REFERENCE_zh.md
@@ -612,7 +612,7 @@ request 中非 null `passphrase` 必须写成 `[REDACTED]`。event result key �
 
 环境变量和路径进入 compatibility inventory；V2 不自动保留 HOME/XDG/per-user 布局。
 **[TARGET V2]** 由 capability/config contract 统一解析领域配置，asc-daemon composition
-root 注入依赖；asc-cli 只处理终端交互和 RPC DTO，不读取领域状态或复制默认值。
+root 注入依赖；agent-sec-cli 只处理终端交互和 RPC DTO，不读取领域状态或复制默认值。
 
 ## 12. V1/Rust action conformance
 
@@ -636,7 +636,7 @@ root 注入依赖；asc-cli 只处理终端交互和 RPC DTO，不读取领域�
 | --- | --- |
 | SAR-008 | Python oracle 与 Rust CapabilityExecutor/action-runtime 比较完整 ActionResult、event 和副作用；daemon compatibility adapter 只比较 V1 projection |
 | SAR-009 | 八个 action handler 候选的 method/params、authorization、未知字段、错误层级和失败 projection 经 protocol Definition Review 后与本参考一致 |
-| SAR-010 | asc-cli 不通过 PyO3/local backend 执行 action；daemon unavailable 返回稳定错误 |
+| SAR-010 | agent-sec-cli 不通过 PyO3/local backend 执行 action；daemon unavailable 返回稳定错误 |
 
 各 action 的最低 fixture：
 

--- a/src/agent-sec-core/docs/design/SECURITY_MIDDLEWARE_CONTRACT_zh.md
+++ b/src/agent-sec-core/docs/design/SECURITY_MIDDLEWARE_CONTRACT_zh.md
@@ -59,7 +59,7 @@ Rust-specific execution、lifecycle 和 observability 的候选实现架构见
 ### 2.2 **[TARGET V2]** Rust 执行路径
 
 1. asc-daemon、Job 和其它正式入口通过 asc-daemon-core 调用同一 asc-action-runtime。
-2. asc-cli 是 daemon client；daemon 不可用时不使用 PyO3、Python backend 或通用本地 fallback。
+2. agent-sec-cli 是 daemon client；daemon 不可用时不使用 PyO3、Python backend 或通用本地 fallback。
 3. Rust panic、V1 Python traceback 或底层任意异常不得穿过进程/protocol boundary 成为未结构化输出。
 4. adapter 只能投影 Action Runtime result，不得复制或重新解释 CapabilityExecutor、lifecycle、event 和
    redaction 语义。
@@ -543,7 +543,7 @@ boundary failure 才返回 `ok=false`。需要 product error type 的新 wire co
 | SMC-012 | 当前 Python oracle 与 Rust action-runtime 对同 fixture 的六字段 ActionResult、core error、event 和副作用等价 |
 | SMC-013 | daemon、Job 和其它入口调用同一 lifecycle owner，每次 invocation 最多一条 event |
 | SMC-014 | panic/traceback/secret 不跨 process 或 protocol boundary 泄露 |
-| SMC-015 | daemon 不存在时 asc-cli 返回稳定 unavailable，不启动用户 daemon、不使用 PyO3 或本地业务 fallback |
+| SMC-015 | daemon 不存在时 agent-sec-cli 返回稳定 unavailable，不启动用户 daemon、不使用 PyO3 或本地业务 fallback |
 | SMC-016 | V1 daemon adapter 只比较 `data/stdout/stderr/exit_code` projection 与 `ok` response layer；内部 action-runtime 比较完整六字段 ActionResult |
 | SMC-017 | V2 ingress 只使用 `traceparent/tracestate`，不存在 AgentSec 自定义 trace ID 生成、fallback、hash 或格式转换 |
 | SMC-018 | 合法上游 carrier 在 daemon request、action invocation 和 CapabilityExecutor 间保持同一 TraceId，并形成可验证的父子 SpanId |

--- a/src/agent-sec-core/v2/Cargo.lock
+++ b/src/agent-sec-core/v2/Cargo.lock
@@ -3,6 +3,79 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "asc-cli"
+version = "0.1.0"
+dependencies = [
+ "asc-daemon",
+ "asc-daemon-client",
+ "asc-daemon-core",
+ "asc-daemon-handler",
+ "asc-daemon-protocol",
+ "asc-daemon-service",
+ "asc-foundation-types",
+ "asc-pap",
+ "asc-pap-repository-memory",
+ "asc-policy-engine",
+ "asc-policy-types",
+ "clap",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "asc-daemon"
 version = "0.1.0"
 dependencies = [
@@ -18,6 +91,17 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "asc-daemon-client"
+version = "0.1.0"
+dependencies = [
+ "asc-daemon-protocol",
+ "serde_json",
+ "socket2",
+ "thiserror",
  "uuid",
 ]
 
@@ -142,6 +226,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +365,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +427,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pin-project-lite"
@@ -409,6 +557,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +672,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/src/agent-sec-core/v2/Cargo.toml
+++ b/src/agent-sec-core/v2/Cargo.toml
@@ -3,7 +3,9 @@
 [workspace]
 resolver = "3"
 members = [
+    "apps/asc-cli",
     "apps/asc-daemon",
+    "crates/daemon/asc-daemon-client",
     "crates/daemon/asc-daemon-core",
     "crates/daemon/asc-daemon-handler",
     "crates/daemon/asc-daemon-protocol",
@@ -24,6 +26,8 @@ repository = "https://github.com/alibaba/anolisa"
 publish = false
 
 [workspace.dependencies]
+asc-daemon = { path = "apps/asc-daemon" }
+asc-daemon-client = { path = "crates/daemon/asc-daemon-client" }
 asc-daemon-core = { path = "crates/daemon/asc-daemon-core" }
 asc-daemon-handler = { path = "crates/daemon/asc-daemon-handler" }
 asc-daemon-protocol = { path = "crates/daemon/asc-daemon-protocol" }
@@ -33,8 +37,10 @@ asc-pap = { path = "crates/policy/asc-pap" }
 asc-pap-repository-memory = { path = "crates/policy/asc-pap-repository-memory" }
 asc-policy-engine = { path = "crates/policy/asc-policy-engine" }
 asc-policy-types = { path = "crates/policy/asc-policy-types" }
+clap = { version = "4.6", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+socket2 = "0.6"
 sha2 = "0.10"
 thiserror = "2"
 time = { version = "=0.3.44", features = ["parsing"] }

--- a/src/agent-sec-core/v2/README.md
+++ b/src/agent-sec-core/v2/README.md
@@ -7,6 +7,11 @@ foreground process bootstrap used by later AgentSecCore V2 work packages. It
 deliberately contains no concrete persistence, Policy runtime, reconciliation
 worker, outbox, or target Adapter.
 
+The Rust `agent-sec-cli` exposes all 15 Policy, Scope and Binding CRUD commands through
+an explicit daemon socket. Its Cargo package and source directory remain `asc-cli`;
+the executable target is `agent-sec-cli`. See the [CLI reference](../../../docs/user-guide/en/agent-security/agent-sec-core/policy-cli.md)
+and [CLI acceptance record](../docs/design/POLICY_CLI_ACCEPTANCE_zh.md).
+
 The current crates are:
 
 - `asc-foundation-types`: bounded transport-independent identifiers and revisions.
@@ -33,6 +38,14 @@ The current crates are:
 - `asc-daemon-service`: bounded UDS admission, one-request framing, kernel peer
   credentials, dispatcher/rejection-encoder injection, connection isolation,
   dispatch cancellation, and controlled drain.
+- `asc-daemon-client`: synchronous UDS client preserving complete responses, with
+  a single connect/write/read deadline and no retries or local fallback. It uses
+  standard-library blocking I/O and `socket2` for bounded connect; neither it nor
+  the CLI binary requires a Tokio runtime.
+- `asc-cli`: command parsing, typed Policy request construction and Policy output;
+  server dependencies are test-only. `commands.rs` registers and dispatches the
+  top-level commands; `commands/{policy,scope,binding}.rs` own their arguments and
+  request mappings, with pagination and encoding helpers in `commands/common.rs`.
 - `asc-daemon`: foreground process and composition root that configures and
   injects concrete adapters into the daemon service.
 
@@ -90,10 +103,12 @@ startup. It also requires an explicit absolute socket path because
 packaging-owned system paths, singleton/stale-socket policy, runtime directory
 hardening, and readiness remain later process-integration work.
 
-UID 0 is always a Policy administrator. Other UIDs are denied until root adds
-them to the process-local allowlist. Delegated administrators cannot delegate
-other UIDs. Loading, persisting, and exposing management RPCs for that allowlist
-remain later daemon state/configuration work.
+UID 0 is always a Policy administrator. A deployment operator can add other UIDs
+at startup with repeatable `--policy-admin-uid <UID>` options. Omitted means root
+only. Configured administrators cannot delegate other UIDs at runtime; that API
+still requires root. The allowlist is process-local and must be supplied on each
+startup. Configuration-file loading, persistence and management RPCs remain later
+work. Authorization does not change OS socket permissions or deployment topology.
 
 Run the independent transport process in the foreground:
 
@@ -123,9 +138,10 @@ statuses, and deterministic digests. Server-generated request and resource UUIDs
 use named placeholders so the same fixture can assert their format and identity
 flow across later requests. A UDS integration E2E always executes the complete
 scenario with a server-authorized test principal. The `asc-daemon` bootstrap E2E
-also starts the real binary and repeats that scenario when the process is root;
-a non-root binary run instead verifies the product's default
-`permission_denied` policy.
+also starts the real binary with `--policy-admin-uid` set to the test UID and
+executes the complete scenario without root. A separate default-config case
+verifies non-root `permission_denied` (or full CRUD when root). CLI process tests
+use an in-process daemon service; a combined CLI and daemon binary E2E is deferred.
 
 Binding create/update accepts desired state and returns `PENDING_APPLY`; delete
 returns `PENDING_DELETE`. These responses prove PAP acceptance only. They do not
@@ -245,7 +261,7 @@ Binding replacement and its reconcile intent atomically, then let the future
 Reconciler consume one complete `BindingView` whose embedded revision fences
 claim, retry, completion, failure, restart recovery, and cancellation.
 
-CLI client, concrete persistence, Policy runtime, reconciliation worker, outbox,
+Concrete persistence, Policy runtime, reconciliation worker, outbox,
 and target Adapter belong to later work packages and are intentionally absent
 from this slice. The compiler included here is limited to the one golden-backed
 `prevent_file_deletion` lowering described above.

--- a/src/agent-sec-core/v2/apps/asc-cli/Cargo.toml
+++ b/src/agent-sec-core/v2/apps/asc-cli/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "asc-cli"
+description = "Daemon-only AgentSecCore CLI with Policy, Scope and Binding CRUD"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[[bin]]
+name = "agent-sec-cli"
+path = "src/main.rs"
+
+[dependencies]
+asc-daemon-client = { workspace = true }
+asc-daemon-protocol = { workspace = true }
+asc-foundation-types = { workspace = true }
+asc-policy-types = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+asc-daemon = { workspace = true }
+asc-daemon-core = { workspace = true }
+asc-daemon-handler = { workspace = true }
+asc-daemon-service = { workspace = true }
+asc-pap = { workspace = true }
+asc-pap-repository-memory = { workspace = true }
+asc-policy-engine = { workspace = true }
+uuid = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/apps/asc-cli/src/commands.rs
+++ b/src/agent-sec-core/v2/apps/asc-cli/src/commands.rs
@@ -1,0 +1,37 @@
+//! Top-level command registration and request dispatch.
+
+mod binding;
+mod common;
+mod policy;
+mod scope;
+
+use asc_daemon_protocol::DaemonRequest;
+use clap::Subcommand;
+
+use self::binding::BindingCommand;
+use self::policy::PolicyCommand;
+use self::scope::ScopeCommand;
+use crate::InputError;
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum Command {
+    /// Manage authored Policy templates.
+    #[command(subcommand)]
+    Policy(PolicyCommand),
+    /// Manage PID or cgroup Scope selectors.
+    #[command(subcommand)]
+    Scope(ScopeCommand),
+    /// Manage Binding desired state; acceptance does not imply enforcement.
+    #[command(subcommand)]
+    Binding(BindingCommand),
+}
+
+impl Command {
+    pub(crate) fn request(&self) -> Result<DaemonRequest, InputError> {
+        match self {
+            Self::Policy(command) => command.request(),
+            Self::Scope(command) => command.request(),
+            Self::Binding(command) => command.request(),
+        }
+    }
+}

--- a/src/agent-sec-core/v2/apps/asc-cli/src/commands/binding.rs
+++ b/src/agent-sec-core/v2/apps/asc-cli/src/commands/binding.rs
@@ -1,0 +1,88 @@
+//! Binding commands mapping desired-state references to PAP requests.
+
+use asc_daemon_protocol::method::{
+    POLICY_BINDINGS_CREATE, POLICY_BINDINGS_DELETE, POLICY_BINDINGS_GET, POLICY_BINDINGS_LIST,
+    POLICY_BINDINGS_UPDATE,
+};
+use asc_daemon_protocol::{
+    CreateBindingParams, DaemonRequest, ResourceParams, UpdateBindingParams,
+};
+use asc_foundation_types::{ResourceId, Revision};
+use clap::{Args, Subcommand};
+
+use super::common::{Page, encode, resource_id, revision};
+use crate::InputError;
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum BindingCommand {
+    /// Create an Apply intent with a server-generated ID.
+    Create(BindingInput),
+    /// Read the current Binding and lifecycle status.
+    Get(BindingId),
+    /// List one page of current Bindings.
+    List(Page),
+    /// Replace an existing Binding's references and request Apply.
+    Update {
+        #[arg(long, value_parser = resource_id)]
+        binding_id: ResourceId,
+        #[command(flatten)]
+        input: BindingInput,
+    },
+    /// Request deletion; completion is asynchronous.
+    Delete(BindingId),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct BindingId {
+    #[arg(long, value_parser = resource_id)]
+    binding_id: ResourceId,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct BindingInput {
+    #[arg(long, value_parser = resource_id)]
+    policy_id: ResourceId,
+    #[arg(long, value_parser = revision)]
+    policy_revision: Revision,
+    #[arg(long, value_parser = resource_id)]
+    scope_id: ResourceId,
+    #[arg(long, value_parser = revision)]
+    scope_revision: Revision,
+}
+
+impl BindingCommand {
+    pub(super) fn request(&self) -> Result<DaemonRequest, InputError> {
+        match self {
+            Self::Create(input) => encode(
+                POLICY_BINDINGS_CREATE,
+                &CreateBindingParams {
+                    policy_id: input.policy_id.clone(),
+                    policy_revision: input.policy_revision,
+                    scope_id: input.scope_id.clone(),
+                    scope_revision: input.scope_revision,
+                },
+            ),
+            Self::Update { binding_id, input } => encode(
+                POLICY_BINDINGS_UPDATE,
+                &UpdateBindingParams {
+                    binding_id: binding_id.clone(),
+                    policy_id: input.policy_id.clone(),
+                    policy_revision: input.policy_revision,
+                    scope_id: input.scope_id.clone(),
+                    scope_revision: input.scope_revision,
+                },
+            ),
+            Self::Get(input) | Self::Delete(input) => encode(
+                if matches!(self, Self::Get(_)) {
+                    POLICY_BINDINGS_GET
+                } else {
+                    POLICY_BINDINGS_DELETE
+                },
+                &ResourceParams {
+                    id: input.binding_id.clone(),
+                },
+            ),
+            Self::List(page) => encode(POLICY_BINDINGS_LIST, &page.params()),
+        }
+    }
+}

--- a/src/agent-sec-core/v2/apps/asc-cli/src/commands/common.rs
+++ b/src/agent-sec-core/v2/apps/asc-cli/src/commands/common.rs
@@ -1,0 +1,43 @@
+//! Shared pagination, identifier parsing and daemon request encoding.
+
+use asc_daemon_protocol::{DaemonRequest, ListParams};
+use asc_foundation_types::{ResourceId, Revision};
+use clap::Args;
+use serde::Serialize;
+
+use crate::InputError;
+
+#[derive(Debug, Args)]
+pub(crate) struct Page {
+    /// Number of records in this page (1..=1000).
+    #[arg(long, default_value_t = 100, value_parser = clap::value_parser!(u32).range(1..=1000))]
+    limit: u32,
+    /// Zero-based offset; the CLI does not fetch additional pages automatically.
+    #[arg(long, default_value_t = 0)]
+    offset: u32,
+}
+
+impl Page {
+    pub(super) fn params(&self) -> ListParams {
+        ListParams {
+            limit: self.limit,
+            offset: self.offset,
+        }
+    }
+}
+
+pub(super) fn encode(method: &str, params: &impl Serialize) -> Result<DaemonRequest, InputError> {
+    Ok(DaemonRequest {
+        method: method.to_owned(),
+        params: serde_json::to_value(params)?,
+    })
+}
+
+pub(super) fn resource_id(value: &str) -> Result<ResourceId, String> {
+    ResourceId::new(value).map_err(|error| error.to_string())
+}
+
+pub(super) fn revision(value: &str) -> Result<Revision, String> {
+    let number = value.parse::<u32>().map_err(|error| error.to_string())?;
+    Revision::new(number).map_err(|error| error.to_string())
+}

--- a/src/agent-sec-core/v2/apps/asc-cli/src/commands/policy.rs
+++ b/src/agent-sec-core/v2/apps/asc-cli/src/commands/policy.rs
@@ -1,0 +1,103 @@
+//! Authored Policy commands and bounded template-file decoding.
+
+use std::fs::File;
+use std::io::Read as _;
+use std::path::PathBuf;
+
+use asc_daemon_protocol::method::{
+    POLICY_TEMPLATES_CREATE, POLICY_TEMPLATES_DELETE, POLICY_TEMPLATES_GET, POLICY_TEMPLATES_LIST,
+    POLICY_TEMPLATES_UPDATE,
+};
+use asc_daemon_protocol::{CreatePolicyParams, DaemonRequest, RevisionParams, UpdatePolicyParams};
+use asc_foundation_types::{ResourceId, Revision};
+use asc_policy_types::authoring::PolicyTemplate;
+use clap::{Args, Subcommand};
+
+use super::common::{Page, encode, resource_id, revision};
+use crate::InputError;
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum PolicyCommand {
+    /// Create a Policy with a server-generated ID.
+    Create(PolicyInput),
+    /// Read the exact current revision.
+    Get(PolicyRevision),
+    /// List one page of current Policies.
+    List(Page),
+    /// Replace an existing Policy's name and complete template (not upsert).
+    Update {
+        #[arg(long, value_parser = resource_id)]
+        policy_id: ResourceId,
+        #[command(flatten)]
+        input: PolicyInput,
+    },
+    /// Delete the exact current revision.
+    Delete(PolicyRevision),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PolicyInput {
+    /// Complete Policy name.
+    #[arg(long)]
+    name: String,
+    /// JSON `PolicyTemplate` file, resolved in the CLI's working directory.
+    #[arg(long)]
+    file: PathBuf,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PolicyRevision {
+    #[arg(long, value_parser = resource_id)]
+    policy_id: ResourceId,
+    #[arg(long, value_parser = revision)]
+    revision: Revision,
+}
+
+impl PolicyCommand {
+    pub(super) fn request(&self) -> Result<DaemonRequest, InputError> {
+        match self {
+            Self::Create(input) => encode(
+                POLICY_TEMPLATES_CREATE,
+                &CreatePolicyParams {
+                    policy_name: input.name.clone(),
+                    template: input.template()?,
+                },
+            ),
+            Self::Update { policy_id, input } => encode(
+                POLICY_TEMPLATES_UPDATE,
+                &UpdatePolicyParams {
+                    policy_id: policy_id.clone(),
+                    policy_name: input.name.clone(),
+                    template: input.template()?,
+                },
+            ),
+            Self::Get(input) | Self::Delete(input) => encode(
+                if matches!(self, Self::Get(_)) {
+                    POLICY_TEMPLATES_GET
+                } else {
+                    POLICY_TEMPLATES_DELETE
+                },
+                &RevisionParams {
+                    id: input.policy_id.clone(),
+                    revision: input.revision,
+                },
+            ),
+            Self::List(page) => encode(POLICY_TEMPLATES_LIST, &page.params()),
+        }
+    }
+}
+
+impl PolicyInput {
+    fn template(&self) -> Result<PolicyTemplate, InputError> {
+        let mut bytes = Vec::new();
+        File::open(&self.file)?
+            .take(4 * 1024 * 1024 + 1)
+            .read_to_end(&mut bytes)?;
+        if bytes.len() > asc_daemon_client::MAX_FRAME_BYTES {
+            return Err(InputError::TooLarge);
+        }
+        // Decode the typed template before conversion to Value, so duplicate
+        // fields cannot be silently collapsed by an untyped JSON map.
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+}

--- a/src/agent-sec-core/v2/apps/asc-cli/src/commands/scope.rs
+++ b/src/agent-sec-core/v2/apps/asc-cli/src/commands/scope.rs
@@ -1,0 +1,93 @@
+//! Scope commands and mutually exclusive process/cgroup selectors.
+
+use asc_daemon_protocol::method::{
+    POLICY_SCOPES_CREATE, POLICY_SCOPES_DELETE, POLICY_SCOPES_GET, POLICY_SCOPES_LIST,
+    POLICY_SCOPES_UPDATE,
+};
+use asc_daemon_protocol::{CreateScopeParams, DaemonRequest, RevisionParams, UpdateScopeParams};
+use asc_foundation_types::{ResourceId, Revision};
+use asc_policy_types::scope::ScopeSelector;
+use clap::{Args, Subcommand};
+
+use super::common::{Page, encode, resource_id, revision};
+use crate::InputError;
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum ScopeCommand {
+    /// Create a Scope with a server-generated ID.
+    Create(Selector),
+    /// Read the exact current revision.
+    Get(ScopeRevision),
+    /// List one page of current Scopes.
+    List(Page),
+    /// Replace an existing Scope's complete selector (not upsert).
+    Update {
+        #[arg(long, value_parser = resource_id)]
+        scope_id: ResourceId,
+        #[command(flatten)]
+        selector: Selector,
+    },
+    /// Delete the exact current revision.
+    Delete(ScopeRevision),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ScopeRevision {
+    #[arg(long, value_parser = resource_id)]
+    scope_id: ResourceId,
+    #[arg(long, value_parser = revision)]
+    revision: Revision,
+}
+
+#[derive(Debug, Args)]
+#[group(required = true, multiple = false)]
+pub(crate) struct Selector {
+    /// Positive root process ID.
+    #[arg(long, value_parser = clap::value_parser!(u32).range(1..))]
+    pid: Option<u32>,
+    /// Positive cgroup ID; mutually exclusive with --pid.
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
+    cgroup_id: Option<u64>,
+}
+
+impl ScopeCommand {
+    pub(super) fn request(&self) -> Result<DaemonRequest, InputError> {
+        match self {
+            Self::Create(selector) => encode(
+                POLICY_SCOPES_CREATE,
+                &CreateScopeParams {
+                    selector: selector.value(),
+                },
+            ),
+            Self::Update { scope_id, selector } => encode(
+                POLICY_SCOPES_UPDATE,
+                &UpdateScopeParams {
+                    scope_id: scope_id.clone(),
+                    selector: selector.value(),
+                },
+            ),
+            Self::Get(input) | Self::Delete(input) => encode(
+                if matches!(self, Self::Get(_)) {
+                    POLICY_SCOPES_GET
+                } else {
+                    POLICY_SCOPES_DELETE
+                },
+                &RevisionParams {
+                    id: input.scope_id.clone(),
+                    revision: input.revision,
+                },
+            ),
+            Self::List(page) => encode(POLICY_SCOPES_LIST, &page.params()),
+        }
+    }
+}
+
+impl Selector {
+    fn value(&self) -> ScopeSelector {
+        match (self.pid, self.cgroup_id) {
+            (Some(pid), None) => ScopeSelector::Pid { pid },
+            (None, Some(cgroup_id)) => ScopeSelector::CgroupId { cgroup_id },
+            _ => unreachable!("clap requires exactly one selector; fields are private"),
+        }
+    }
+}

--- a/src/agent-sec-core/v2/apps/asc-cli/src/lib.rs
+++ b/src/agent-sec-core/v2/apps/asc-cli/src/lib.rs
@@ -1,0 +1,117 @@
+//! Command parsing and input preparation, separate from transport and rendering.
+
+mod commands;
+pub mod output;
+
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStrExt as _;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use asc_daemon_protocol::DaemonRequest;
+use clap::Parser;
+use commands::Command;
+
+/// Parsed invocation. Only Policy administration commands are currently exposed.
+#[derive(Debug)]
+pub struct Cli {
+    /// Absolute endpoint of an already-running daemon.
+    pub socket: PathBuf,
+    timeout_ms: u32,
+    command: Command,
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "agent-sec-cli",
+    version,
+    about = "Manage Policy, Scope and Binding through asc-daemon"
+)]
+struct Arguments {
+    /// Absolute endpoint of an already-running daemon.
+    #[arg(long, global = true)]
+    socket: Option<PathBuf>,
+    /// Total connect/write/read deadline in milliseconds; requests are never retried.
+    #[arg(long, global = true, default_value_t = 5000, value_parser = clap::value_parser!(u32).range(1..))]
+    timeout_ms: u32,
+    #[command(subcommand)]
+    command: Command,
+}
+
+impl Cli {
+    /// Parses argv including its executable name, preserving OS-native file paths.
+    ///
+    /// # Errors
+    /// Returns clap help/version outcomes or usage errors; never connects to a daemon.
+    pub fn parse_from<I, T>(arguments: I) -> Result<Self, clap::Error>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        let argv: Vec<OsString> = arguments.into_iter().map(Into::into).collect();
+        let arguments = Arguments::try_parse_from(&argv)?;
+        // Clap propagates global values across subcommands using last-wins.
+        // After successful parsing, a standalone --option token cannot be a
+        // value: these commands do not accept hyphen values or positional tails.
+        for option in ["--socket", "--timeout-ms"] {
+            let count = argv
+                .iter()
+                .skip(1)
+                .filter(|argument| {
+                    argument.as_bytes().split(|byte| *byte == b'=').next()
+                        == Some(option.as_bytes())
+                })
+                .count();
+            if count > 1 {
+                return Err(clap::Error::raw(
+                    clap::error::ErrorKind::ArgumentConflict,
+                    format!("{option} may be specified only once"),
+                ));
+            }
+        }
+        let socket = arguments.socket.ok_or_else(|| {
+            clap::Error::raw(
+                clap::error::ErrorKind::MissingRequiredArgument,
+                "--socket <ABSOLUTE_PATH> is required",
+            )
+        })?;
+        if !socket.is_absolute() {
+            return Err(clap::Error::raw(
+                clap::error::ErrorKind::ValueValidation,
+                "--socket must be an absolute path",
+            ));
+        }
+        Ok(Self {
+            socket,
+            timeout_ms: arguments.timeout_ms,
+            command: arguments.command,
+        })
+    }
+
+    /// Returns the single call deadline duration.
+    pub fn timeout(&self) -> Duration {
+        Duration::from_millis(u64::from(self.timeout_ms))
+    }
+
+    /// Delegates to the selected command to construct a typed daemon request.
+    ///
+    /// # Errors
+    /// Returns a file read, template decode, or request encoding error.
+    pub fn request(&self) -> Result<DaemonRequest, InputError> {
+        self.command.request()
+    }
+}
+
+/// Local input failures, reported as execution failures rather than daemon errors.
+#[derive(Debug, thiserror::Error)]
+pub enum InputError {
+    /// Template file access failed.
+    #[error("cannot read Policy template: {0}")]
+    Read(#[from] std::io::Error),
+    /// Bound input before parsing or constructing a request.
+    #[error("Policy template exceeds the 4194304-byte input limit")]
+    TooLarge,
+    /// Invalid authoring JSON or request serialization.
+    #[error("invalid Policy request input: {0}")]
+    Json(#[from] serde_json::Error),
+}

--- a/src/agent-sec-core/v2/apps/asc-cli/src/main.rs
+++ b/src/agent-sec-core/v2/apps/asc-cli/src/main.rs
@@ -1,0 +1,36 @@
+use std::io;
+use std::process::ExitCode;
+
+use asc_cli::{Cli, output::render_policy};
+
+fn main() -> ExitCode {
+    let cli = match Cli::parse_from(std::env::args_os()) {
+        Ok(cli) => cli,
+        Err(error) => {
+            let code = if error.use_stderr() { 2 } else { 0 };
+            return if error.print().is_ok() {
+                ExitCode::from(code)
+            } else {
+                ExitCode::FAILURE
+            };
+        }
+    };
+    match run(&cli) {
+        Ok(code) => ExitCode::from(code),
+        Err(error) => {
+            eprintln!("agent-sec-cli: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(cli: &Cli) -> Result<u8, Box<dyn std::error::Error>> {
+    let request = cli.request()?;
+    let response = asc_daemon_client::call(&cli.socket, &request, cli.timeout())?;
+    render_policy(
+        &response,
+        &mut io::stdout().lock(),
+        &mut io::stderr().lock(),
+    )
+    .map_err(Into::into)
+}

--- a/src/agent-sec-core/v2/apps/asc-cli/src/output.rs
+++ b/src/agent-sec-core/v2/apps/asc-cli/src/output.rs
@@ -1,0 +1,28 @@
+//! Policy output policy; transport does not select presentation or process exit codes.
+
+use std::io::{self, Write};
+
+use asc_daemon_protocol::DaemonResponse;
+
+/// Prints a Policy result to stdout or the complete daemon error to stderr.
+///
+/// # Errors
+/// Returns output encoding or write failures, including a closed output pipe.
+pub fn render_policy(
+    response: &DaemonResponse,
+    stdout: &mut impl Write,
+    stderr: &mut impl Write,
+) -> io::Result<u8> {
+    match response {
+        DaemonResponse::Success(success) => {
+            serde_json::to_writer_pretty(&mut *stdout, &success.result)?;
+            writeln!(stdout)?;
+            Ok(0)
+        }
+        DaemonResponse::Error(error) => {
+            serde_json::to_writer(&mut *stderr, error)?;
+            writeln!(stderr)?;
+            Ok(1)
+        }
+    }
+}

--- a/src/agent-sec-core/v2/apps/asc-cli/tests/commands.rs
+++ b/src/agent-sec-core/v2/apps/asc-cli/tests/commands.rs
@@ -1,0 +1,299 @@
+use std::ffi::OsString;
+
+use asc_cli::{Cli, InputError, output::render_policy};
+use asc_daemon_protocol::{DaemonResponse, RequestId};
+use serde_json::{Value, json};
+
+mod common;
+
+#[test]
+fn all_fifteen_commands_match_frozen_wire_parameters() {
+    let directory = common::Directory::new();
+    let methods: Value = serde_json::from_str(common::METHODS).unwrap();
+    let mut covered = std::collections::BTreeSet::new();
+    for row in methods.as_array().unwrap() {
+        let mut args = vec![OsString::from("agent-sec-cli")];
+        args.extend(common::args_for(
+            row,
+            &directory.0,
+            &directory.0.join("socket"),
+        ));
+        let actual =
+            serde_json::to_value(Cli::parse_from(args).unwrap().request().unwrap()).unwrap();
+        assert_eq!(
+            actual,
+            json!({"method": row["method"], "params": row["canonicalParams"]})
+        );
+        covered.insert(row["method"].as_str().unwrap());
+    }
+    assert_eq!(
+        covered,
+        asc_daemon_protocol::method::PAP_METHODS
+            .into_iter()
+            .collect()
+    );
+}
+
+#[test]
+fn equals_syntax_option_looking_values_and_os_native_paths_are_preserved() {
+    use std::os::unix::ffi::OsStringExt as _;
+    let directory = common::Directory::new();
+    let file = directory
+        .0
+        .join(OsString::from_vec(b"policy-\xff.json".to_vec()));
+    std::fs::write(
+        &file,
+        br#"{"kind":"prevent_file_deletion","files":["/work/a b"]}"#,
+    )
+    .unwrap();
+    let args: Vec<OsString> = vec![
+        "agent-sec-cli".into(),
+        "policy".into(),
+        "create".into(),
+        "--name=--help".into(),
+        "--file".into(),
+        file.into_os_string(),
+        "--socket=/run/asc.sock".into(),
+    ];
+    let request = Cli::parse_from(args).unwrap().request().unwrap();
+    assert_eq!(request.params["policyName"], "--help");
+    assert_eq!(request.params["template"]["files"][0], "/work/a b");
+}
+
+#[test]
+fn invalid_and_ambiguous_options_are_usage_errors() {
+    let cases = [
+        vec!["policy", "get", "--policy-id", "p"],
+        vec!["policy", "get", "--policy-id", "p", "--revision", "0"],
+        vec!["policy", "get", "--policy-id", "", "--revision", "1"],
+        vec!["policy", "list", "--limit", "1001"],
+        vec!["policy", "list", "--limit", "0"],
+        vec!["scope", "list", "--offset", "4294967296"],
+        vec!["scope", "list", "--offset", "-1"],
+        vec!["scope", "create"],
+        vec!["scope", "create", "--pid", "0"],
+        vec!["scope", "create", "--cgroup-id", "0"],
+        vec!["scope", "create", "--pid", "1", "--cgroup-id", "2"],
+        vec!["scope", "create", "--pid", "1", "--pid", "2"],
+        vec!["policy", "list", "--timeout-ms", "0"],
+        vec!["--timeout-ms", "100", "policy", "list", "--timeout-ms=200"],
+        vec!["policy", "list", "--unknown"],
+        vec!["policy", "list", "--role", "admin"],
+        vec!["binding", "get", "--binding-id", "b", "--revision", "1"],
+        vec!["policy", "create", "--name", "--help", "--file", "x"],
+        vec!["policy", "list", "--socket", "/run/other.sock"],
+    ];
+    for case in cases {
+        let mut args = vec!["agent-sec-cli", "--socket", "/run/asc.sock"];
+        args.extend(case);
+        let error = Cli::parse_from(args.clone()).unwrap_err();
+        assert!(error.use_stderr(), "{args:?} unexpectedly produced help");
+    }
+    assert!(Cli::parse_from(["agent-sec-cli", "policy", "list"]).is_err());
+    assert!(
+        Cli::parse_from([
+            "agent-sec-cli",
+            "--socket",
+            "relative.sock",
+            "policy",
+            "list"
+        ])
+        .is_err()
+    );
+}
+
+#[test]
+fn repeated_socket_options_reject_non_utf8_inline_paths_at_every_level() {
+    use std::os::unix::ffi::OsStringExt as _;
+
+    let native = OsString::from_vec(b"--socket=/run/asc-\xff.sock".to_vec());
+    let endpoints = [
+        vec![native.clone()],
+        vec!["--socket=/run/other.sock".into()],
+        vec!["--socket".into(), "/run/other.sock".into()],
+    ];
+    for endpoint in endpoints {
+        for (first, second) in [
+            (vec![native.clone()], endpoint.clone()),
+            (endpoint, vec![native.clone()]),
+        ] {
+            for position in [1, 2] {
+                let mut args = first.clone();
+                args.extend(["policy", "list"][..position].iter().map(OsString::from));
+                args.extend(second.clone());
+                args.extend(["policy", "list"][position..].iter().map(OsString::from));
+                let error = Cli::parse_from(
+                    std::iter::once(OsString::from("agent-sec-cli")).chain(args.clone()),
+                )
+                .unwrap_err();
+                assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+                let output = common::run(&args);
+                assert_eq!(output.status.code(), Some(2), "{args:?}");
+                assert!(output.stdout.is_empty());
+                assert!(
+                    String::from_utf8_lossy(&output.stderr)
+                        .contains("--socket may be specified only once")
+                );
+            }
+        }
+    }
+
+    let cli = Cli::parse_from(vec![
+        "agent-sec-cli".into(),
+        native,
+        "policy".into(),
+        "list".into(),
+    ])
+    .unwrap();
+    assert_eq!(
+        cli.socket.into_os_string(),
+        OsString::from_vec(b"/run/asc-\xff.sock".to_vec())
+    );
+}
+
+#[test]
+fn file_errors_duplicate_keys_and_oversized_inputs_are_local_failures() {
+    let directory = common::Directory::new();
+    let path = directory.0.join("template.json");
+    let args = [
+        "agent-sec-cli",
+        "--socket",
+        "/run/absent.sock",
+        "policy",
+        "create",
+        "--name",
+        "test",
+        "--file",
+        path.to_str().unwrap(),
+    ];
+    assert!(matches!(
+        Cli::parse_from(args).unwrap().request(),
+        Err(InputError::Read(_))
+    ));
+    for bytes in [
+        b"not-json".as_slice(),
+        br#"{"kind":"prevent_file_deletion","files":[],"files":["/etc"]}"#,
+        br#"{"kind":"prevent_file_deletion","kind":"high_sensitivity_read_deny","files":["/etc"]}"#,
+        br#"{"kind":"low_sensitivity_egress","files":["/etc"],"trustedDestinations":[{"type":"host","pattern":"one","pattern":"two","ports":[443]}]}"#,
+        br#"{"kind":"prevent_file_deletion","files":[],"extra":true}"#,
+    ] {
+        std::fs::write(&path, bytes).unwrap();
+        assert!(matches!(
+            Cli::parse_from(args).unwrap().request(),
+            Err(InputError::Json(_))
+        ));
+    }
+    std::fs::write(&path, vec![b' '; 4 * 1024 * 1024 + 1]).unwrap();
+    assert!(matches!(
+        Cli::parse_from(args).unwrap().request(),
+        Err(InputError::TooLarge)
+    ));
+}
+
+#[test]
+fn result_rendering_keeps_domains_and_errors_separate() {
+    let response = DaemonResponse::success(
+        RequestId::new("r1").unwrap(),
+        json!({"status":"PENDING_APPLY"}),
+    );
+    let (mut stdout, mut stderr) = (Vec::new(), Vec::new());
+    assert_eq!(
+        render_policy(&response, &mut stdout, &mut stderr).unwrap(),
+        0
+    );
+    assert_eq!(
+        serde_json::from_slice::<Value>(&stdout).unwrap(),
+        json!({"status":"PENDING_APPLY"})
+    );
+    assert!(stderr.is_empty());
+    stdout.clear();
+    let response: DaemonResponse = DaemonResponse::error(
+        RequestId::new("r2").unwrap(),
+        "not_found",
+        "Policy not found",
+    );
+    assert_eq!(
+        render_policy(&response, &mut stdout, &mut stderr).unwrap(),
+        1
+    );
+    assert!(stdout.is_empty());
+    assert_eq!(
+        serde_json::from_slice::<Value>(&stderr).unwrap(),
+        json!({"requestId":"r2","error":{"code":"not_found","message":"Policy not found"}})
+    );
+}
+
+#[test]
+fn binary_help_version_and_failures_have_stable_exit_codes() {
+    let mut help_cases = vec![vec!["--help"], vec!["--version"]];
+    for resource in ["policy", "scope", "binding"] {
+        help_cases.push(vec![resource, "--help"]);
+        for operation in ["create", "get", "list", "update", "delete"] {
+            help_cases.push(vec![resource, operation, "--help"]);
+        }
+    }
+    for args in help_cases {
+        let output = common::run(&args.iter().map(OsString::from).collect::<Vec<_>>());
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if args == ["--version"] {
+            assert_eq!(
+                stdout,
+                format!("agent-sec-cli {}\n", env!("CARGO_PKG_VERSION"))
+            );
+        } else {
+            assert!(stdout.contains("Usage: agent-sec-cli"), "{stdout}");
+        }
+        assert!(output.stderr.is_empty());
+    }
+    let directory = common::Directory::new();
+    let socket = directory.0.join("absent.sock");
+    for (args, code, message) in [
+        (
+            vec!["--socket", socket.to_str().unwrap(), "policy", "list"],
+            1,
+            "connection unavailable",
+        ),
+        (vec!["policy", "list"], 2, "--socket"),
+        (
+            vec![
+                "--socket",
+                socket.to_str().unwrap(),
+                "scope",
+                "create",
+                "--pid",
+                "0",
+            ],
+            2,
+            "invalid value",
+        ),
+        (
+            vec![
+                "--socket",
+                socket.to_str().unwrap(),
+                "policy",
+                "create",
+                "--name",
+                "x",
+                "--file",
+                "/no-such-policy-input",
+            ],
+            1,
+            "cannot read Policy template",
+        ),
+    ] {
+        let output = common::run(&args.iter().map(OsString::from).collect::<Vec<_>>());
+        assert_eq!(output.status.code(), Some(code));
+        assert!(output.stdout.is_empty());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains(message));
+        if code == 1 {
+            assert!(stderr.starts_with("agent-sec-cli: "), "{stderr}");
+        }
+    }
+    assert!(!socket.exists());
+}

--- a/src/agent-sec-core/v2/apps/asc-cli/tests/common/mod.rs
+++ b/src/agent-sec-core/v2/apps/asc-cli/tests/common/mod.rs
@@ -1,0 +1,146 @@
+#![allow(dead_code)] // Shared by independent contract and process test targets.
+
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+use uuid::Uuid;
+
+pub const METHODS: &str =
+    include_str!("../../../../crates/daemon/asc-daemon-protocol/tests/fixtures/pap-methods.json");
+pub const SCENARIO: &str =
+    include_str!("../../../../crates/daemon/asc-daemon-protocol/tests/fixtures/pap-crud-e2e.json");
+
+pub struct Directory(pub PathBuf);
+impl Directory {
+    pub fn new() -> Self {
+        let path = std::env::temp_dir().join(format!("asc-cli-{}", Uuid::new_v4()));
+        std::fs::create_dir(&path).unwrap();
+        Self(path)
+    }
+}
+impl Drop for Directory {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+pub fn args_for(request: &Value, directory: &Path, socket: &Path) -> Vec<OsString> {
+    let method = request["method"].as_str().unwrap();
+    let parts: Vec<_> = method.split('.').collect();
+    let resource = match parts[1] {
+        "templates" => "policy",
+        "scopes" => "scope",
+        "bindings" => "binding",
+        _ => panic!("unknown fixture method"),
+    };
+    let mut args: Vec<OsString> = ["--socket", socket.to_str().unwrap(), resource, parts[2]]
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    for (field, value) in request["params"].as_object().unwrap() {
+        match field.as_str() {
+            "template" => {
+                let path = directory.join("template with spaces.json");
+                std::fs::write(&path, serde_json::to_vec(value).unwrap()).unwrap();
+                args.extend([OsString::from("--file"), path.into_os_string()]);
+            }
+            "selector" => {
+                let (option, number) = if value["kind"] == "pid" {
+                    ("--pid", &value["pid"])
+                } else {
+                    ("--cgroup-id", &value["cgroupId"])
+                };
+                args.extend([option.into(), number.to_string().into()]);
+            }
+            _ => {
+                let option = match field.as_str() {
+                    "policyName" => "--name",
+                    "policyId" => "--policy-id",
+                    "policyRevision" => "--policy-revision",
+                    "scopeId" => "--scope-id",
+                    "scopeRevision" => "--scope-revision",
+                    "bindingId" => "--binding-id",
+                    "revision" => "--revision",
+                    "limit" => "--limit",
+                    "offset" => "--offset",
+                    "id" => match resource {
+                        "policy" => "--policy-id",
+                        "scope" => "--scope-id",
+                        _ => "--binding-id",
+                    },
+                    _ => panic!("unknown fixture field {field}"),
+                };
+                let value = value
+                    .as_str()
+                    .map_or_else(|| value.to_string(), str::to_owned);
+                args.extend([option.into(), value.into()]);
+            }
+        }
+    }
+    args
+}
+
+pub fn expand(value: &Value, objects: &Value, variables: &BTreeMap<String, Value>) -> Value {
+    match value {
+        Value::Object(map) if map.len() == 1 && map.contains_key("$ref") => {
+            expand(&objects[map["$ref"].as_str().unwrap()], objects, variables)
+        }
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(key, value)| (key.clone(), expand(value, objects, variables)))
+                .collect(),
+        ),
+        Value::Array(values) => Value::Array(
+            values
+                .iter()
+                .map(|value| expand(value, objects, variables))
+                .collect(),
+        ),
+        Value::String(text) if text.starts_with("${") && text.ends_with('}') => {
+            variables[&text[2..text.len() - 1]].clone()
+        }
+        _ => value.clone(),
+    }
+}
+
+pub fn run(args: &[OsString]) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_agent-sec-cli"))
+        .args(args)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    // Drain both pipes concurrently so large snapshots cannot block child exit.
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+    let read = |mut stream: Box<dyn std::io::Read + Send>| {
+        std::thread::spawn(move || {
+            let mut bytes = Vec::new();
+            stream.read_to_end(&mut bytes).unwrap();
+            bytes
+        })
+    };
+    let stdout = read(Box::new(stdout));
+    let stderr = read(Box::new(stderr));
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let status = loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("CLI process exceeded test deadline");
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    };
+    Output {
+        status,
+        stdout: stdout.join().unwrap(),
+        stderr: stderr.join().unwrap(),
+    }
+}

--- a/src/agent-sec-core/v2/apps/asc-cli/tests/pap_process.rs
+++ b/src/agent-sec-core/v2/apps/asc-cli/tests/pap_process.rs
@@ -1,0 +1,221 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use asc_daemon::{BootstrapConfig, serve};
+use asc_daemon_core::{PeerCredentials, PrincipalPolicy, PrincipalRole};
+use asc_daemon_handler::{DaemonDispatcher, JsonRejectionEncoder};
+use asc_daemon_service::{
+    DispatchError, DispatchRequest, RequestDispatcher, ResponseDisposition, ShutdownToken,
+};
+use asc_pap::PapService;
+use asc_pap_repository_memory::ProcessLocalPapRepository;
+use asc_policy_engine::PolicyTemplateCompiler;
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+mod common;
+
+struct TestPolicy(PrincipalRole);
+impl PrincipalPolicy for TestPolicy {
+    fn role_for(&self, _peer: PeerCredentials) -> PrincipalRole {
+        self.0
+    }
+}
+
+struct RecordingDispatcher {
+    inner: Arc<dyn RequestDispatcher>,
+    requests: Arc<Mutex<Vec<Value>>>,
+}
+impl RequestDispatcher for RecordingDispatcher {
+    fn dispatch(
+        &self,
+        request: DispatchRequest,
+        response: &mut dyn std::io::Write,
+    ) -> Result<ResponseDisposition, DispatchError> {
+        self.requests
+            .lock()
+            .unwrap()
+            .push(serde_json::from_slice(&request.payload).unwrap());
+        self.inner.dispatch(request, response)
+    }
+}
+
+async fn start(
+    socket: &Path,
+    role: PrincipalRole,
+) -> (
+    ShutdownToken,
+    tokio::task::JoinHandle<()>,
+    Arc<Mutex<Vec<Value>>>,
+) {
+    let application = PapService::new(
+        Arc::new(ProcessLocalPapRepository::default()),
+        Arc::new(PolicyTemplateCompiler),
+    );
+    let inner = Arc::new(DaemonDispatcher::new(
+        application,
+        Arc::new(TestPolicy(role)),
+    ));
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let dispatcher = Arc::new(RecordingDispatcher {
+        inner,
+        requests: Arc::clone(&requests),
+    });
+    let config = BootstrapConfig::new(socket);
+    let shutdown = ShutdownToken::new();
+    let service_shutdown = shutdown.clone();
+    let task = tokio::spawn(async move {
+        serve(
+            config,
+            dispatcher,
+            Arc::new(JsonRejectionEncoder),
+            service_shutdown,
+        )
+        .await
+        .unwrap();
+    });
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while !socket.exists() {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .unwrap();
+    (shutdown, task, requests)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn real_cli_processes_execute_the_complete_frozen_pap_crud_scenario() {
+    let directory = common::Directory::new();
+    let socket = directory.0.join("daemon.sock");
+    let (shutdown, task, requests) = start(&socket, PrincipalRole::PolicyAdministrator).await;
+    let fixture: Value = serde_json::from_str(common::SCENARIO).unwrap();
+    let mut variables = BTreeMap::new();
+    let mut expected_requests = Vec::new();
+    for step in fixture["steps"].as_array().unwrap() {
+        let request = common::expand(&step["request"], &fixture["objects"], &variables);
+        let args = common::args_for(&request, &directory.0, &socket);
+        let output = tokio::task::spawn_blocking(move || common::run(&args))
+            .await
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}: {}",
+            step["name"],
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(output.stderr.is_empty());
+        let result: Value = serde_json::from_slice(&output.stdout).unwrap();
+        let wrapper = json!({"result":result});
+        for capture in step["captures"].as_array().unwrap() {
+            let value = wrapper
+                .pointer(capture["pointer"].as_str().unwrap())
+                .unwrap()
+                .clone();
+            Uuid::parse_str(value.as_str().unwrap()).unwrap();
+            assert!(
+                variables
+                    .insert(capture["name"].as_str().unwrap().to_owned(), value)
+                    .is_none()
+            );
+        }
+        assert_eq!(
+            result,
+            common::expand(
+                &step["expectedResponse"]["result"],
+                &fixture["objects"],
+                &variables
+            ),
+            "{}",
+            step["name"]
+        );
+        expected_requests.push(request);
+    }
+    assert_ne!(variables["policy_id"], variables["scope_id"]);
+    assert_ne!(variables["binding_id"], variables["scope_id"]);
+    assert_ne!(variables["binding_id"], variables["policy_id"]);
+    assert_eq!(*requests.lock().unwrap(), expected_requests);
+    let request = json!({"method":"policy.templates.get","params":{"id":variables["policy_id"],"revision":2}});
+    let args = common::args_for(&request, &directory.0, &socket);
+    let output = tokio::task::spawn_blocking(move || common::run(&args))
+        .await
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert_eq!(error["error"]["code"], "not_found");
+    Uuid::parse_str(error["requestId"].as_str().unwrap()).unwrap();
+    shutdown.request();
+    task.await.unwrap();
+    assert!(!socket.exists());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unauthorized_cli_cannot_read_or_modify_any_pap_resource() {
+    let directory = common::Directory::new();
+    let socket = directory.0.join("daemon.sock");
+    let (shutdown, task, _) = start(&socket, PrincipalRole::LocalUser).await;
+    let methods: Value = serde_json::from_str(common::METHODS).unwrap();
+    for row in methods.as_array().unwrap() {
+        let args = common::args_for(row, &directory.0, &socket);
+        let output = tokio::task::spawn_blocking(move || common::run(&args))
+            .await
+            .unwrap();
+        assert_eq!(output.status.code(), Some(1));
+        assert!(output.stdout.is_empty());
+        let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+        assert_eq!(error["error"]["code"], "permission_denied");
+        assert!(!error["error"]["message"].as_str().unwrap().is_empty());
+        Uuid::parse_str(error["requestId"].as_str().unwrap()).unwrap();
+    }
+    shutdown.request();
+    task.await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn domain_validation_and_pagination_are_owned_by_the_daemon() {
+    let directory = common::Directory::new();
+    let socket = directory.0.join("daemon.sock");
+    let (shutdown, task, requests) = start(&socket, PrincipalRole::PolicyAdministrator).await;
+    let request = json!({"method":"policy.templates.create","params":{"policyName":"", "template":{"kind":"prevent_file_deletion","files":["/work"]}}});
+    let args = common::args_for(&request, &directory.0, &socket);
+    let output = tokio::task::spawn_blocking(move || common::run(&args))
+        .await
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stderr).unwrap()["error"]["code"],
+        "invalid_argument"
+    );
+    for pid in 1..=3 {
+        let request =
+            json!({"method":"policy.scopes.create","params":{"selector":{"kind":"pid","pid":pid}}});
+        let args = common::args_for(&request, &directory.0, &socket);
+        assert!(
+            tokio::task::spawn_blocking(move || common::run(&args))
+                .await
+                .unwrap()
+                .status
+                .success()
+        );
+    }
+    let request = json!({"method":"policy.scopes.list","params":{"limit":1,"offset":1}});
+    let args = common::args_for(&request, &directory.0, &socket);
+    let output = tokio::task::spawn_blocking(move || common::run(&args))
+        .await
+        .unwrap();
+    assert!(output.status.success());
+    let result: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(result["total"], 3);
+    assert_eq!(result["items"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        requests.lock().unwrap().len(),
+        5,
+        "CLI must not auto-page or perform hidden reads"
+    );
+    shutdown.request();
+    task.await.unwrap();
+}

--- a/src/agent-sec-core/v2/apps/asc-daemon/src/cli.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/src/cli.rs
@@ -1,13 +1,15 @@
+use std::collections::BTreeSet;
 use std::ffi::{OsStr, OsString};
 use std::fmt::Write as _;
 use std::path::PathBuf;
 
 use crate::BootstrapConfig;
 
-const HELP: &str = "Usage: asc-daemon [serve] --socket <ABSOLUTE_PATH>\n\
+const HELP: &str = "Usage: asc-daemon [serve] --socket <ABSOLUTE_PATH> [--policy-admin-uid <UID>]...\n\
 \n\
 Runs the AgentSecCore V2 UDS service with PAP administration methods.\n\
-Only root may modify Policy state unless root delegates an additional UID.\n\
+Root is always authorized. --policy-admin-uid adds an administrator at startup.\n\
+Repeat this option for multiple UIDs; omitted means root only.\n\
 PAP state is process-local until durable Repository integration lands.\n";
 
 /// Parsed command-line configuration for the daemon process.
@@ -15,6 +17,8 @@ PAP state is process-local until durable Repository integration lands.\n";
 pub struct Cli {
     /// Bootstrap configuration selected by the explicit process invocation.
     pub bootstrap: BootstrapConfig,
+    /// Additional administrator UIDs selected by the daemon deployment operator.
+    pub policy_admin_uids: BTreeSet<u32>,
 }
 
 /// Successful command-line parse outcome.
@@ -35,7 +39,7 @@ impl Cli {
     ///
     /// # Errors
     /// Returns a stable parse error for a missing value, unknown option, repeated
-    /// socket, non-Unicode option, or absent socket path.
+    /// socket, invalid administrator UID, non-Unicode option, or absent socket path.
     pub fn parse_from<I, T>(arguments: I) -> Result<ParseOutcome, CliError>
     where
         I: IntoIterator<Item = T>,
@@ -45,6 +49,7 @@ impl Cli {
         let _program = arguments.next();
         let mut socket_path = None;
         let mut command_seen = false;
+        let mut policy_admin_uids = BTreeSet::new();
 
         while let Some(argument) = arguments.next() {
             if argument == OsStr::new("--help") || argument == OsStr::new("-h") {
@@ -65,6 +70,26 @@ impl Cli {
                 socket_path = Some(PathBuf::from(value));
                 continue;
             }
+            let inline_uid = argument
+                .to_str()
+                .and_then(|value| value.strip_prefix("--policy-admin-uid="));
+            if argument == OsStr::new("--policy-admin-uid") || inline_uid.is_some() {
+                let value = if let Some(value) = inline_uid {
+                    OsString::from(value)
+                } else {
+                    arguments.next().ok_or(CliError::MissingAdminUid)?
+                };
+                let value = value.to_str().ok_or(CliError::InvalidAdminUid)?;
+                if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+                    return Err(CliError::InvalidAdminUid);
+                }
+                policy_admin_uids.insert(
+                    value
+                        .parse::<u32>()
+                        .map_err(|_| CliError::InvalidAdminUid)?,
+                );
+                continue;
+            }
 
             let mut rendered = String::new();
             write!(&mut rendered, "{}", argument.to_string_lossy())
@@ -78,6 +103,7 @@ impl Cli {
         }
         Ok(ParseOutcome::Serve(Self {
             bootstrap: BootstrapConfig::new(socket_path),
+            policy_admin_uids,
         }))
     }
 }
@@ -85,6 +111,12 @@ impl Cli {
 /// Invalid daemon command-line input.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum CliError {
+    /// A startup administrator option was not followed by a UID.
+    #[error("--policy-admin-uid requires a UID")]
+    MissingAdminUid,
+    /// Kernel UIDs are unsigned 32-bit decimal values.
+    #[error("--policy-admin-uid must be a decimal integer between 0 and 4294967295")]
+    InvalidAdminUid,
     /// A socket path is required until packaging freezes a system-owned default.
     #[error("--socket <ABSOLUTE_PATH> is required")]
     MissingSocket,
@@ -97,7 +129,7 @@ pub enum CliError {
     /// The service framework rejects relative daemon endpoints.
     #[error("--socket must be an absolute path")]
     RelativeSocket,
-    /// The current independent bootstrap has no other process options.
+    /// An unsupported process option was supplied.
     #[error("unknown argument: {0}")]
     UnknownArgument(String),
 }
@@ -134,6 +166,56 @@ mod tests {
                 "/run/two.sock",
             ]),
             Err(CliError::RepeatedSocket)
+        );
+    }
+
+    #[test]
+    fn administrator_uids_are_explicit_repeatable_and_bounded() {
+        let ParseOutcome::Serve(default) =
+            Cli::parse_from(["asc-daemon", "--socket", "/run/asc.sock"]).unwrap()
+        else {
+            panic!("expected daemon invocation");
+        };
+        assert!(default.policy_admin_uids.is_empty());
+        let ParseOutcome::Serve(configured) = Cli::parse_from([
+            "asc-daemon",
+            "serve",
+            "--socket",
+            "/run/asc.sock",
+            "--policy-admin-uid",
+            "1000",
+            "--policy-admin-uid=2000",
+            "--policy-admin-uid",
+            "1000",
+            "--policy-admin-uid=0",
+        ])
+        .unwrap() else {
+            panic!("expected daemon invocation");
+        };
+        assert_eq!(
+            configured.policy_admin_uids,
+            BTreeSet::from([0, 1000, 2000])
+        );
+        for value in ["", "-1", "+1", "4294967296", "root", "1,2", "--help"] {
+            assert_eq!(
+                Cli::parse_from([
+                    "asc-daemon",
+                    "--socket",
+                    "/run/asc.sock",
+                    "--policy-admin-uid",
+                    value,
+                ]),
+                Err(CliError::InvalidAdminUid)
+            );
+        }
+        assert_eq!(
+            Cli::parse_from([
+                "asc-daemon",
+                "--socket",
+                "/run/asc.sock",
+                "--policy-admin-uid",
+            ]),
+            Err(CliError::MissingAdminUid)
         );
     }
 }

--- a/src/agent-sec-core/v2/apps/asc-daemon/src/main.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/src/main.rs
@@ -47,7 +47,9 @@ async fn run() -> ExitCode {
     };
     let repository = Arc::new(ProcessLocalPapRepository::default());
     let pap = PapService::new(repository, Arc::new(PolicyTemplateCompiler));
-    let principal_policy = Arc::new(RootManagedPrincipalPolicy::default());
+    let principal_policy = Arc::new(RootManagedPrincipalPolicy::with_admin_uids(
+        cli.policy_admin_uids,
+    ));
     let policy_for_handler: Arc<dyn PrincipalPolicy> = principal_policy.clone();
     let dispatcher = Arc::new(DaemonDispatcher::new(pap, policy_for_handler));
     eprintln!("asc-daemon: warning: PAP state is process-local and is lost on restart");

--- a/src/agent-sec-core/v2/apps/asc-daemon/tests/bootstrap.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/tests/bootstrap.rs
@@ -76,10 +76,24 @@ async fn request(path: &Path, payload: &[u8]) -> Value {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn dproc_002_003_and_partial_013_binary_registers_pap_and_cleans_socket() {
+    run_binary_scenario(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dproc_configured_administrator_runs_full_crud_without_root() {
+    run_binary_scenario(true).await;
+}
+
+async fn run_binary_scenario(configure_admin: bool) {
     let directory = unique_directory();
     std::fs::create_dir(&directory).unwrap();
     let socket_path = directory.join("daemon.sock");
-    let child = Command::new(env!("CARGO_BIN_EXE_asc-daemon"))
+    let mut command = Command::new(env!("CARGO_BIN_EXE_asc-daemon"));
+    if configure_admin {
+        let uid = std::fs::metadata(&directory).unwrap().uid();
+        command.args(["--policy-admin-uid", &uid.to_string()]);
+    }
+    let child = command
         .args(["serve", "--socket"])
         .arg(&socket_path)
         .stdin(Stdio::null())
@@ -98,7 +112,7 @@ async fn dproc_002_003_and_partial_013_binary_registers_pap_and_cleans_socket() 
         "../../../crates/daemon/asc-daemon-protocol/tests/fixtures/pap-crud-e2e.json"
     ))
     .unwrap();
-    if std::fs::metadata(&running.socket_path).unwrap().uid() == 0 {
+    if configure_admin || std::fs::metadata(&running.socket_path).unwrap().uid() == 0 {
         support::run_frozen_pap_crud_scenario(&running.socket_path, &fixture).await;
     } else {
         let first_request = fixture["steps"][0]["request"].clone();

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-client/Cargo.toml
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-client/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "asc-daemon-client"
+description = "Bounded daemon-only UDS client for AgentSecCore"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+asc-daemon-protocol = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+socket2 = { workspace = true }
+
+[dev-dependencies]
+uuid = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-client/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-client/src/lib.rs
@@ -1,0 +1,169 @@
+//! One bounded daemon call per UDS connection, with no retries or local execution.
+
+use std::io::{self, Read as _, Write as _};
+use std::os::fd::OwnedFd;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use asc_daemon_protocol::{DaemonRequest, DaemonResponse};
+use socket2::{Domain, SockAddr, Socket, Type};
+
+/// LF-inclusive wire limit, matching the current daemon bootstrap defaults.
+pub const MAX_FRAME_BYTES: usize = 4 * 1024 * 1024;
+
+/// Sends one request and preserves the complete protocol response.
+///
+/// The deadline covers connect, write, and read together. A complete LF frame
+/// returns immediately; EOF also terminates a nonempty frame. This function
+/// never retries, including after failures whose execution outcome is unknown.
+/// The caller's thread blocks until completion; no async runtime is needed.
+/// Encoding precedes the I/O deadline, and decoding follows receipt of the frame.
+///
+/// # Errors
+/// Returns local encoding/limit failures, connection failures, a call deadline,
+/// I/O failures, or malformed/oversized responses. Daemon errors remain responses.
+pub fn call(
+    socket: &Path,
+    request: &DaemonRequest,
+    timeout: Duration,
+) -> Result<DaemonResponse, ClientError> {
+    if timeout.is_zero() || Instant::now().checked_add(timeout).is_none() {
+        return Err(ClientError::InvalidTimeout);
+    }
+    let mut payload = serde_json::to_vec(request).map_err(ClientError::Encode)?;
+    payload.push(b'\n');
+    if payload.len() > MAX_FRAME_BYTES {
+        return Err(ClientError::RequestTooLarge);
+    }
+
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or(ClientError::InvalidTimeout)?;
+    let address = SockAddr::unix(socket).map_err(ClientError::Connect)?;
+    let socket = Socket::new(Domain::UNIX, Type::STREAM, None).map_err(ClientError::Connect)?;
+    // std's UnixStream has no bounded connect; socket2 uses nonblocking connect
+    // and an OS readiness wait without a runtime or helper thread.
+    socket
+        .connect_timeout(&address, remaining(deadline, false)?)
+        .map_err(|error| transport_error(error, false))?;
+    // Linux can return EAGAIN for a full UDS listen queue without starting a
+    // connection. Writable readiness alone does not prove that it connected.
+    socket.peer_addr().map_err(ClientError::Connect)?;
+    let mut stream = UnixStream::from(OwnedFd::from(socket));
+    let mut write_started = false;
+    let mut pending = payload.as_slice();
+    while !pending.is_empty() {
+        stream
+            .set_write_timeout(Some(remaining(deadline, write_started)?))
+            .map_err(|error| transport_error(error, write_started))?;
+        // Even a failed write may have delivered enough bytes for execution.
+        write_started = true;
+        match stream.write(pending) {
+            Ok(0) => return Err(ClientError::Io(io::ErrorKind::WriteZero.into())),
+            Ok(count) => pending = &pending[count..],
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(transport_error(error, true)),
+        }
+    }
+    read_response(&mut stream, deadline)
+}
+
+fn remaining(deadline: Instant, request_may_have_executed: bool) -> Result<Duration, ClientError> {
+    deadline
+        .checked_duration_since(Instant::now())
+        .filter(|duration| !duration.is_zero())
+        .ok_or(ClientError::Timeout {
+            request_may_have_executed,
+        })
+}
+
+fn transport_error(error: io::Error, request_may_have_executed: bool) -> ClientError {
+    // Blocking socket timeouts are reported as WouldBlock on Linux and may be
+    // TimedOut on other platforms. Neither permits replaying a sent request.
+    if matches!(
+        error.kind(),
+        io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+    ) {
+        ClientError::Timeout {
+            request_may_have_executed,
+        }
+    } else if request_may_have_executed {
+        ClientError::Io(error)
+    } else {
+        ClientError::Connect(error)
+    }
+}
+
+fn read_response(
+    stream: &mut UnixStream,
+    deadline: Instant,
+) -> Result<DaemonResponse, ClientError> {
+    let mut frame = Vec::new();
+    let mut chunk = [0_u8; 8192];
+    loop {
+        stream
+            .set_read_timeout(Some(remaining(deadline, true)?))
+            .map_err(ClientError::Io)?;
+        let count = match stream.read(&mut chunk) {
+            Ok(count) => count,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(transport_error(error, true)),
+        };
+        if count == 0 {
+            break;
+        }
+        let newline = chunk[..count].iter().position(|byte| *byte == b'\n');
+        let end = newline.map_or(count, |index| index + 1);
+        if frame.len() + end > MAX_FRAME_BYTES {
+            return Err(ClientError::ResponseTooLarge);
+        }
+        frame.extend_from_slice(&chunk[..end]);
+        if newline.is_some() {
+            break;
+        }
+    }
+    if frame.is_empty() {
+        return Err(ClientError::EmptyResponse);
+    }
+    serde_json::from_slice(&frame).map_err(ClientError::Decode)
+}
+
+/// Client failures are separate from structured daemon method errors.
+#[derive(Debug, thiserror::Error)]
+pub enum ClientError {
+    /// Invalid caller configuration; no request was sent.
+    #[error("timeout must be positive and representable")]
+    InvalidTimeout,
+    /// Local request encoding failed before connecting.
+    #[error("request encoding failed: {0}")]
+    Encode(serde_json::Error),
+    /// Local wire limit exceeded before connecting.
+    #[error("request exceeds the 4194304-byte frame limit; not sent")]
+    RequestTooLarge,
+    /// No connection was established.
+    #[error("daemon connection unavailable; request not sent: {0}")]
+    Connect(io::Error),
+    /// A single call deadline elapsed, without replaying the request.
+    #[error(
+        "daemon call timed out (request may have executed: {request_may_have_executed}); not retried"
+    )]
+    Timeout {
+        /// True once any request write has been attempted.
+        request_may_have_executed: bool,
+    },
+    /// Write/read failures do not prove the operation failed to execute.
+    #[error("daemon I/O failed; request may have executed; not retried: {0}")]
+    Io(io::Error),
+    /// No valid response means the execution outcome is unknown.
+    #[error("daemon returned an empty response; request may have executed; not retried")]
+    EmptyResponse,
+    /// No valid response means the execution outcome is unknown.
+    #[error(
+        "daemon response exceeds the 4194304-byte frame limit; request may have executed; not retried"
+    )]
+    ResponseTooLarge,
+    /// No valid response means the execution outcome is unknown.
+    #[error("invalid daemon response; request may have executed; not retried: {0}")]
+    Decode(serde_json::Error),
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-client/tests/transport.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-client/tests/transport.rs
@@ -1,0 +1,336 @@
+use std::io::{self, BufRead as _, BufReader, Read as _, Write as _};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::PathBuf;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use asc_daemon_client::{ClientError, MAX_FRAME_BYTES, call};
+use asc_daemon_protocol::{DaemonRequest, DaemonResponse};
+use serde_json::json;
+use socket2::{Domain, SockAddr, Socket, Type};
+use uuid::Uuid;
+
+struct Endpoint {
+    directory: PathBuf,
+    path: PathBuf,
+    listener: UnixListener,
+}
+
+impl Endpoint {
+    fn new() -> Self {
+        let directory = std::env::temp_dir().join(format!("asc-client-{}", Uuid::new_v4()));
+        std::fs::create_dir(&directory).unwrap();
+        let path = directory.join("daemon.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        Self {
+            directory,
+            path,
+            listener,
+        }
+    }
+
+    fn accept(&self) -> UnixStream {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            match self.listener.accept() {
+                Ok((stream, _)) => {
+                    stream
+                        .set_read_timeout(Some(Duration::from_secs(3)))
+                        .unwrap();
+                    stream
+                        .set_write_timeout(Some(Duration::from_secs(3)))
+                        .unwrap();
+                    return stream;
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    assert!(Instant::now() < deadline, "client did not connect");
+                    thread::sleep(Duration::from_millis(1));
+                }
+                Err(error) => panic!("accept failed: {error}"),
+            }
+        }
+    }
+
+    fn no_connection(&self) {
+        assert_eq!(
+            self.listener.accept().unwrap_err().kind(),
+            io::ErrorKind::WouldBlock
+        );
+    }
+
+    fn exchange<T: Send>(
+        &self,
+        input: &DaemonRequest,
+        timeout: Duration,
+        server: impl FnOnce(&Self) -> T + Send,
+    ) -> Result<DaemonResponse, ClientError> {
+        let result = thread::scope(|scope| {
+            let server = scope.spawn(|| server(self));
+            let result = call(&self.path, input, timeout);
+            // A returned peer stays open until after call finishes, allowing
+            // tests to prove LF completion and deadlines without relying on EOF.
+            let _peer = server.join().unwrap();
+            result
+        });
+        self.no_connection();
+        result
+    }
+}
+
+impl Drop for Endpoint {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+
+fn request() -> DaemonRequest {
+    DaemonRequest {
+        method: "test.method".to_owned(),
+        params: json!({}),
+    }
+}
+
+fn read_request(stream: UnixStream) -> (BufReader<UnixStream>, Vec<u8>) {
+    let mut stream = BufReader::new(stream);
+    let mut frame = Vec::new();
+    stream.read_until(b'\n', &mut frame).unwrap();
+    (stream, frame)
+}
+
+const RESPONSE: &[u8] =
+    b"{\"requestId\":\"request-1\",\"result\":{\"status\":\"PENDING_APPLY\"}}\n";
+
+#[test]
+fn fragmented_lf_response_returns_without_waiting_for_eof() {
+    let endpoint = Endpoint::new();
+    let response = endpoint
+        .exchange(&request(), Duration::from_secs(1), |endpoint| {
+            let (mut stream, frame) = read_request(endpoint.accept());
+            assert_eq!(
+                serde_json::from_slice::<DaemonRequest>(&frame).unwrap(),
+                request()
+            );
+            stream.get_mut().write_all(&RESPONSE[..10]).unwrap();
+            thread::sleep(Duration::from_millis(10));
+            stream.get_mut().write_all(&RESPONSE[10..]).unwrap();
+            stream
+        })
+        .unwrap();
+    assert_eq!(response.request_id().as_str(), "request-1");
+    assert!(matches!(response, DaemonResponse::Success(_)));
+}
+
+fn exchange(bytes: &[u8]) -> Result<DaemonResponse, ClientError> {
+    Endpoint::new().exchange(&request(), Duration::from_secs(2), |endpoint| {
+        let (mut stream, _) = read_request(endpoint.accept());
+        let _ = stream.get_mut().write_all(bytes);
+    })
+}
+
+#[test]
+fn eof_delimited_response_and_first_frame_only_are_supported() {
+    assert!(exchange(&RESPONSE[..RESPONSE.len() - 1]).is_ok());
+    let mut bytes = RESPONSE.to_vec();
+    bytes.extend_from_slice(b"unexpected trailing bytes");
+    assert!(exchange(&bytes).is_ok());
+}
+
+#[test]
+fn daemon_errors_preserve_code_message_and_request_id() {
+    let response = exchange(b"{\"requestId\":\"r1\",\"error\":{\"code\":\"permission_denied\",\"message\":\"denied\"}}\n").unwrap();
+    let DaemonResponse::Error(error) = response else {
+        panic!("expected daemon error")
+    };
+    assert_eq!(error.request_id.as_str(), "r1");
+    assert_eq!(error.error.code.as_str(), "permission_denied");
+    assert_eq!(error.error.message(), "denied");
+}
+
+#[test]
+fn empty_invalid_and_ambiguous_responses_do_not_trigger_replay() {
+    assert!(matches!(exchange(&[]), Err(ClientError::EmptyResponse)));
+    for payload in [
+        b"not-json\n".as_slice(),
+        b"{\"requestId\":\"r\",\"result\":{},\"error\":{\"code\":\"internal\",\"message\":\"bad\"}}\n",
+        b"{\"result\":{}}\n",
+    ] {
+        assert!(matches!(exchange(payload), Err(ClientError::Decode(_))));
+    }
+}
+
+#[test]
+fn response_frame_limit_includes_lf() {
+    let mut exact = RESPONSE[..RESPONSE.len() - 1].to_vec();
+    exact.resize(MAX_FRAME_BYTES - 1, b' ');
+    exact.push(b'\n');
+    assert!(exchange(&exact).is_ok());
+    exact.insert(exact.len() - 1, b' ');
+    assert!(matches!(
+        exchange(&exact),
+        Err(ClientError::ResponseTooLarge)
+    ));
+}
+
+#[test]
+fn request_frame_limit_is_checked_before_connecting() {
+    let endpoint = Endpoint::new();
+    let mut input = request();
+    input.params = json!({"payload": ""});
+    let overhead = serde_json::to_vec(&input).unwrap().len() + 1;
+    input.params["payload"] = json!("x".repeat(MAX_FRAME_BYTES - overhead + 1));
+    assert!(matches!(
+        call(&endpoint.path, &input, Duration::from_secs(1)),
+        Err(ClientError::RequestTooLarge)
+    ));
+    endpoint.no_connection();
+    input.params["payload"] = json!("x".repeat(MAX_FRAME_BYTES - overhead));
+    assert!(
+        endpoint
+            .exchange(&input, Duration::from_secs(2), |endpoint| {
+                let (mut stream, frame) = read_request(endpoint.accept());
+                assert_eq!(frame.len(), MAX_FRAME_BYTES);
+                stream.get_mut().write_all(RESPONSE).unwrap();
+            })
+            .is_ok()
+    );
+}
+
+#[test]
+fn deadline_does_not_reset_for_each_response_chunk() {
+    let result = Endpoint::new().exchange(&request(), Duration::from_millis(100), |endpoint| {
+        let (mut stream, _) = read_request(endpoint.accept());
+        for _ in 0..10 {
+            if stream.get_mut().write_all(b" ").is_err() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(30));
+        }
+        stream
+    });
+    assert!(matches!(
+        result,
+        Err(ClientError::Timeout {
+            request_may_have_executed: true
+        })
+    ));
+}
+
+#[test]
+fn deadline_also_covers_a_blocked_write() {
+    let mut input = request();
+    input.params = json!({"payload": "x".repeat(MAX_FRAME_BYTES / 2)});
+    let result = Endpoint::new().exchange(&input, Duration::from_millis(100), Endpoint::accept);
+    assert!(matches!(
+        result,
+        Err(ClientError::Timeout {
+            request_may_have_executed: true
+        })
+    ));
+}
+
+#[test]
+fn deadline_covers_a_silent_response() {
+    let result = Endpoint::new().exchange(&request(), Duration::from_millis(100), |endpoint| {
+        let (stream, _) = read_request(endpoint.accept());
+        stream
+    });
+    assert!(matches!(
+        result,
+        Err(ClientError::Timeout {
+            request_may_have_executed: true
+        })
+    ));
+}
+
+#[test]
+fn partial_writes_and_response_wait_share_one_deadline() {
+    let mut input = request();
+    input.params = json!({"payload": "x".repeat(MAX_FRAME_BYTES / 2)});
+    // A slow reader makes multiple writes necessary. Draining the complete
+    // request must not give the response wait a fresh timeout budget.
+    let result = Endpoint::new().exchange(&input, Duration::from_millis(300), |endpoint| {
+        let mut stream = endpoint.accept();
+        thread::sleep(Duration::from_millis(180));
+        let mut frame = Vec::new();
+        let mut chunk = [0; 16384];
+        loop {
+            let count = stream.read(&mut chunk).unwrap();
+            assert_ne!(count, 0);
+            frame.extend_from_slice(&chunk[..count]);
+            if frame.ends_with(b"\n") {
+                break;
+            }
+        }
+        assert_eq!(
+            serde_json::from_slice::<DaemonRequest>(&frame).unwrap(),
+            input
+        );
+        thread::sleep(Duration::from_millis(180));
+        let _ = stream.write_all(RESPONSE);
+    });
+    assert!(matches!(
+        result,
+        Err(ClientError::Timeout {
+            request_may_have_executed: true
+        })
+    ));
+}
+
+#[test]
+fn absent_daemon_and_invalid_deadline_are_local_failures() {
+    let directory = std::env::temp_dir().join(format!("absent-{}", Uuid::new_v4()));
+    assert!(matches!(
+        call(&directory, &request(), Duration::from_secs(1)),
+        Err(ClientError::Connect(_))
+    ));
+    assert!(matches!(
+        call(&directory, &request(), Duration::ZERO),
+        Err(ClientError::InvalidTimeout)
+    ));
+    assert!(matches!(
+        call(&directory, &request(), Duration::MAX),
+        Err(ClientError::InvalidTimeout)
+    ));
+    assert!(!directory.exists());
+}
+
+#[test]
+fn expired_budget_before_connect_sends_nothing() {
+    let endpoint = Endpoint::new();
+    assert!(matches!(
+        call(&endpoint.path, &request(), Duration::from_nanos(1)),
+        Err(ClientError::Timeout {
+            request_may_have_executed: false
+        })
+    ));
+    endpoint.no_connection();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn full_connect_queue_is_bounded_and_never_marks_request_sent() {
+    let endpoint = Endpoint::new();
+    let queued_path = endpoint.directory.join("queued.sock");
+    let address = SockAddr::unix(&queued_path).unwrap();
+    let listener = Socket::new(Domain::UNIX, Type::STREAM, None).unwrap();
+    listener.bind(&address).unwrap();
+    listener.listen(0).unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let _queued = UnixStream::connect(&queued_path).unwrap();
+    let started = Instant::now();
+    let result = call(&queued_path, &request(), Duration::from_millis(100));
+    assert!(started.elapsed() < Duration::from_secs(1));
+    assert!(matches!(
+        result,
+        Err(ClientError::Connect(_)
+            | ClientError::Timeout {
+                request_may_have_executed: false
+            })
+    ));
+    let (_peer, _) = listener.accept().unwrap();
+    assert_eq!(
+        listener.accept().unwrap_err().kind(),
+        io::ErrorKind::WouldBlock
+    );
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/identity.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/identity.rs
@@ -52,17 +52,28 @@ pub trait PrincipalPolicy: Send + Sync {
     fn role_for(&self, peer: PeerCredentials) -> PrincipalRole;
 }
 
-/// Root-owned Policy-administrator allowlist.
+/// Deployment-configured Policy-administrator allowlist with root-only delegation.
 ///
-/// UID 0 is always a Policy administrator. Other UIDs are denied until root
-/// adds them. The allowlist is process-local in this slice; loading and
-/// persisting it belongs to the later daemon configuration/state integration.
+/// UID 0 is always a Policy administrator. Other UIDs must be configured by the
+/// deployment operator at startup or added by root at runtime. The allowlist is
+/// process-local; configuration-file loading and persistence remain separate work.
 #[derive(Debug, Default)]
 pub struct RootManagedPrincipalPolicy {
     allowed_uids: RwLock<BTreeSet<u32>>,
 }
 
 impl RootManagedPrincipalPolicy {
+    /// Initializes additional administrators from trusted deployment configuration.
+    ///
+    /// Use only at daemon composition, never with request-supplied identity data.
+    /// An operator controlling startup already controls the daemon's process and
+    /// resources. Configured administrators do not gain runtime delegation rights.
+    pub fn with_admin_uids(uids: impl IntoIterator<Item = u32>) -> Self {
+        Self {
+            allowed_uids: RwLock::new(uids.into_iter().collect()),
+        }
+    }
+
     /// Adds one UID to the Policy-administrator allowlist.
     ///
     /// The acting peer must be the kernel-authenticated root peer. Merely being
@@ -172,5 +183,29 @@ mod tests {
             Err(PrincipalPolicyError::RootRequired)
         );
         assert_eq!(policy.role_for(other), PrincipalRole::LocalUser);
+    }
+
+    #[test]
+    fn startup_administrators_are_explicit_and_cannot_delegate() {
+        let configured = PeerCredentials::new(1000, 100, 2);
+        let other = PeerCredentials::new(2000, 100, 3);
+        let root = PeerCredentials::new(0, 0, 1);
+        let policy = RootManagedPrincipalPolicy::with_admin_uids([1000, 1000]);
+        assert_eq!(
+            policy.role_for(configured),
+            PrincipalRole::PolicyAdministrator
+        );
+        assert_eq!(policy.role_for(root), PrincipalRole::PolicyAdministrator);
+        assert_eq!(policy.role_for(other), PrincipalRole::LocalUser);
+        assert_eq!(
+            policy.allow_uid(configured, 2000),
+            Err(PrincipalPolicyError::RootRequired)
+        );
+        assert_eq!(policy.role_for(other), PrincipalRole::LocalUser);
+        // Startup configuration does not become global or persistent state.
+        assert_eq!(
+            RootManagedPrincipalPolicy::default().role_for(configured),
+            PrincipalRole::LocalUser
+        );
     }
 }


### PR DESCRIPTION
## Why

<!-- What problem does this change solve? Why is it needed now? -->

## What changed

<!-- Keep this focused on one logical change. -->
add seccore v2 client as well as daemon client used to call daemon service. Only policy commands are added for now.
## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->

## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
