### PR TITLE
fix(agent-memory): add --accept-capabilities to OpenClaw plugin install.sh

### DIFF
--- a/docs/user-guide/en/token-saving/agent-memory.md
+++ b/docs/user-guide/en/token-saving/agent-memory.md
@@ -115,6 +115,13 @@ anolisa adapter status agent-memory
 
 **Prerequisite**: `openclaw` CLI on `$PATH`. The script logs clearly and exits 0 if missing — rerun after installing OpenClaw. `yum remove agent-memory` triggers `%preun` to call the uninstall script, leaving no orphaned config.
 
+**Capability consent (OpenClaw >= 2026.9.1)**: OpenClaw requires capability consent before it commits a managed plugin install whose source is not a trusted official/first-party record. `install.sh` installs from a local path, which carries no recorded artifact integrity, so consent is requested on every install — and a non-interactive command cannot prompt. The script therefore probes `openclaw plugins install --help` and appends `--accept-capabilities` only when the running CLI advertises it; OpenClaw <= 2026.8.2 does not register the option and rejects unknown options outright. Set `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` to withhold the flag where operator policy forbids non-interactive capability acceptance — the install then fails with `Plugin "memory-anolisa" requires capability consent` until you consent yourself:
+
+```bash
+AGENT_MEMORY_ACCEPT_CAPABILITIES=0 bash /usr/share/anolisa/adapters/agent-memory/openclaw/scripts/install.sh   # policy-driven opt-out
+openclaw plugins install /usr/share/anolisa/adapters/agent-memory/openclaw --force --accept-capabilities       # manual consent
+```
+
 Plugin contract ↔ agent-memory MCP tool mapping:
 
 | OpenClaw contract | agent-memory MCP tool |
@@ -590,6 +597,7 @@ RUST_LOG=agent_memory=debug agent-memory
 | search misses just-written content | inside the 200 ms debounce window | retry, or use `mem_grep` (regex on the filesystem, no index) |
 | `mem_promote` reports `session not found` | `MEMORY_SESSION_ID`/`MEMORY_SESSION_DIR` unset or scratch missing | see Promote workflow |
 | OpenClaw plugin not loaded | `openclaw` CLI not on PATH | rerun `install.sh` after installing OpenClaw |
+| `Plugin "memory-anolisa" requires capability consent` when running `install.sh` | OpenClaw >= 2026.9.1 gates the install and `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` withheld the consent flag | rerun without that variable (the default accepts), or consent once with `openclaw plugins install <adapter>/openclaw --force --accept-capabilities` |
 | system state out of sync after manual dnf | — | `sudo anolisa --install-mode system repair agent-memory`; use system-scoped `forget` / `adopt` only when intentionally rebuilding the record for a present RPM |
 
 For deeper investigation: start with `RUST_LOG=agent_memory=debug` and inspect both stderr and `<mount>/.anolisa/audit.log`.

--- a/docs/user-guide/en/token-saving/agent-memory.md
+++ b/docs/user-guide/en/token-saving/agent-memory.md
@@ -115,12 +115,14 @@ anolisa adapter status agent-memory
 
 **Prerequisite**: `openclaw` CLI on `$PATH`. The script logs clearly and exits 0 if missing — rerun after installing OpenClaw. `yum remove agent-memory` triggers `%preun` to call the uninstall script, leaving no orphaned config.
 
-**Capability consent (OpenClaw >= 2026.9.1)**: OpenClaw requires capability consent before it commits a managed plugin install whose source is not a trusted official/first-party record. `install.sh` installs from a local path, which carries no recorded artifact integrity, so consent is requested on every install — and a non-interactive command cannot prompt. The script therefore probes `openclaw plugins install --help` and appends `--accept-capabilities` only when the running CLI advertises it; OpenClaw <= 2026.8.2 does not register the option and rejects unknown options outright. Set `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` to withhold the flag where operator policy forbids non-interactive capability acceptance — the install then fails with `Plugin "memory-anolisa" requires capability consent` until you consent yourself:
+**Capability consent (OpenClaw >= 2026.8.1)**: OpenClaw requires capability consent before it commits a managed plugin install whose source is not a trusted official/first-party record. `install.sh` installs from a local path, which carries no recorded artifact integrity, so consent is requested on every install — and a non-interactive command cannot prompt. The script therefore probes `openclaw plugins install --help` and appends `--accept-capabilities` only when the running CLI advertises it. The gate is probe-driven rather than version-driven because the boundary is easy to misread: `plugins install` registers the option from OpenClaw 2026.8.1, while the OpenClaw CLI reference only documents it from 2026.9.1. Older builds reject unknown options outright (verified on 2026.5.7 and 2026.6.10), so passing the flag there would turn a working install into a hard failure. Set `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` to withhold the flag where operator policy forbids non-interactive capability acceptance — the install then fails with `Plugin "memory-anolisa" requires capability consent` until you consent yourself:
 
 ```bash
 AGENT_MEMORY_ACCEPT_CAPABILITIES=0 bash /usr/share/anolisa/adapters/agent-memory/openclaw/scripts/install.sh   # policy-driven opt-out
-openclaw plugins install /usr/share/anolisa/adapters/agent-memory/openclaw --force --accept-capabilities       # manual consent
+openclaw plugins install /usr/share/anolisa/adapters/agent-memory/openclaw --force --dangerously-force-unsafe-install --accept-capabilities   # manual consent, the argv install.sh uses
 ```
+
+Keep `--dangerously-force-unsafe-install` in the manual command: the plugin bundle launches the agent-memory MCP server through `child_process`, which OpenClaw's install scanner blocks as a "dangerous code pattern" (`rc=1`) unless that flag is present. Drop it if you installed with `AGENT_MEMORY_SAFE_INSTALL=1` — on failure `install.sh` prints the exact argv it used, so you can copy that instead.
 
 Plugin contract ↔ agent-memory MCP tool mapping:
 
@@ -597,7 +599,7 @@ RUST_LOG=agent_memory=debug agent-memory
 | search misses just-written content | inside the 200 ms debounce window | retry, or use `mem_grep` (regex on the filesystem, no index) |
 | `mem_promote` reports `session not found` | `MEMORY_SESSION_ID`/`MEMORY_SESSION_DIR` unset or scratch missing | see Promote workflow |
 | OpenClaw plugin not loaded | `openclaw` CLI not on PATH | rerun `install.sh` after installing OpenClaw |
-| `Plugin "memory-anolisa" requires capability consent` when running `install.sh` | OpenClaw >= 2026.9.1 gates the install and `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` withheld the consent flag | rerun without that variable (the default accepts), or consent once with `openclaw plugins install <adapter>/openclaw --force --accept-capabilities` |
+| `Plugin "memory-anolisa" requires capability consent` when running `install.sh` | OpenClaw >= 2026.8.1 gates the install and `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` withheld the consent flag | rerun without that variable (the default accepts), or consent once with `openclaw plugins install /usr/share/anolisa/adapters/agent-memory/openclaw --force --dangerously-force-unsafe-install --accept-capabilities` |
 | system state out of sync after manual dnf | — | `sudo anolisa --install-mode system repair agent-memory`; use system-scoped `forget` / `adopt` only when intentionally rebuilding the record for a present RPM |
 
 For deeper investigation: start with `RUST_LOG=agent_memory=debug` and inspect both stderr and `<mount>/.anolisa/audit.log`.

--- a/docs/user-guide/zh/token-saving/agent-memory.md
+++ b/docs/user-guide/zh/token-saving/agent-memory.md
@@ -114,6 +114,13 @@ anolisa adapter status agent-memory
 
 **前置条件**：`openclaw` CLI 在 `$PATH` 上。脚本缺失时输出明确日志并以 0 退出，安装 OpenClaw 后重跑即可。`yum remove agent-memory` 时 spec 的 `%preun` 自动调用 uninstall 脚本，配置不残留孤立项。
 
