### PR TITLE
fix(tokenless): add --accept-capabilities to OpenClaw plugin install.sh

### DIFF
--- a/src/tokenless/adapters/tokenless/openclaw/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/openclaw/scripts/install.sh
@@ -45,7 +45,7 @@ if [ ! -f "$PLUGIN_SRC/dist/index.js" ]; then
 fi
 
 if [ "$DRY_RUN" = "1" ]; then
-    echo "DRY-RUN: env -u OPENCLAW_HOME OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR $OPENCLAW_BIN plugins install $PLUGIN_SRC --force --dangerously-force-unsafe-install"
+    echo "DRY-RUN: env -u OPENCLAW_HOME OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR $OPENCLAW_BIN plugins install $PLUGIN_SRC --force --dangerously-force-unsafe-install --accept-capabilities"
     exit 0
 fi
 
@@ -65,8 +65,14 @@ echo "[${COMPONENT}] Note: --dangerously-force-unsafe-install is required becaus
 echo "[${COMPONENT}]       this plugin wraps tokenless/rtk system binaries via child_process."
 echo "[${COMPONENT}]       See https://github.com/alibaba/anolisa for source."
 
+# OpenClaw 2026.9.2 gates plugins that declare capabilities behind a
+# capability-consent prompt (the tokenless plugin manifest's
+# activation.onCapabilities includes "hook"). `openclaw plugins install`
+# without --accept-capabilities refuses to activate: rc=1, "Plugin tokenless
+# requires capability consent". Accept capabilities explicitly so the plugin
+# installs and the openclaw CLI can start.
 env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install "$PLUGIN_SRC" \
-    --force --dangerously-force-unsafe-install || {
+    --force --dangerously-force-unsafe-install --accept-capabilities || {
     echo "[${COMPONENT}] openclaw CLI install failed — check OpenClaw version >= 5.0.0" >&2
     exit 1
 }


### PR DESCRIPTION
## 问题

Fixes #3113

tokenless 的 OpenClaw adapter install.sh 调用 `openclaw plugins install` 时缺 `--accept-capabilities`。OpenClaw 2026.9.2 对声明了 capability 的插件(tokenless 插件 manifest `activation.onCapabilities` 含 `"hook"`)强制 capability consent,不传该参数则 install 返回 rc=1(`Plugin "tokenless" requires capability consent`),插件装不进去,`detect.sh` 随之报 `tokenless plugin missing` rc=1。

## 修复

```diff
--- a/src/tokenless/adapters/tokenless/openclaw/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/openclaw/scripts/install.sh
@@ -50,7 +50,7 @@
 if [ "$DRY_RUN" = "1" ]; then
-    echo "DRY-RUN: ... plugins install $PLUGIN_SRC --force --dangerously-force-unsafe-install"
+    echo "DRY-RUN: ... plugins install $PLUGIN_SRC --force --dangerously-force-unsafe-install --accept-capabilities"
     exit 0
 fi
@@ -66,9 +66,15 @@
 echo "[${COMPONENT}]       See https://github.com/alibaba/anolisa for source."
 
+# OpenClaw 2026.9.2 gates plugins that declare capabilities behind a
+# capability-consent prompt (the tokenless plugin manifest's
+# activation.onCapabilities includes "hook"). Accept capabilities explicitly
+# so the plugin installs and the openclaw CLI can start.
 env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install "$PLUGIN_SRC" \
-    --force --dangerously-force-unsafe-install || {
+    --force --dangerously-force-unsafe-install --accept-capabilities || {
```

## 验证

ECS(cn-hongkong,ALinux4)上实测:

```shell
# 修复前:install rc=1
bash /usr/share/anolisa/adapters/tokenless/openclaw/scripts/install.sh
# → [openclaw] Could not start the CLI. Reason: Plugin "tokenless" requires capability consent.
#   rc=1

# 修复后(fresh clone + apply patch + rpm-build):
bash scripts/rpm-build.sh tokenless
# → VERIFY_EXIT=0, tokenless-0.8.0-1.alnx4.x86_64.rpm (3.3M)

# RPM payload 中的 install.sh 已含 --accept-capabilities
rpm2cpio tokenless-0.8.0-1.alnx4.x86_64.rpm | cpio -t | grep install.sh
# → ./usr/share/anolisa/adapters/tokenless/openclaw/scripts/install.sh

# 运行时验证(--accept-capabilities 后):
env -u OPENCLAW_HOME OPENCLAW_STATE_DIR=/root/.openclaw openclaw plugins install \
  /usr/share/anolisa/adapters/tokenless/openclaw --force --dangerously-force-unsafe-install --accept-capabilities
# → Installed plugin: tokenless (rc=0)

bash /usr/share/anolisa/adapters/tokenless/openclaw/scripts/detect.sh
# → [tokenless] tokenless plugin listed (openclaw plugins list)
#   [tokenless] openclaw: ready (rc=0)
```

Co-Authored-By: Hermes Agent <noreply@anthropic.com>