### PR TITLE
fix(sight): match OpenClaw gateway launched with --max-old-space-size V8 flag

### DIFF
--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -82,6 +82,7 @@
       {"rule": ["*openclaw-gatewa*"], "agent_name": "OpenClaw"},
       {"rule": ["node*", "*openclaw*"], "agent_name": "OpenClaw"},
       {"rule": ["*node*", "*openclaw*", "gatewa*"], "agent_name": "OpenClaw"},
+      {"rule": ["*node*", "*", "*openclaw*", "gatewa*"], "agent_name": "OpenClaw"},
       {"rule": ["openclaw"], "agent_name": "OpenClaw"},
       {"rule": ["claude*"], "agent_name": "Claude"},
       {"rule": ["*/claude*"], "agent_name": "Claude"},

--- a/src/agentsight/src/discovery/matcher.rs
+++ b/src/agentsight/src/discovery/matcher.rs
@@ -438,4 +438,26 @@ mod tests {
             Some("QwenCode")
         );
     }
+
+    #[test]
+    fn test_default_rules_capture_openclaw_gateway_with_node_heap_flag() {
+        // OpenClaw 2026.9.2 launches the gateway via systemd --user with a
+        // V8 heap flag, so argv[0] is the full node path and "openclaw" sits
+        // at argv[2] (not argv[1]) — the flag position must be wildcarded.
+        assert_eq!(
+            match_default_rules(
+                &[
+                    "/usr/bin/node",
+                    "--max-old-space-size=7722",
+                    "/usr/local/lib/node_modules/openclaw/dist/index.js",
+                    "gateway",
+                    "--port",
+                    "18789",
+                ],
+                ""
+            )
+            .as_deref(),
+            Some("OpenClaw")
+        );
+    }
 }


### PR DESCRIPTION
## 问题

Fixes #3104

Nightly 回归 `tests/test_config_file_overrides.py::TestConfigReplaceSemantics::test_discover_falls_back_to_builtin_rules_with_hint` 失败：当 `/etc/agentsight/config.json` 损坏触发 built-in fallback 后，`agentsight discover` 报「未发现正在运行的 AI Agent」(0 found)，但 ECS 上 openclaw gateway (`node --max-old-space-size=7722 .../openclaw/dist/index.js gateway --port 18789`) 确实在运行。

根因：`src/agentsight/agentsight.json` 默认 OpenClaw 规则是 positional glob，假设 `argv[0]=node*` 前缀且 `argv[1]=*openclaw*`。OpenClaw 2026.9.2 经 systemd --user ExecStart 启动时 `argv[0]=/usr/bin/node`（全路径），且第二个参数是 V8 heap flag `--max-old-space-size=7722`，`openclaw` 落在 `argv[2]`，4 条默认规则全部失配 → discover/trace 发现 0 个 OpenClaw。

## 修复

新增一条与既有 QwenCode 规则 `["*node*", "*", "*qwen*"]` 同构的 OpenClaw 规则，通配掉 argv[1] 的 V8 flag 位置：

```diff
+      {"rule": ["*node*", "*", "*openclaw*", "gatewa*"], "agent_name": "OpenClaw"},
```

并在 `matcher.rs` 补一个针对该 gateway 启动形态的默认规则单元测试。

## 验证

已在保留 ECS 上 fresh clone main + `git apply` 该 patch + `bash scripts/rpm-build.sh agentsight`，构建绿：

- `VERIFY_EXIT=0`，产出 `agentsight-0.12.0-1.alnx4.x86_64.rpm`
- build log 含 `[OK] agentsight RPM built successfully`
- ECS 上损坏 config 后 `agentsight discover` 由 0 found 变为命中 OpenClaw

Co-Authored-By: Claude <noreply@anthropic.com>