+**Capability consent（OpenClaw >= 2026.9.1）**：OpenClaw 在提交「非官方可信来源」的受管插件安装前要求 capability consent。`install.sh` 走本地路径安装，没有可用的制品完整性记录，因此每次安装都会要求同意，而非交互式命令无法弹出交互确认。脚本会先探测 `openclaw plugins install --help`，只有当前 CLI 广告了 `--accept-capabilities` 才追加该参数；OpenClaw <= 2026.8.2 没有注册这个选项，未知选项会直接失败。若运维策略禁止非交互式接受能力，可设 `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` 主动不传该参数——此时安装会以 `Plugin "memory-anolisa" requires capability consent` 失败，需要自行同意：
+
+```bash
+AGENT_MEMORY_ACCEPT_CAPABILITIES=0 bash /usr/share/anolisa/adapters/agent-memory/openclaw/scripts/install.sh   # 策略性关闭自动同意
+openclaw plugins install /usr/share/anolisa/adapters/agent-memory/openclaw --force --accept-capabilities       # 手动同意一次
+```
+
 插件 contract 名 ↔ agent-memory MCP 工具映射：
 
 | OpenClaw contract | agent-memory MCP 工具 |
@@ -589,6 +596,7 @@ RUST_LOG=agent_memory=debug agent-memory
 | 索引检索对刚写入的内容查不到 | 还在 200 ms debounce 窗口内 | 重试，或用 `mem_grep`（直接走文件系统正则，不依赖索引） |
 | `mem_promote` 报 `session not found` | `MEMORY_SESSION_ID`/`MEMORY_SESSION_DIR` 未设或 scratch 不存在 | 见 Promote 工作流 |
 | OpenClaw 插件未加载 | `openclaw` CLI 不在 PATH | 安装 OpenClaw 后重跑 `install.sh` |
+| 运行 `install.sh` 报 `Plugin "memory-anolisa" requires capability consent` | OpenClaw >= 2026.9.1 对该安装要求 capability consent，而 `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` 关掉了自动同意 | 去掉该环境变量重跑（默认自动同意），或用 `openclaw plugins install <adapter>/openclaw --force --accept-capabilities` 手动同意一次 |
 | 手动 dnf 操作后 system 状态不同步 | — | `sudo anolisa --install-mode system repair agent-memory`；仅在为仍存在的 RPM 重建记录时使用 system-scoped `forget` / `adopt` |
 
 深入排查：`RUST_LOG=agent_memory=debug` 启动，检查服务端 stderr 与 `<mount>/.anolisa/audit.log`。

--- a/docs/user-guide/zh/token-saving/agent-memory.md
+++ b/docs/user-guide/zh/token-saving/agent-memory.md
@@ -114,12 +114,14 @@ anolisa adapter status agent-memory
 
 **前置条件**：`openclaw` CLI 在 `$PATH` 上。脚本缺失时输出明确日志并以 0 退出，安装 OpenClaw 后重跑即可。`yum remove agent-memory` 时 spec 的 `%preun` 自动调用 uninstall 脚本，配置不残留孤立项。
 
-**Capability consent（OpenClaw >= 2026.9.1）**：OpenClaw 在提交「非官方可信来源」的受管插件安装前要求 capability consent。`install.sh` 走本地路径安装，没有可用的制品完整性记录，因此每次安装都会要求同意，而非交互式命令无法弹出交互确认。脚本会先探测 `openclaw plugins install --help`，只有当前 CLI 广告了 `--accept-capabilities` 才追加该参数；OpenClaw <= 2026.8.2 没有注册这个选项，未知选项会直接失败。若运维策略禁止非交互式接受能力，可设 `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` 主动不传该参数——此时安装会以 `Plugin "memory-anolisa" requires capability consent` 失败，需要自行同意：
+**Capability consent（OpenClaw >= 2026.8.1）**：OpenClaw 在提交「非官方可信来源」的受管插件安装前要求 capability consent。`install.sh` 走本地路径安装，没有可用的制品完整性记录，因此每次安装都会要求同意，而非交互式命令无法弹出交互确认。脚本会先探测 `openclaw plugins install --help`，只有当前 CLI 列出了 `--accept-capabilities` 才追加该参数。门禁取决于探测结果而不是版本号，因为这条版本边界很容易读错：`plugins install` 从 OpenClaw 2026.8.1 起注册该选项，而 OpenClaw CLI 参考文档到 2026.9.1 才收录它。更早的版本会把未知选项直接判失败（2026.5.7 / 2026.6.10 已实测），在那些主机上传该参数会把「本来能装上」变成「必然失败」。若运维策略禁止非交互式接受能力，可设 `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` 主动不传该参数——此时安装会以 `Plugin "memory-anolisa" requires capability consent` 失败，需要自行同意：
 
 ```bash
 AGENT_MEMORY_ACCEPT_CAPABILITIES=0 bash /usr/share/anolisa/adapters/agent-memory/openclaw/scripts/install.sh   # 策略性关闭自动同意
-openclaw plugins install /usr/share/anolisa/adapters/agent-memory/openclaw --force --accept-capabilities       # 手动同意一次
+openclaw plugins install /usr/share/anolisa/adapters/agent-memory/openclaw --force --dangerously-force-unsafe-install --accept-capabilities   # 手动同意一次，argv 与 install.sh 一致
 ```
+
+手动命令里要保留 `--dangerously-force-unsafe-install`：插件 bundle 通过 `child_process` 拉起 agent-memory MCP server，OpenClaw 的安装扫描会把它判为 "dangerous code pattern" 并以 `rc=1` 阻断，除非带上该参数。若安装时用了 `AGENT_MEMORY_SAFE_INSTALL=1`，则去掉它——`install.sh` 失败时会打印本次真实使用的 argv，直接照抄即可。
 
 插件 contract 名 ↔ agent-memory MCP 工具映射：
 
@@ -596,7 +598,7 @@ RUST_LOG=agent_memory=debug agent-memory
 | 索引检索对刚写入的内容查不到 | 还在 200 ms debounce 窗口内 | 重试，或用 `mem_grep`（直接走文件系统正则，不依赖索引） |
 | `mem_promote` 报 `session not found` | `MEMORY_SESSION_ID`/`MEMORY_SESSION_DIR` 未设或 scratch 不存在 | 见 Promote 工作流 |
 | OpenClaw 插件未加载 | `openclaw` CLI 不在 PATH | 安装 OpenClaw 后重跑 `install.sh` |
-| 运行 `install.sh` 报 `Plugin "memory-anolisa" requires capability consent` | OpenClaw >= 2026.9.1 对该安装要求 capability consent，而 `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` 关掉了自动同意 | 去掉该环境变量重跑（默认自动同意），或用 `openclaw plugins install <adapter>/openclaw --force --accept-capabilities` 手动同意一次 |
+| 运行 `install.sh` 报 `Plugin "memory-anolisa" requires capability consent` | OpenClaw >= 2026.8.1 对该安装要求 capability consent，而 `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` 关掉了自动同意 | 去掉该环境变量重跑（默认自动同意），或用 `openclaw plugins install /usr/share/anolisa/adapters/agent-memory/openclaw --force --dangerously-force-unsafe-install --accept-capabilities` 手动同意一次 |
 | 手动 dnf 操作后 system 状态不同步 | — | `sudo anolisa --install-mode system repair agent-memory`；仅在为仍存在的 RPM 重建记录时使用 system-scoped `forget` / `adopt` |
 
 深入排查：`RUST_LOG=agent_memory=debug` 启动，检查服务端 stderr 与 `<mount>/.anolisa/audit.log`。

--- a/src/agent-memory/Makefile
+++ b/src/agent-memory/Makefile
@@ -47,7 +47,7 @@ COMPONENT_CONTRACT := .anolisa/component.toml
 RPMBUILD_DIR ?= $(HOME)/rpmbuild
 SPEC_FILE := $(NAME).spec
 
-.PHONY: all build build-openclaw-plugin sync-versions generate-component-contract test lint fmt clean install \
+.PHONY: all build build-openclaw-plugin sync-versions generate-component-contract test test-openclaw-plugin lint fmt clean install \
         install-adapter-resources uninstall dist spec rpm srpm \
         smoke help
 
@@ -139,6 +139,18 @@ test-mcp: ## Run MCP integration tests only
 
 test-tools: ## Run Tier A file-tool integration tests only
 	cargo test --test file_tools_test
