### PR TITLE
fix(ws-ckpt): add --accept-capabilities to OpenClaw plugin install

### DIFF
--- a/src/ws-ckpt/scripts/openclaw/install-openclaw.sh
+++ b/src/ws-ckpt/scripts/openclaw/install-openclaw.sh
@@ -22,11 +22,15 @@ fi
 # 2. Try plugin install (preferred).
 if PLUGIN_SRC=$(find_plugin_src openclaw); then
     if [ "$DRY_RUN" = "1" ]; then
-        echo "DRY-RUN: env -u OPENCLAW_HOME OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR $OPENCLAW_BIN plugins install $PLUGIN_SRC --force"
+        echo "DRY-RUN: env -u OPENCLAW_HOME OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR $OPENCLAW_BIN plugins install $PLUGIN_SRC --force --accept-capabilities"
         echo "DRY-RUN: env -u OPENCLAW_HOME OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR $OPENCLAW_BIN plugins enable ws-ckpt"
         exit 0
     fi
-    env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install "$PLUGIN_SRC" --force
+    # OpenClaw 2026.9.2 gates plugins that declare capabilities (kind "tool" with
+    # activation.onStartup) behind a capability-consent prompt. Installing without
+    # --accept-capabilities fails rc=1: 'Plugin "ws-ckpt" requires capability consent'.
+    # Accept capabilities explicitly so the plugin installs and the CLI can start.
+    env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install "$PLUGIN_SRC" --force --accept-capabilities
     env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins enable ws-ckpt 2>/dev/null || true
     echo "openclaw ws-ckpt plugin installed and enabled successfully (from $PLUGIN_SRC)"
     exit 0


### PR DESCRIPTION
## 问题

Fixes #3116

ws-ckpt 的 OpenClaw adapter 安装脚本 `src/ws-ckpt/scripts/openclaw/install-openclaw.sh` 调用 `openclaw plugins install` 时缺 `--accept-capabilities`。OpenClaw 2026.9.2 对声明了 capability 的插件（ws-ckpt 插件 manifest `openclaw.plugin.json` 为 `"kind": "tool"` + `"activation": {"onStartup": true}`）强制 capability consent，不传该参数则 install 返回 rc=1（`Plugin "ws-ckpt" requires capability consent`），插件装不进去，`ws-ckpt plugin install --runtime openclaw` 随之 `Error: install failed for Openclaw (exit 1)`。

与同根因 sibling 一致：agent-memory #3099/PR #3100、tokenless #3113/PR #3114、agent-sec-core #3105/PR #3106。

## 修复

```diff
--- a/src/ws-ckpt/scripts/openclaw/install-openclaw.sh
+++ b/src/ws-ckpt/scripts/openclaw/install-openclaw.sh
@@ -22,11 +22,15 @@ fi
     if [ "$DRY_RUN" = "1" ]; then
-        echo "DRY-RUN: ... plugins install $PLUGIN_SRC --force"
+        echo "DRY-RUN: ... plugins install $PLUGIN_SRC --force --accept-capabilities"
         echo "DRY-RUN: ... plugins enable ws-ckpt"
         exit 0
     fi
-    env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install "$PLUGIN_SRC" --force
+    # OpenClaw 2026.9.2 gates plugins that declare capabilities (kind "tool" with
+    # activation.onStartup) behind a capability-consent prompt. Installing without
+    # --accept-capabilities fails rc=1: 'Plugin "ws-ckpt" requires capability consent'.
+    # Accept capabilities explicitly so the plugin installs and the CLI can start.
+    env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install "$PLUGIN_SRC" --force --accept-capabilities
```

## 验证

- ECS 8.210.218.100 复现：`ws-ckpt plugin install --runtime openclaw` → `Plugin "ws-ckpt" requires capability consent` + `Error: install failed for Openclaw (exit 1)`（REPRO_EXIT=1）。
- 对照组：`openclaw plugins install /usr/share/anolisa/runtime/ws-ckpt/plugins/openclaw --force --accept-capabilities` → rc=0 `Installed plugin: ws-ckpt`，`/root/.openclaw/extensions/ws-ckpt` 落地。
- ECS verify-build：fresh clone main + `git apply` + `cd src/ws-ckpt && sh build-rpm.sh` → `VERIFY_EXIT=0`，产出 `ws-ckpt-0.4.5-1.alnx4.x86_64.rpm`。