### PR TITLE
fix(agent-sec-core): deploy.sh pass --accept-capabilities for OpenClaw 2026.9.2 hook activation

### DIFF
--- a/src/agent-sec-core/openclaw-plugin/scripts/deploy.sh
+++ b/src/agent-sec-core/openclaw-plugin/scripts/deploy.sh
@@ -23,6 +23,7 @@ MIN_CONVERSATION_ACCESS_VERSION="2026.4.24"
 OPENCLAW_INSTALL_HELP=""
 OPENCLAW_INSTALL_SUPPORTS_UNSAFE=0
 OPENCLAW_INSTALL_REQUIRES_UNSAFE=0
+OPENCLAW_INSTALL_SUPPORTS_ACCEPT_CAPABILITIES=0
 OPENCLAW_INSPECT_HELP=""
 OPENCLAW_INSPECT_SUPPORTS_RUNTIME=0
 VERIFY_RUNTIME_TMPDIR=""
@@ -191,6 +192,9 @@ verify_openclaw_install_cli() {
     if [[ "$install_help_normalized" == *"--dangerously-force-unsafe-install"* ]]; then
         OPENCLAW_INSTALL_SUPPORTS_UNSAFE=1
     fi
+    if [[ "$install_help_normalized" == *"--accept-capabilities"* ]]; then
+        OPENCLAW_INSTALL_SUPPORTS_ACCEPT_CAPABILITIES=1
+    fi
 
     # Treat help output as the CLI contract: if the current OpenClaw installer
     # advertises the compatibility flag, pass it on the first install attempt
@@ -211,6 +215,11 @@ verify_openclaw_inspect_cli() {
 
 install_plugin() {
     local install_args=("plugins" "install" "$PLUGIN_DIR" "--force")
+
+    if [[ "$OPENCLAW_INSTALL_SUPPORTS_ACCEPT_CAPABILITIES" == "1" ]]; then
+        echo "安装策略: OpenClaw ${OPENCLAW_VERSION_DETECTED} 安装器暴露 --accept-capabilities，将接受插件声明的 capabilities（含 hook 激活）。"
+        install_args+=("--accept-capabilities")
+    fi
 
     if [[ "$OPENCLAW_INSTALL_REQUIRES_UNSAFE" == "1" ]]; then
         echo "安装策略: OpenClaw ${OPENCLAW_VERSION_DETECTED} 安装器暴露 legacy --dangerously-force-unsafe-install，首次安装将使用该兼容参数。"


### PR DESCRIPTION
## 问题

Fixes #3105

agent-sec-core 的 OpenClaw 插件部署脚本 `scripts/deploy.sh` 的 `install_plugin()` 只传 `--force`，未传 `--accept-capabilities`。OpenClaw 2026.9.2 引入 plugin capability-consent 门禁（`--accept-capabilities` 默认 false），未显式接受时插件声明的 `activation.onCapabilities: ["hook"]` 不会被激活，导致插件 enabled/loaded 但 `hookCount=0`、`hookNames=[]`，`before_dispatch`（pii-scan）、`before_tool_call`（code-scan/skill-ledger）等安全钩子全部静默失效。

## 修复

在 `deploy.sh` 中沿用既有 CLI-contract 探测模式，探测 `--accept-capabilities` 并在安装时传上：

```diff
--- a/src/agent-sec-core/openclaw-plugin/scripts/deploy.sh
+++ b/src/agent-sec-core/openclaw-plugin/scripts/deploy.sh
@@ -23,6 +23,7 @@ OPENCLAW_INSTALL_HELP=""
 OPENCLAW_INSTALL_SUPPORTS_UNSAFE=0
 OPENCLAW_INSTALL_REQUIRES_UNSAFE=0
+OPENCLAW_INSTALL_SUPPORTS_ACCEPT_CAPABILITIES=0
 OPENCLAW_INSPECT_HELP=""
@@ -191,6 +192,9 @@ verify_openclaw_install_cli() {
     if [[ "$install_help_normalized" == *"--dangerously-force-unsafe-install"* ]]; then
         OPENCLAW_INSTALL_SUPPORTS_UNSAFE=1
     fi
+    if [[ "$install_help_normalized" == *"--accept-capabilities"* ]]; then
+        OPENCLAW_INSTALL_SUPPORTS_ACCEPT_CAPABILITIES=1
+    fi
@@ -216,6 +220,11 @@ install_plugin() {
     local install_args=("plugins" "install" "$PLUGIN_DIR" "--force")
 
+    if [[ "$OPENCLAW_INSTALL_SUPPORTS_ACCEPT_CAPABILITIES" == "1" ]]; then
+        echo "安装策略: OpenClaw ${OPENCLAW_VERSION_DETECTED} 安装器暴露 --accept-capabilities，将接受插件声明的 capabilities（含 hook 激活）。"
+        install_args+=("--accept-capabilities")
+    fi
+
     if [[ "$OPENCLAW_INSTALL_REQUIRES_UNSAFE" == "1" ]]; then
```

## 验证

- `bash -n src/agent-sec-core/openclaw-plugin/scripts/deploy.sh` 通过（语法 OK）。
- patch 对 fresh `origin/main`（c6b8063b）`git apply --check` 干净通过。
- ECS（OpenClaw 2026.9.2 3928bad + agent-sec-core 0.12.0-1.alnx4）功能实测：`bash deploy.sh /opt/agent-sec/openclaw-plugin` 输出：
  - `安装策略: OpenClaw 2026.9.2 安装器暴露 --accept-capabilities，将接受插件声明的 capabilities（含 hook 激活）。`
  - `[plugins] [agent-sec] registered: pii-scan-user-input -> [before_dispatch, before_tool_call, after_tool_call, llm_output]`
  - `[plugins] [agent-sec] registered: skill-ledger -> [before_tool_call]`
  - `[plugins] [agent-sec] 5/5 capabilities active`
  - 对照修复前：`openclaw plugins list --json` 显示 agent-sec `hookCount=0`、`hookNames=[]`。

Co-Authored-By: Claude <noreply@anthropic.com>