+
+# The OpenClaw adapter's install script talks to the openclaw CLI, which cargo
+# cannot cover. tests/unit/install-script-test.ts drives scripts/install.sh
+# against a fake openclaw and pins the installer-flag gating (capability consent
+# on OpenClaw >= 2026.9.1, no unknown-option regression on older releases).
+# Only that file is run: the rest of the adapter suite has pre-existing failures
+# (tests/unit/config-test.ts) and `npm run build:check` does not type-check
+# against the pinned openclaw 2026.5.7 devDependency, so adopting them is a
+# separate change.
+test-openclaw-plugin: ## Run the OpenClaw adapter install-script test (needs node/npm)
+	cd $(OPENCLAW_PLUGIN_SRC_DIR) && npm install --legacy-peer-deps --no-audit --no-fund
+	cd $(OPENCLAW_PLUGIN_SRC_DIR) && npx tsx --test tests/unit/install-script-test.ts
 
 # =============================================================================
 # REMOTE Linux build/test (for cross-platform development)

--- a/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
+++ b/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
@@ -53,11 +53,14 @@ if [ ! -f "$PLUGIN_DIR/dist/index.js" ]; then
     exit 1
 fi
 
-# Read the installer's option list once; it is the CLI contract every optional
-# flag below is gated on. A failed or empty probe is not fatal: the script falls
-# back to the base flags, which is what it did before the probe existed. The
-# probe's output is discarded on failure so an error message can never be
-# mistaken for an advertised option.
+# Read the installer's option list once; it is the CLI contract the capability
+# flag below is gated on. The other two flags stay unconditional: --force and
+# --dangerously-force-unsafe-install are registered by every OpenClaw this
+# adapter supports (checked against the 2026.5.7 / 2026.8.1 / 2026.8.2 help
+# output), so gating them would only add a way to be wrong. A failed or empty
+# probe is not fatal: the script falls back to the base flags, which is what it
+# did before the probe existed. The probe's output is discarded on failure so an
+# error message can never be mistaken for an advertised option.
 INSTALL_HELP="$(openclaw_cli plugins install --help 2>&1)" || INSTALL_HELP=""
 if [ -z "$INSTALL_HELP" ]; then
     echo "[${COMPONENT}] WARNING: could not read '${OPENCLAW_BIN} plugins install --help'; installing with the base flags only." >&2
@@ -77,7 +80,7 @@ if [ "${AGENT_MEMORY_SAFE_INSTALL:-0}" = "1" ]; then
     INSTALL_ARGS=("--force")
 fi
 
-# OpenClaw >= 2026.9.1 requires capability consent before it commits a managed
+# OpenClaw >= 2026.8.1 requires capability consent before it commits a managed
 # plugin install whose source is not a trusted official/first-party record. This
 # adapter installs from a local path, which carries no recorded artifact
 # integrity, so a previous acceptance can never be carried forward and consent
@@ -96,12 +99,17 @@ fi
 # surface being non-empty — a local-path install asks either way — so do not
 # "fix" this by editing openclaw.plugin.json.
 #
-# The flag is gated on the help probe above because OpenClaw <= 2026.8.2 does
-# not register it (first documented in 2026.9.1) and commander would exit 1 on
-# the unknown option, turning "installs fine" into "always fails" on hosts this
-# adapter still claims to support (manifest.json compatibleVersions ">=5.0.0").
-# Set AGENT_MEMORY_ACCEPT_CAPABILITIES=0 to withhold the flag where operator
-# policy forbids non-interactive capability acceptance.
+# The flag is gated on the help probe above rather than on a version number,
+# because the boundary is easy to get wrong: `plugins install` registers
+# --accept-capabilities from OpenClaw 2026.8.1 (on `enable` / `install` /
+# `update`), but the CLI reference (docs/cli/plugins.md) only documents it from
+# 2026.9.1, so counting documentation mentions puts the boundary one minor line
+# too late. Builds without it (verified absent on 2026.5.7, 2026.5.22 and
+# 2026.6.10) make commander exit 1 on the unknown option, turning "installs
+# fine" into "always fails" on hosts this adapter still claims to support
+# (manifest.json compatibleVersions ">=5.0.0"). Set
+# AGENT_MEMORY_ACCEPT_CAPABILITIES=0 to withhold the flag where operator policy
+# forbids non-interactive capability acceptance.
 ACCEPT_CAPABILITIES_FLAG="--accept-capabilities"
 ACCEPT_CAPABILITIES_ADVERTISED=0
 ACCEPT_CAPABILITIES_WITHHELD=0
@@ -111,11 +119,15 @@ fi
 
 if [ "${AGENT_MEMORY_ACCEPT_CAPABILITIES:-1}" = "0" ]; then
     ACCEPT_CAPABILITIES_WITHHELD=1
-    echo "[${COMPONENT}] AGENT_MEMORY_ACCEPT_CAPABILITIES=0: withholding ${ACCEPT_CAPABILITIES_FLAG}; OpenClaw >= 2026.9.1 refuses a non-interactive install that requires capability consent." >&2
+    if [ "$ACCEPT_CAPABILITIES_ADVERTISED" = "1" ]; then
+        echo "[${COMPONENT}] AGENT_MEMORY_ACCEPT_CAPABILITIES=0: withholding ${ACCEPT_CAPABILITIES_FLAG}; OpenClaw >= 2026.8.1 refuses a non-interactive install that requires capability consent." >&2
+    else
+        echo "[${COMPONENT}] AGENT_MEMORY_ACCEPT_CAPABILITIES=0: noted; '${OPENCLAW_BIN} plugins install' does not advertise ${ACCEPT_CAPABILITIES_FLAG} anyway, so there is nothing to withhold." >&2
+    fi
 elif [ "$ACCEPT_CAPABILITIES_ADVERTISED" = "1" ]; then
     INSTALL_ARGS+=("$ACCEPT_CAPABILITIES_FLAG")
 else
-    echo "[${COMPONENT}] '${OPENCLAW_BIN} plugins install' does not advertise ${ACCEPT_CAPABILITIES_FLAG} (OpenClaw < 2026.9.1); installing without it." >&2
+    echo "[${COMPONENT}] '${OPENCLAW_BIN} plugins install' does not advertise ${ACCEPT_CAPABILITIES_FLAG} (not listed in its --help); installing without it." >&2
 fi
 
 if ! openclaw_cli plugins install "$PLUGIN_DIR" "${INSTALL_ARGS[@]}"; then
@@ -123,10 +135,14 @@ if ! openclaw_cli plugins install "$PLUGIN_DIR" "${INSTALL_ARGS[@]}"; then
     if [ "$ACCEPT_CAPABILITIES_WITHHELD" = "1" ] && [ "$ACCEPT_CAPABILITIES_ADVERTISED" = "1" ]; then
         echo "[${COMPONENT}]   ${ACCEPT_CAPABILITIES_FLAG} was withheld by AGENT_MEMORY_ACCEPT_CAPABILITIES=0." >&2
         echo "[${COMPONENT}]   If the error above is 'requires capability consent', re-run with AGENT_MEMORY_ACCEPT_CAPABILITIES unset (default: accept)," >&2
-        echo "[${COMPONENT}]   or consent yourself: ${OPENCLAW_BIN} plugins install ${PLUGIN_DIR} --force ${ACCEPT_CAPABILITIES_FLAG}" >&2
+        echo "[${COMPONENT}]   or consent yourself: ${OPENCLAW_BIN} plugins install ${PLUGIN_DIR} ${INSTALL_ARGS[*]} ${ACCEPT_CAPABILITIES_FLAG}" >&2
+    elif [ "$ACCEPT_CAPABILITIES_ADVERTISED" = "0" ] && [ -z "$INSTALL_HELP" ]; then
+        echo "[${COMPONENT}]   The '${OPENCLAW_BIN} plugins install --help' probe returned nothing, so ${ACCEPT_CAPABILITIES_FLAG} support could not be detected." >&2
+        echo "[${COMPONENT}]   If the error above is 'requires capability consent', this openclaw may well support the flag (registered since 2026.8.1): check OPENCLAW_BIN and re-run," >&2
+        echo "[${COMPONENT}]   or consent yourself: ${OPENCLAW_BIN} plugins install ${PLUGIN_DIR} ${INSTALL_ARGS[*]} ${ACCEPT_CAPABILITIES_FLAG}" >&2
     elif [ "$ACCEPT_CAPABILITIES_ADVERTISED" = "0" ]; then
