### PR TITLE
fix(agent-memory): pass --accept-capabilities to OpenClaw plugin install

### DIFF
--- a/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
+++ b/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
@@ -42,10 +42,14 @@ fi
 # subprocess communication and malicious shell usage, we bypass it
 # by default. Set AGENT_MEMORY_SAFE_INSTALL=1 to go through the
 # regular (blocking) safe-install path instead.
-INSTALL_ARGS=("--force" "--dangerously-force-unsafe-install")
+# OpenClaw 2026.9.2 introduced a capability-consent gate: a plugin whose
+# manifest declares capabilities (memory-anolisa declares 4 contract tools)
+# must pass --accept-capabilities explicitly, otherwise `plugins install`
+# refuses to start the CLI. Add it to both the fast and safe install paths.
+INSTALL_ARGS=("--force" "--dangerously-force-unsafe-install" "--accept-capabilities")
 if [ "${AGENT_MEMORY_SAFE_INSTALL:-0}" = "1" ]; then
     echo "[${COMPONENT}] AGENT_MEMORY_SAFE_INSTALL=1: using OpenClaw safe-install path (may block on child_process scan)." >&2
-    INSTALL_ARGS=("--force")
+    INSTALL_ARGS=("--force" "--accept-capabilities")
 fi
 
 env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install "$PLUGIN_DIR" \


### PR DESCRIPTION
## 问题

Fixes #3101

OpenClaw 2026.9.2 引入 capability-consent gate：声明了 capabilities 的插件（`memory-anolisa` 声明 4 个 contract 工具）安装时必须显式传 `--accept-capabilities`，否则 `openclaw plugins install` 拒绝启动 CLI。agent-memory 的 `install.sh` 只传 `--force --dangerously-force-unsafe-install`（后者在 2026.9.2 已是 deprecated no-op），导致插件安装失败、9 个 OpenClaw E2E 用例在 fixture setup 阶段全部 error。

## 修复

在 `install.sh` 的快装路径与 safe-install 路径都补上 `--accept-capabilities`。

```diff
-INSTALL_ARGS=("--force" "--dangerously-force-unsafe-install")
+# OpenClaw 2026.9.2 introduced a capability-consent gate: a plugin whose
+# manifest declares capabilities (memory-anolisa declares 4 contract tools)
+# must pass --accept-capabilities explicitly, otherwise `plugins install`
+# refuses to start the CLI. Add it to both the fast and safe install paths.
+INSTALL_ARGS=("--force" "--dangerously-force-unsafe-install" "--accept-capabilities")
 if [ "${AGENT_MEMORY_SAFE_INSTALL:-0}" = "1" ]; then
     echo "[${COMPONENT}] AGENT_MEMORY_SAFE_INSTALL=1: using OpenClaw safe-install path (may block on child_process scan)." >&2
-    INSTALL_ARGS=("--force")
+    INSTALL_ARGS=("--force" "--accept-capabilities")
 fi
```

## 验证

在 HK ECS（8.210.218.100，ALinux 4，OpenClaw 2026.9.2）上 fresh main + apply patch + 构建：

```shell
bash scripts/rpm-build.sh agent-memory
# → [OK] agent-memory RPM built successfully
# → agent-memory-0.2.6-1.alnx4.x86_64.rpm (4.5M)
```

- `VERIFY_EXIT=0`，`rpm2cpio` 解包确认 payload 内 `install.sh` 已含 `--accept-capabilities`（L49/L52）。
- 运行时验证：`openclaw plugins install <plugin_dir> --force --accept-capabilities` 返回 0，`openclaw plugins list` 显示 `memory-anolisa enabled`。

Co-Authored-By: zhangtaibo <zhangtaibo.ztb@alibaba-inc.com>