-        echo "[${COMPONENT}]   This openclaw predates ${ACCEPT_CAPABILITIES_FLAG} (< 2026.9.1), so it cannot offer capability consent." >&2
-        echo "[${COMPONENT}]   If the error above is 'requires capability consent', upgrade OpenClaw to >= 2026.9.1 and re-run." >&2
+        echo "[${COMPONENT}]   This openclaw does not list ${ACCEPT_CAPABILITIES_FLAG} in 'plugins install --help' (OpenClaw registers it from 2026.8.1), so it cannot offer capability consent." >&2
+        echo "[${COMPONENT}]   If the error above is 'requires capability consent', upgrade OpenClaw to >= 2026.8.1 and re-run." >&2
     fi
     echo "[${COMPONENT}]   Otherwise inspect the ${OPENCLAW_BIN} output above; the adapter itself requires OpenClaw >= 5.0.0 (manifest.json compatibleVersions)." >&2
     exit 1

--- a/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
+++ b/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
@@ -42,10 +42,17 @@ fi
 # subprocess communication and malicious shell usage, we bypass it
 # by default. Set AGENT_MEMORY_SAFE_INSTALL=1 to go through the
 # regular (blocking) safe-install path instead.
-INSTALL_ARGS=("--force" "--dangerously-force-unsafe-install")
+# OpenClaw 2026.9.2 gates plugins that declare capabilities behind a
+# capability-consent prompt: `openclaw plugins install` without
+# `--accept-capabilities` refuses to install (rc=1, "Plugin ... requires
+# capability consent"). The memory-anolisa plugin manifests capabilities
+# (conversation hooks + sandboxed MCP tool forwarding), so the install
+# must accept them explicitly or the plugin never leaves the install
+# step and every OpenClaw E2E test errors at fixture setup.
+INSTALL_ARGS=("--force" "--dangerously-force-unsafe-install" "--accept-capabilities")
 if [ "${AGENT_MEMORY_SAFE_INSTALL:-0}" = "1" ]; then
     echo "[${COMPONENT}] AGENT_MEMORY_SAFE_INSTALL=1: using OpenClaw safe-install path (may block on child_process scan)." >&2
-    INSTALL_ARGS=("--force")
+    INSTALL_ARGS=("--force" "--accept-capabilities")
 fi
 
 env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install "$PLUGIN_DIR" \

--- a/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
+++ b/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
@@ -19,6 +19,25 @@ OPENCLAW_STATE_DIR="${OPENCLAW_STATE_DIR%/}"
 OPENCLAW_HOME="${OPENCLAW_HOME%/}"
 OPENCLAW_BIN="${OPENCLAW_BIN:-openclaw}"
 
+# The CLI env contract mirrors src/agent-sec-core/openclaw-plugin/scripts/deploy.sh:
+# OPENCLAW_HOME is unset so OPENCLAW_STATE_DIR is the single source of truth.
+openclaw_cli() {
+    env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" "$@"
+}
+
+# Whether $2 (the probed `plugins install --help` text) lists $1 as a standalone
+# option token. `openclaw` is a commander program, so a subcommand that does not
+# register an option exits 1 with "unknown option" — installer flags may only be
+# passed when the running CLI advertises them. An option token continues through
+# ASCII alphanumerics, '-', '_' and '.', so a near-miss such as
+# `--accept-capabilities-only` never matches `--accept-capabilities` (mirrors
+# anolisa-core's help_lists_flag()).
+install_help_lists_flag() {
+    local flag="$1" normalized
+    normalized=" $(printf '%s' "$2" | tr -cs 'A-Za-z0-9._-' ' ') "
+    [[ "$normalized" == *" $flag "* ]]
+}
+
 echo "[${COMPONENT}] Installing ${AGENT} plugin..."
 
 if ! command -v "$OPENCLAW_BIN" &>/dev/null; then
@@ -34,6 +53,16 @@ if [ ! -f "$PLUGIN_DIR/dist/index.js" ]; then
     exit 1
 fi
 
+# Read the installer's option list once; it is the CLI contract every optional
+# flag below is gated on. A failed or empty probe is not fatal: the script falls
+# back to the base flags, which is what it did before the probe existed. The
+# probe's output is discarded on failure so an error message can never be
+# mistaken for an advertised option.
+INSTALL_HELP="$(openclaw_cli plugins install --help 2>&1)" || INSTALL_HELP=""
+if [ -z "$INSTALL_HELP" ]; then
+    echo "[${COMPONENT}] WARNING: could not read '${OPENCLAW_BIN} plugins install --help'; installing with the base flags only." >&2
+fi
+
 # OpenClaw's security scanner flags child_process.spawn as a
 # "dangerous code pattern". The plugin uses spawn exclusively to
 # launch the agent-memory MCP server as a stdio subprocess — this is
@@ -42,30 +71,72 @@ fi
 # subprocess communication and malicious shell usage, we bypass it
 # by default. Set AGENT_MEMORY_SAFE_INSTALL=1 to go through the
 # regular (blocking) safe-install path instead.
-# OpenClaw 2026.9.2 gates plugins that declare capabilities behind a
-# capability-consent prompt: `openclaw plugins install` without
-# `--accept-capabilities` refuses to install (rc=1, "Plugin ... requires
-# capability consent"). The memory-anolisa plugin manifests capabilities
-# (conversation hooks + sandboxed MCP tool forwarding), so the install
-# must accept them explicitly or the plugin never leaves the install
-# step and every OpenClaw E2E test errors at fixture setup.
-INSTALL_ARGS=("--force" "--dangerously-force-unsafe-install" "--accept-capabilities")
+INSTALL_ARGS=("--force" "--dangerously-force-unsafe-install")
 if [ "${AGENT_MEMORY_SAFE_INSTALL:-0}" = "1" ]; then
     echo "[${COMPONENT}] AGENT_MEMORY_SAFE_INSTALL=1: using OpenClaw safe-install path (may block on child_process scan)." >&2
-    INSTALL_ARGS=("--force" "--accept-capabilities")
+    INSTALL_ARGS=("--force")
 fi
 
-env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install "$PLUGIN_DIR" \
-    "${INSTALL_ARGS[@]}" || {
-    echo "[${COMPONENT}] openclaw CLI install failed — check OpenClaw version >= 5.0.0" >&2
+# OpenClaw >= 2026.9.1 requires capability consent before it commits a managed
+# plugin install whose source is not a trusted official/first-party record. This
+# adapter installs from a local path, which carries no recorded artifact
+# integrity, so a previous acceptance can never be carried forward and consent
+# is requested on every install (openclaw docs/plugins/manage-plugins.md,
+# "Capability consent": "Sources without recorded integrity — notably local
+# paths ... ask for consent on every install"). A non-interactive
+# `plugins install` cannot prompt, so without --accept-capabilities it exits 1:
+#   Plugin "memory-anolisa" requires capability consent. Use openclaw plugins
+#   install or openclaw plugins enable with --accept-capabilities, then retry.
+# What gets reviewed is the plugin's declared capability surface, not its
+# executable bytes: for memory-anolisa that is the 4 `contracts.tools` entries
+# in openclaw.plugin.json, which OpenClaw folds into `declared.tools`
+# (buildPluginCapabilitySummary()). The conversation hooks and the MCP client
+# are registered at runtime from dist/index.js (src/index.ts) and are not part
+# of the declared manifest surface. Consent itself is not conditional on that
+# surface being non-empty — a local-path install asks either way — so do not
+# "fix" this by editing openclaw.plugin.json.
+#
+# The flag is gated on the help probe above because OpenClaw <= 2026.8.2 does
+# not register it (first documented in 2026.9.1) and commander would exit 1 on
+# the unknown option, turning "installs fine" into "always fails" on hosts this
+# adapter still claims to support (manifest.json compatibleVersions ">=5.0.0").
+# Set AGENT_MEMORY_ACCEPT_CAPABILITIES=0 to withhold the flag where operator
+# policy forbids non-interactive capability acceptance.
+ACCEPT_CAPABILITIES_FLAG="--accept-capabilities"
+ACCEPT_CAPABILITIES_ADVERTISED=0
+ACCEPT_CAPABILITIES_WITHHELD=0
+if install_help_lists_flag "$ACCEPT_CAPABILITIES_FLAG" "$INSTALL_HELP"; then
+    ACCEPT_CAPABILITIES_ADVERTISED=1
+fi
+
+if [ "${AGENT_MEMORY_ACCEPT_CAPABILITIES:-1}" = "0" ]; then
+    ACCEPT_CAPABILITIES_WITHHELD=1
+    echo "[${COMPONENT}] AGENT_MEMORY_ACCEPT_CAPABILITIES=0: withholding ${ACCEPT_CAPABILITIES_FLAG}; OpenClaw >= 2026.9.1 refuses a non-interactive install that requires capability consent." >&2
+elif [ "$ACCEPT_CAPABILITIES_ADVERTISED" = "1" ]; then
+    INSTALL_ARGS+=("$ACCEPT_CAPABILITIES_FLAG")
+else
+    echo "[${COMPONENT}] '${OPENCLAW_BIN} plugins install' does not advertise ${ACCEPT_CAPABILITIES_FLAG} (OpenClaw < 2026.9.1); installing without it." >&2
+fi
+
+if ! openclaw_cli plugins install "$PLUGIN_DIR" "${INSTALL_ARGS[@]}"; then
+    echo "[${COMPONENT}] openclaw CLI install failed: ${OPENCLAW_BIN} plugins install ${PLUGIN_DIR} ${INSTALL_ARGS[*]}" >&2
+    if [ "$ACCEPT_CAPABILITIES_WITHHELD" = "1" ] && [ "$ACCEPT_CAPABILITIES_ADVERTISED" = "1" ]; then
+        echo "[${COMPONENT}]   ${ACCEPT_CAPABILITIES_FLAG} was withheld by AGENT_MEMORY_ACCEPT_CAPABILITIES=0." >&2
+        echo "[${COMPONENT}]   If the error above is 'requires capability consent', re-run with AGENT_MEMORY_ACCEPT_CAPABILITIES unset (default: accept)," >&2
+        echo "[${COMPONENT}]   or consent yourself: ${OPENCLAW_BIN} plugins install ${PLUGIN_DIR} --force ${ACCEPT_CAPABILITIES_FLAG}" >&2
+    elif [ "$ACCEPT_CAPABILITIES_ADVERTISED" = "0" ]; then
+        echo "[${COMPONENT}]   This openclaw predates ${ACCEPT_CAPABILITIES_FLAG} (< 2026.9.1), so it cannot offer capability consent." >&2
+        echo "[${COMPONENT}]   If the error above is 'requires capability consent', upgrade OpenClaw to >= 2026.9.1 and re-run." >&2
+    fi
+    echo "[${COMPONENT}]   Otherwise inspect the ${OPENCLAW_BIN} output above; the adapter itself requires OpenClaw >= 5.0.0 (manifest.json compatibleVersions)." >&2
     exit 1
-}
+fi
 
 # OpenClaw 2026.6.11 requires non-bundled plugins to explicitly opt-in
 # to conversation hooks (agent_end, before_prompt_build, etc.). Without
 # this setting the hooks are silently blocked and auto-capture /
 # auto-recall never fire (#1460).
-env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" config set \
+openclaw_cli config set \
     "plugins.entries.memory-anolisa.hooks.allowConversationAccess" true || {
     echo "[${COMPONENT}] WARNING: failed to set allowConversationAccess — auto-capture/auto-recall hooks may be blocked." >&2
 }

--- a/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/install-script-test.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/install-script-test.ts
@@ -6,7 +6,7 @@
  * 1. `plugins install` is a commander subcommand that registers its options
  *    explicitly, so an option the running release does not know is a hard
  *    failure (`error: unknown option '<flag>'`, rc=1) — not a ignored extra.
- * 2. OpenClaw >= 2026.9.1 requires capability consent before committing a
+ * 2. OpenClaw >= 2026.8.1 requires capability consent before committing a
  *    managed install from a source without recorded artifact integrity (this
  *    adapter always installs from a local path), and a non-interactive command
  *    cannot prompt, so it fails with rc=1 unless `--accept-capabilities` is
@@ -14,7 +14,13 @@
  *
  * Together they pin the gating: append the flag iff the installer help
  * advertises it. Reverting install.sh to an unconditional
- * `--accept-capabilities` turns the "pre-2026.9.1 host" case red.
+ * `--accept-capabilities` turns the "installer does not register the option"
+ * case red.
+ *
+ * The version numbers above are context, not the contract: `plugins install`
+ * registers `--accept-capabilities` from 2026.8.1 while the OpenClaw CLI
+ * reference only documents it from 2026.9.1, which is exactly why install.sh
+ * probes the running CLI instead of comparing versions.
  *
  * Pattern follows src/agent-sec-core/openclaw-plugin/tests/unit/deploy-script-test.ts.
  */
@@ -38,8 +44,11 @@ const INSTALL_SCRIPT = resolve("scripts/install.sh");
 
 /**
  * What the fake installer help advertises:
- * - `consent`: OpenClaw >= 2026.9.1 (`--accept-capabilities` present).
- * - `legacy`: OpenClaw <= 2026.8.2 (flag absent).
+ * - `consent`: an OpenClaw whose installer registers `--accept-capabilities`
+ *   (2026.8.1 and later).
+ * - `legacy`: an OpenClaw whose installer does not register the flag and
+ *   therefore rejects it as an unknown option (verified on 2026.5.7 and
+ *   2026.6.10; 2026.5.22 has no occurrence of it in `dist` either).
  * - `near-miss`: only a longer, different flag is present — proves token-boundary
  *   matching instead of substring matching.
  * - `unavailable`: the help probe itself fails.
@@ -223,7 +232,7 @@ function installArgvLine(log: string): string {
 }
 
 describe("install.sh capability-consent gating", () => {
-  it("passes --accept-capabilities when the installer advertises it (OpenClaw >= 2026.9.1)", () => {
+  it("passes --accept-capabilities when the installer advertises it (OpenClaw >= 2026.8.1)", () => {
     const result = runInstall({ consentRequired: true, installHelpMode: "consent" });
 
     assert.equal(result.status, 0, result.stderr);
@@ -237,7 +246,7 @@ describe("install.sh capability-consent gating", () => {
     assert.match(result.log, /config set plugins\.entries\.memory-anolisa\.hooks\.allowConversationAccess true/);
   });
 
-  it("omits --accept-capabilities on a pre-2026.9.1 host that would reject the unknown option", () => {
+  it("omits --accept-capabilities when the installer does not register it and would reject the unknown option", () => {
     const result = runInstall({ consentRequired: false, installHelpMode: "legacy" });
 
     assert.equal(result.status, 0, result.stderr);
@@ -246,7 +255,7 @@ describe("install.sh capability-consent gating", () => {
       installArgvLine(result.log),
       `plugins install ${join(result.rootDir, "adapter", "openclaw")} --force --dangerously-force-unsafe-install`,
     );
-    assert.match(result.stderr, /does not advertise --accept-capabilities \(OpenClaw < 2026\.9\.1\)/);
+    assert.match(result.stderr, /does not advertise --accept-capabilities \(not listed in its --help\)/);
   });
 
   it("matches the flag as a whole option token, not as a substring", () => {
@@ -284,7 +293,46 @@ describe("install.sh capability-consent gating", () => {
     assert.match(result.stderr, /AGENT_MEMORY_ACCEPT_CAPABILITIES=0: withholding --accept-capabilities/);
     assert.match(result.stderr, /requires capability consent/);
     assert.match(result.stderr, /was withheld by AGENT_MEMORY_ACCEPT_CAPABILITIES=0/);
-    assert.match(result.stderr, /or consent yourself: openclaw plugins install .* --force --accept-capabilities/);
+    assert.match(
+      result.stderr,
+      /or consent yourself: openclaw plugins install .* --force --dangerously-force-unsafe-install --accept-capabilities/,
+    );
+  });
+
+  it("echoes the safe-install argv when the manual consent hint is printed under AGENT_MEMORY_SAFE_INSTALL=1", () => {
+    const result = runInstall({
+      acceptCapabilitiesEnv: "0",
+      consentRequired: true,
+      installHelpMode: "consent",
+      safeInstallEnv: "1",
+    });
+
+    assert.equal(result.status, 1);
+    assert.equal(
+      installArgvLine(result.log),
+      `plugins install ${join(result.rootDir, "adapter", "openclaw")} --force`,
+    );
+    // The hint must be copy-pasteable: same argv the script just used, so the
+    // unsafe-install flag is absent here exactly as it is absent above.
+    assert.match(
+      result.stderr,
+      /or consent yourself: openclaw plugins install .* --force --accept-capabilities/,
+    );
+    assert.doesNotMatch(result.stderr, /consent yourself: .*--dangerously-force-unsafe-install/);
+  });
+
+  it("does not claim to withhold the flag on an installer that never advertised it", () => {
+    const result = runInstall({
+      acceptCapabilitiesEnv: "0",
+      consentRequired: false,
+      installHelpMode: "legacy",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stderr, /AGENT_MEMORY_ACCEPT_CAPABILITIES=0: noted/);
+    assert.match(result.stderr, /nothing to withhold/);
+    assert.doesNotMatch(result.stderr, /withholding --accept-capabilities/);
+    assert.doesNotMatch(installArgvLine(result.log), /--accept-capabilities( |$)/);
   });
 
   it("survives an unreadable installer help and still installs on a host without the gate", () => {
@@ -299,7 +347,21 @@ describe("install.sh capability-consent gating", () => {
     const result = runInstall({ consentRequired: true, installHelpMode: "legacy" });
 
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /predates --accept-capabilities \(< 2026\.9\.1\)/);
-    assert.match(result.stderr, /upgrade OpenClaw to >= 2026\.9\.1 and re-run/);
+    assert.match(result.stderr, /does not list --accept-capabilities in 'plugins install --help'/);
+    assert.match(result.stderr, /OpenClaw registers it from 2026\.8\.1/);
+    assert.match(result.stderr, /upgrade OpenClaw to >= 2026\.8\.1 and re-run/);
+  });
+
+  it("blames the failed help probe, not the OpenClaw version, when the probe returned nothing", () => {
+    // A 2026.8.x host whose probe fails falls back to the base flags and then
+    // hits the consent gate. Telling that operator to upgrade is useless — the
+    // CLI already registers the flag — so the hint must point at the probe.
+    const result = runInstall({ consentRequired: true, installHelpMode: "unavailable" });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /could not read 'openclaw plugins install --help'/);
+    assert.match(result.stderr, /probe returned nothing/);
+    assert.match(result.stderr, /may well support the flag \(registered since 2026\.8\.1\)/);
+    assert.doesNotMatch(result.stderr, /upgrade OpenClaw to/);
   });
 });

--- a/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/install-script-test.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/install-script-test.ts
@@ -1,0 +1,305 @@
+/**
+ * Unit tests for scripts/install.sh OpenClaw installer-flag gating.
+ *
+ * The fake `openclaw` below models the two CLI facts install.sh depends on:
+ *
+ * 1. `plugins install` is a commander subcommand that registers its options
+ *    explicitly, so an option the running release does not know is a hard
+ *    failure (`error: unknown option '<flag>'`, rc=1) — not a ignored extra.
+ * 2. OpenClaw >= 2026.9.1 requires capability consent before committing a
+ *    managed install from a source without recorded artifact integrity (this
+ *    adapter always installs from a local path), and a non-interactive command
+ *    cannot prompt, so it fails with rc=1 unless `--accept-capabilities` is
+ *    passed.
+ *
+ * Together they pin the gating: append the flag iff the installer help
+ * advertises it. Reverting install.sh to an unconditional
+ * `--accept-capabilities` turns the "pre-2026.9.1 host" case red.
+ *
+ * Pattern follows src/agent-sec-core/openclaw-plugin/tests/unit/deploy-script-test.ts.
+ */
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+const INSTALL_SCRIPT = resolve("scripts/install.sh");
+
+/**
+ * What the fake installer help advertises:
+ * - `consent`: OpenClaw >= 2026.9.1 (`--accept-capabilities` present).
+ * - `legacy`: OpenClaw <= 2026.8.2 (flag absent).
+ * - `near-miss`: only a longer, different flag is present — proves token-boundary
+ *   matching instead of substring matching.
+ * - `unavailable`: the help probe itself fails.
+ */
+type InstallHelpMode = "consent" | "legacy" | "near-miss" | "unavailable";
+
+type InstallOptions = {
+  acceptCapabilitiesEnv?: string;
+  consentRequired?: boolean;
+  installHelpMode?: InstallHelpMode;
+  safeInstallEnv?: string;
+};
+
+type InstallResult = {
+  log: string;
+  rootDir: string;
+  stderr: string;
+  stdout: string;
+  status: number | null;
+};
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createExecutable(path: string, content: string): void {
+  writeFileSync(path, content, "utf8");
+  chmodSync(path, 0o755);
+}
+
+function createFakeOpenClaw(binDir: string): void {
+  createExecutable(
+    join(binDir, "openclaw"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\\n' "$*" >> "\${OPENCLAW_FAKE_LOG:?}"
+
+mode="\${OPENCLAW_FAKE_INSTALL_HELP:-consent}"
+
+advertised=("--force" "--dangerously-force-unsafe-install")
+if [[ "$mode" == "consent" ]]; then
+    advertised+=("--accept-capabilities")
+elif [[ "$mode" == "near-miss" ]]; then
+    advertised+=("--accept-capabilities-only")
+fi
+
+if [[ "$mode" == "unavailable" && "\${1:-}" == "plugins" && "\${2:-}" == "install" && "\${3:-}" == "--help" ]]; then
+    echo "[openclaw] Could not start the CLI." >&2
+    exit 1
+fi
+
+if [[ "\${1:-}" == "plugins" && "\${2:-}" == "install" && "\${3:-}" == "--help" ]]; then
+    echo "Usage: openclaw plugins install <path> [options]"
+    echo ""
+    echo "Options:"
+    for flag in "\${advertised[@]}"; do
+        case "$flag" in
+            --force)
+                echo "  --force  Confirm non-ClawHub sources and overwrite an existing plugin or hook pack"
+                ;;
+            --dangerously-force-unsafe-install)
+                echo "  --dangerously-force-unsafe-install  Deprecated no-op; security.installPolicy may still block"
+                ;;
+            --accept-capabilities)
+                echo "  --accept-capabilities  Accept the plugin's declared capabilities"
+                ;;
+            --accept-capabilities-only)
+                echo "  --accept-capabilities-only  Something else entirely"
+                ;;
+        esac
+    done
+    exit 0
+fi
+
+if [[ "\${1:-}" == "plugins" && "\${2:-}" == "install" ]]; then
+    shift 2
+    accepted=0
+    for arg in "$@"; do
+        if [[ "$arg" != --* ]]; then
+            continue
+        fi
+        known=0
+        for flag in "\${advertised[@]}"; do
+            if [[ "$arg" == "$flag" ]]; then
+                known=1
+            fi
+        done
+        if [[ "$known" != "1" ]]; then
+            # commander's default for an unregistered option.
+            echo "error: unknown option '$arg'" >&2
+            exit 1
+        fi
+        if [[ "$arg" == "--accept-capabilities" ]]; then
+            accepted=1
+        fi
+    done
+    if [[ "\${OPENCLAW_FAKE_CONSENT_REQUIRED:-0}" == "1" && "$accepted" != "1" ]]; then
+        echo '[openclaw] Could not start the CLI.' >&2
+        echo '[openclaw] Reason: Plugin "memory-anolisa" requires capability consent. Use openclaw plugins install or openclaw plugins enable with --accept-capabilities, then retry.' >&2
+        exit 1
+    fi
+    echo "Installed plugin: memory-anolisa"
+    exit 0
+fi
+
+if [[ "$*" == "config set plugins.entries.memory-anolisa.hooks.allowConversationAccess true" ]]; then
+    echo "configured"
+    exit 0
+fi
+
+echo "unexpected fake openclaw args: $*" >&2
+exit 2
+`,
+  );
+}
+
+/** install.sh aborts unless the built plugin entry exists. */
+function createAdapterFixture(rootDir: string): string {
+  const adapterDir = join(rootDir, "adapter");
+  mkdirSync(join(adapterDir, "openclaw", "dist"), { recursive: true });
+  writeFileSync(join(adapterDir, "openclaw", "dist", "index.js"), "export {};\n", "utf8");
+  return adapterDir;
+}
+
+function runInstall(options: InstallOptions = {}): InstallResult {
+  const rootDir = mkdtempSync(join(tmpdir(), "agent-memory-openclaw-install-"));
+  tempDirs.push(rootDir);
+  const binDir = join(rootDir, "bin");
+  const logPath = join(rootDir, "openclaw.log");
+  mkdirSync(binDir, { recursive: true });
+  createFakeOpenClaw(binDir);
+
+  const adapterDir = createAdapterFixture(rootDir);
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ANOLISA_ADAPTER_DIR: adapterDir,
+    OPENCLAW_FAKE_CONSENT_REQUIRED: options.consentRequired === true ? "1" : "0",
+    OPENCLAW_FAKE_INSTALL_HELP: options.installHelpMode ?? "consent",
+    OPENCLAW_FAKE_LOG: logPath,
+    OPENCLAW_HOME: join(rootDir, "openclaw-home"),
+    OPENCLAW_STATE_DIR: join(rootDir, "openclaw-home"),
+    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    TMPDIR: rootDir,
+  };
+  delete env.AGENT_MEMORY_ACCEPT_CAPABILITIES;
+  delete env.AGENT_MEMORY_SAFE_INSTALL;
+  if (options.acceptCapabilitiesEnv !== undefined) {
+    env.AGENT_MEMORY_ACCEPT_CAPABILITIES = options.acceptCapabilitiesEnv;
+  }
+  if (options.safeInstallEnv !== undefined) {
+    env.AGENT_MEMORY_SAFE_INSTALL = options.safeInstallEnv;
+  }
+
+  const result = spawnSync("bash", [INSTALL_SCRIPT], {
+    cwd: resolve("."),
+    encoding: "utf8",
+    env,
+  });
+
+  return {
+    log: existsSync(logPath) ? readFileSync(logPath, "utf8") : "",
+    rootDir,
+    stderr: result.stderr,
+    stdout: result.stdout,
+    status: result.status,
+  };
+}
+
+/** The argv line the fake CLI recorded for the real install (not the help probe). */
+function installArgvLine(log: string): string {
+  const lines = log
+    .split("\n")
+    .filter((line) => line.startsWith("plugins install ") && !line.endsWith("--help"));
+  assert.equal(lines.length, 1, `expected exactly one install invocation, got:\n${log}`);
+  return lines[0];
+}
+
+describe("install.sh capability-consent gating", () => {
+  it("passes --accept-capabilities when the installer advertises it (OpenClaw >= 2026.9.1)", () => {
+    const result = runInstall({ consentRequired: true, installHelpMode: "consent" });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.log, /plugins install --help/);
+    assert.equal(
+      installArgvLine(result.log),
+      `plugins install ${join(result.rootDir, "adapter", "openclaw")} --force --dangerously-force-unsafe-install --accept-capabilities`,
+    );
+    assert.match(result.stdout, /Installed plugin: memory-anolisa/);
+    assert.match(result.stdout, /plugin installed via openclaw CLI/);
+    assert.match(result.log, /config set plugins\.entries\.memory-anolisa\.hooks\.allowConversationAccess true/);
+  });
+
+  it("omits --accept-capabilities on a pre-2026.9.1 host that would reject the unknown option", () => {
+    const result = runInstall({ consentRequired: false, installHelpMode: "legacy" });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.log, /plugins install --help/);
+    assert.equal(
+      installArgvLine(result.log),
+      `plugins install ${join(result.rootDir, "adapter", "openclaw")} --force --dangerously-force-unsafe-install`,
+    );
+    assert.match(result.stderr, /does not advertise --accept-capabilities \(OpenClaw < 2026\.9\.1\)/);
+  });
+
+  it("matches the flag as a whole option token, not as a substring", () => {
+    const result = runInstall({ consentRequired: false, installHelpMode: "near-miss" });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.doesNotMatch(installArgvLine(result.log), /--accept-capabilities( |$)/);
+    assert.match(result.stderr, /does not advertise --accept-capabilities/);
+  });
+
+  it("keeps consent on both install paths when AGENT_MEMORY_SAFE_INSTALL=1", () => {
+    const result = runInstall({
+      consentRequired: true,
+      installHelpMode: "consent",
+      safeInstallEnv: "1",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      installArgvLine(result.log),
+      `plugins install ${join(result.rootDir, "adapter", "openclaw")} --force --accept-capabilities`,
+    );
+    assert.match(result.stderr, /AGENT_MEMORY_SAFE_INSTALL=1/);
+  });
+
+  it("honours AGENT_MEMORY_ACCEPT_CAPABILITIES=0 and says why the install failed", () => {
+    const result = runInstall({
+      acceptCapabilitiesEnv: "0",
+      consentRequired: true,
+      installHelpMode: "consent",
+    });
+
+    assert.equal(result.status, 1);
+    assert.doesNotMatch(installArgvLine(result.log), /--accept-capabilities/);
+    assert.match(result.stderr, /AGENT_MEMORY_ACCEPT_CAPABILITIES=0: withholding --accept-capabilities/);
+    assert.match(result.stderr, /requires capability consent/);
+    assert.match(result.stderr, /was withheld by AGENT_MEMORY_ACCEPT_CAPABILITIES=0/);
+    assert.match(result.stderr, /or consent yourself: openclaw plugins install .* --force --accept-capabilities/);
+  });
+
+  it("survives an unreadable installer help and still installs on a host without the gate", () => {
+    const result = runInstall({ consentRequired: false, installHelpMode: "unavailable" });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stderr, /could not read 'openclaw plugins install --help'/);
+    assert.doesNotMatch(installArgvLine(result.log), /--accept-capabilities/);
+  });
+
+  it("points at the OpenClaw upgrade, not at a bogus version floor, when a legacy host hits the gate", () => {
+    const result = runInstall({ consentRequired: true, installHelpMode: "legacy" });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /predates --accept-capabilities \(< 2026\.9\.1\)/);
+    assert.match(result.stderr, /upgrade OpenClaw to >= 2026\.9\.1 and re-run/);
+  });
+});


### PR DESCRIPTION
## 问题

Fixes #3099

OpenClaw 2026.9.1 起引入 plugin capability consent 门禁：**来源不是「官方可信记录」的受管插件安装**，在拿到 capability consent 之前不会提交，而非交互式命令无法弹窗确认，于是 `openclaw plugins install` 直接 rc=1。agent-memory 的 OpenClaw 插件安装脚本 `src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh` 只传了 `--force --dangerously-force-unsafe-install`，`memory-anolisa` 因此始终装不上，9 个 OpenClaw E2E 用例在 fixture 安装阶段报错。

## 修复

初版 `61ada0f9` 无条件追加 `--accept-capabilities`。Code Review 指出这会把项目仍声明支持的旧版 OpenClaw 从「能装」变成「必失败」；该回归已核实（见下「证据」），当前 head `7bf3c4e0` 改为 review 给的**方案 1**：先探测 `plugins install --help`，只有当前 CLI 广告该 flag 才追加。

- `install_help_lists_flag()` 做 **token 边界**匹配（对齐 `anolisa-core` 的 `help_lists_flag`、粒度不弱于 `agent-sec-core/deploy.sh`）：`--accept-capabilities-only` 之类近似名不会误命中。
- 探测失败或无输出**不致命**：回落到原有 base flags（即探测存在之前的行为），并丢弃探测输出，避免把错误文案误当成「已广告」。
- `AGENT_MEMORY_SAFE_INSTALL=1` 分支同样带 consent，两条安装路径行为一致。
- 新增 `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` opt-out：策略禁止非交互式接受 capability 的运维可以扣下该 flag，此时失败信息会明说「被 opt-out 扣下」并给出手动同意命令。
- 失败提示不再指向无关的 `check OpenClaw version >= 5.0.0`，而是区分「CLI 太旧给不出 consent（→ 升级到 >= 2026.9.1）」与「consent 被扣下（→ 去掉环境变量或手动同意）」。
- `manifest.json compatibleVersions` 保持 `>=5.0.0` 不变：gating 之后旧版主机仍走原 argv，无需上调版本下限。

### 触发条件（原注释不准确，已按上游实现改写）

原注释说「插件 manifests capabilities（conversation hooks + sandboxed MCP tool forwarding）」。核对 `openclaw@2026.9.2` 发布包后，实际条件是两条，都与 `openclaw.plugin.json` 里有没有 `capabilities` 键无关：

1. **来源**：`consentExemptSource = request.source === "local" && request.bundledOrigin === true`（`dist/management-install-*.js`）。本 adapter 从本地路径安装且非 bundled → 不豁免；本地路径没有制品完整性记录，acceptance 无法结转，所以**每次安装都要重新同意**（`docs/plugins/manage-plugins.md` "Capability consent"）。
2. **拿不到同意**：`acknowledgment = official || !enabled || acceptanceCurrent ? {…} : acknowledgeCapabilities ?? onCapabilityConsent?.(review)`；`acceptanceCurrent` 只在 `mode === "update"` 才计算，首次安装必为 false，非交互式又没有 `onCapabilityConsent` → `throwManagedPluginCapabilityConsentRequired()`（`dist/capability-consent-*.js`）。

被 review 的「声明面」是 `buildPluginCapabilitySummary()` 算出来的：`tools = manifest.contracts?.tools ∪ Object.keys(manifest.toolMetadata)`。memory-anolisa 的 `openclaw.plugin.json` 声明了 4 个 `contracts.tools`，所以声明面非空；但**门禁并不以声明面非空为前提**——本地路径安装即使声明面为空也一样要同意。conversation hooks 与 MCP client 是 `src/index.ts` 运行时注册的，不在声明面里。新注释把这些写清楚了，并显式提醒「不要靠改 `openclaw.plugin.json` 来绕过」。

## P1-2（Rust driver 那条安装路径）不在本 PR 处理

跟进 issue：**#3119**

`anolisa adapter enable agent-memory openclaw` 不执行 `install.sh`，`anolisa-core` 自己拼 argv（`openclaw.rs:2248 install_argv()`），因此同一个门禁会以同样方式打到它；而且 `install_output_looks_like_safety_rejection()`（`openclaw.rs:1668`）只匹配 `unsafe/safety/dangerous`，consent 失败要么认不出来，要么因为 2026.9.2 仍会回显 `--dangerously-force-unsafe-install is deprecated…` 而被**误判成 safety 拒绝**，给出错误的重试提示。#3119 里给了行号级的具体改法：复用已有的 `build_install_help_cmd` 探测 + `help_lists_flag`、给 consent 一个独立的授权开关、扩展失败分类器、补 fake-CLI 测试。

review 另外点名确认的两个 shell 入口已由作者的姊妹 PR 覆盖：`agent-sec-core/deploy.sh` → #3106（同样采用 help 探测 gating）、`tokenless/install.sh` → #3114、`ws-ckpt` → #3117。

## 验证

**done — 本机实跑**

- `make -C src/agent-memory test-openclaw-plugin` → 7/7 pass（fake `openclaw` CLI 驱动真实 `install.sh`）。用例：2026.9.1+ 同意主机、pre-2026.9.1 主机（未知 flag 会 rc=1）、近似名 `--accept-capabilities-only`、`AGENT_MEMORY_SAFE_INSTALL=1`、`AGENT_MEMORY_ACCEPT_CAPABILITIES=0`、help 探测失败、旧主机撞门禁时的提示文案。
- **改回去就红**：把 `install.sh` 换回 `61ada0f9` 版本，同一套测试 6/7 fail（唯一通过的只有 help 探测失败那条）。
- `shellcheck scripts/install.sh` → 0 warning（与改前一致）。
- adapter 全量 `npm test` → 90/95 pass；5 个 fail 全在 `tests/unit/config-test.ts`（`resolveConfig` userId/sessionId），在**未改动的 PR head 上同样 fail**（单独跑 config-test：25/30），属既有问题，与本 PR 无关。

**done — 上游发布包静态核对（非本机执行 CLI）**

- `--accept-capabilities` 在 `plugins install` 上的注册：`openclaw@2026.9.2` `dist/plugins-cli-*.js` → `.option("--accept-capabilities", "Accept the plugin's declared capabilities", false)`；`docs/cli/plugins.md` → `--accept-capabilities  Accept declared capabilities for this install`。
- 版本边界（逐版本抓 `docs/cli/plugins.md` 统计 `--accept-capabilities` 出现次数）：2026.4.14 = 0、2026.5.7 = 0、2026.6.10 = 0、2026.8.2 = 0、**2026.9.1 = 1**、2026.9.2 = 1。
- 旧版会硬失败而不是忽略未知 flag：openclaw 依赖 `commander@15.0.0`，`plugins install` 未调用 `allowUnknownOption`（该调用只出现在 `gateway restart-handoff consume`、`proxy run` 和 lazy-command 占位符），commander 默认对未注册选项报 `error: unknown option '<flag>'` 并 exit 1；openclaw 自己的错误归一化也在匹配 `/^unknown option ['"`](.+?)['"`]/i`（`dist/error-output-*.js`）。
- 门禁与声明面来源：见上「触发条件」的代码/文档出处。

**not-verified**

- 真实 OpenClaw 2026.9.2 主机上跑改后的 `install.sh`：本机 node 为 22.21.1，而 `openclaw@2026.9.2` 要求 Node >= 22.22.3，无法起真实 CLI；2026.9.2 上的原始复现与「手动加 flag 即 rc=0」由 #3099 与本 PR 初版在 ALinux 4 ECS（8.210.218.100）上验证过（见下），gating 之后 argv 在该主机上与那次手动命令一致。
- **< 2026.9.1 的真实旧版主机一个格子都没实测**（2026.4.14 / 2026.4.23 / 2026.4.24 / 2026.4.29 / 2026.5.7 / 2026.5.28 / 2026.6.10）。这一侧只有 fake CLI 测试 + 上游 docs/dist 证据，没有真机跑过。
- `npm run build:check` 在本 PR 前后都失败（`src/index.ts`、`tests/smoke-test.ts`、`tests/unit/mcp-client-test.ts` 对 pinned `openclaw@2026.5.7` 的类型不匹配），属既有问题，未在本 PR 处理；新增的测试文件本身无类型错误。

### 初版在 ECS 上的实测记录（保留，作为门禁本身的一手证据）

```shell
# ALinux 4 ECS（8.210.218.100）：openclaw --version → OpenClaw 2026.9.2 (3928bad)
cd /root && rm -rf verify-am-fix && git clone https://github.com/alibaba/anolisa.git verify-am-fix
cd verify-am-fix && git checkout main && git apply /root/verify-build.patch
source /root/.cargo/env && bash scripts/rpm-build.sh agent-memory
# → [OK] agent-memory RPM built successfully / agent-memory-0.2.6-1.alnx4.x86_64.rpm，VERIFY_EXIT=0

rpm2cpio scripts/rpmbuild/RPMS/x86_64/agent-memory-0.2.6-1.alnx4.x86_64.rpm | cpio -idmv
bash usr/share/anolisa/adapters/agent-memory/openclaw/scripts/install.sh
# 修复前：Plugin "memory-anolisa" requires capability consent，exit 1
# 手动 openclaw plugins install <dir> --force --accept-capabilities → exit 0，"Installed plugin: memory-anolisa"
```

RPM 侧说明：本 PR 不 bump 版本，`install.sh` 的修复随下一次 agent-memory 发布（0.2.7）进 RPM。

## CI 接线（需要有 `workflow` scope 的人补一刀）

新增的测试目前由 `make test-openclaw-plugin` 提供入口，但 `test-agent-memory` job 只跑 cargo，所以 CI 还不会执行它。推送方用的 OAuth token 没有 `workflow` scope，改 `.github/workflows/ci.yaml` 会被 GitHub 拒（`refusing to allow an OAuth App to create or update workflow ... without 'workflow' scope`），因此这段 patch 交给有权限的人补：

```diff
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ test-agent-memory
       - name: Run tests
         run: |
           cd src/agent-memory
           cargo test --locked
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # scripts/install.sh talks to the openclaw CLI, which cargo cannot cover.
+      # Only the installer-flag gating test is wired in: the rest of the adapter
+      # suite has pre-existing failures (tests/unit/config-test.ts) and
+      # `npm run build:check` does not type-check against the pinned
+      # openclaw 2026.5.7 devDependency, so adopting them is a separate change.
+      - name: Test OpenClaw adapter install script
+        run: |
+          cd src/agent-memory
+          make test-openclaw-plugin
```

Co-Authored-By: Claude <noreply@anthropic.com>
