### PR TITLE
feat(anolisa): recover untracked plugin cleanup

### DIFF
--- a/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
@@ -679,6 +679,32 @@ impl FrameworkDriver for OpenClawDriver {
                 messages.push(format!(
                     "openclaw plugin '{plugin_id}' was already unregistered"
                 ));
+            } else if uninstall_reports_untracked_plugin(&output, &plugin_id) {
+                // Missing package ownership does not prove that the plugin is
+                // gone. Verify against the same instance as the uninstall.
+                let mut cmd = build_list_cmd(&home, ctx.user_home.as_deref());
+                cmd.args.push("--json".to_string());
+                let verification = ctx.ops.run_framework_cli_json(cmd);
+                if !verification
+                    .as_ref()
+                    .is_ok_and(|output| json_list_confirms_plugin_absent(output, &plugin_id))
+                {
+                    let reason = match verification {
+                        Ok(output) => inspect_diagnostics(&output),
+                        Err(err) => err.to_string(),
+                    };
+                    return Ok(DisableReport {
+                        cleanup_complete: false,
+                        messages: vec![format!(
+                            "openclaw plugin '{plugin_id}' has no tracked package install; \
+                             `plugins list --json` could not confirm absence: {reason}; \
+                             repair the OpenClaw plugin registry and retry disable"
+                        )],
+                    });
+                }
+                messages.push(format!(
+                    "openclaw plugin '{plugin_id}' is absent from `plugins list --json`"
+                ));
             } else {
                 return Ok(DisableReport {
                     cleanup_complete: false,
@@ -2817,6 +2843,56 @@ fn uninstall_reports_missing_plugin(output: &CliOutput, plugin_id: &str) -> bool
     matches!(lines.next(), Some(line) if line == expected) && lines.next().is_none()
 }
 
+fn uninstall_reports_untracked_plugin(output: &CliOutput, plugin_id: &str) -> bool {
+    if output.timed_out {
+        return false;
+    }
+    let expected = format!(
+        "plugin \"{}\" is not associated with a tracked package install.",
+        plugin_id.to_ascii_lowercase()
+    );
+    let combined = format!(
+        "{}\n{}",
+        strip_ansi(&output.stdout),
+        strip_ansi(&output.stderr)
+    );
+    let mut lines = combined
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_ascii_lowercase);
+    matches!(lines.next(), Some(line) if line == expected || line.starts_with(&format!("{expected} ")))
+        && lines.next().is_none()
+}
+
+fn json_list_confirms_plugin_absent(output: &CliOutput, plugin_id: &str) -> bool {
+    if !output.success() || !output.stderr.trim().is_empty() {
+        return false;
+    }
+    // A text/table miss or a partial discovery report cannot authorize
+    // deleting cleanup ownership. Require JSON IDs and clean diagnostics.
+    let Ok(report) = serde_json::from_str::<serde_json::Value>(&output.stdout) else {
+        return false;
+    };
+    let Some(plugins) = report.get("plugins").and_then(serde_json::Value::as_array) else {
+        return false;
+    };
+    let mut diagnostics = vec![report.get("diagnostics")];
+    if let Some(registry) = report.get("registry") {
+        diagnostics.push(registry.get("diagnostics"));
+    }
+    plugins.iter().all(|plugin| {
+        plugin
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|id| !id.is_empty() && id != plugin_id)
+    }) && diagnostics.into_iter().all(|value| {
+        value
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|items| items.iter().all(|item| item["level"] == "info"))
+    })
+}
+
 /// Extract skill names from a claim's `skill_resources` by parsing the
 /// resource ids. Each id has the form `openclaw_skill_<name>`, and we
 /// extract `<name>` as the directory name under `<home>/skills/`.
@@ -3017,6 +3093,91 @@ mod tests {
             ..missing
         };
         assert!(!uninstall_reports_missing_plugin(&timed_out, "tokenless"));
+    }
+
+    #[test]
+    fn untracked_uninstall_requires_exact_plugin_and_completed_output() {
+        let output = CliOutput {
+            status: Some(1),
+            timed_out: false,
+            stdout: String::new(),
+            stderr: "\x1b[31mPlugin \"tokenless\" is not associated with a tracked package install.\x1b[0m\n".to_string(),
+        };
+        assert!(uninstall_reports_untracked_plugin(&output, "tokenless"));
+        assert!(!uninstall_reports_missing_plugin(&output, "tokenless"));
+        assert!(!uninstall_reports_untracked_plugin(&output, "token"));
+        for stderr in [
+            "Plugin \"tokenless-other\" is not associated with a tracked package install.",
+            "Plugin \"tokenless\" is not associated with a tracked package installer.",
+            "Plugin \"tokenless\" is not associated with a tracked package install.\nUnable to update registry",
+        ] {
+            assert!(!uninstall_reports_untracked_plugin(
+                &CliOutput {
+                    stderr: stderr.to_string(),
+                    ..output.clone()
+                },
+                "tokenless"
+            ));
+        }
+        assert!(!uninstall_reports_untracked_plugin(
+            &CliOutput {
+                timed_out: true,
+                ..output
+            },
+            "tokenless"
+        ));
+    }
+
+    #[test]
+    fn json_absence_requires_success_and_usable_diagnostics() {
+        let output = CliOutput {
+            status: Some(0),
+            timed_out: false,
+            stdout:
+                r#"{"plugins":[],"diagnostics":[{"level":"info"}],"registry":{"diagnostics":[]}}"#
+                    .to_string(),
+            stderr: String::new(),
+        };
+        assert!(json_list_confirms_plugin_absent(&output, "tokenless"));
+        for failed in [
+            CliOutput {
+                timed_out: true,
+                ..output.clone()
+            },
+            CliOutput {
+                status: Some(1),
+                ..output.clone()
+            },
+            CliOutput {
+                status: None,
+                ..output.clone()
+            },
+            CliOutput {
+                stderr: "discovery failed".to_string(),
+                ..output.clone()
+            },
+        ] {
+            assert!(!json_list_confirms_plugin_absent(&failed, "tokenless"));
+        }
+        for stdout in [
+            r#"{"plugins":[]}"#,
+            r#"{"plugins":[],"diagnostics":null}"#,
+            r#"{"plugins":[],"diagnostics":[{}]}"#,
+            r#"{"plugins":[],"diagnostics":[],"registry":{}}"#,
+            r#"{"plugins":[{"id":""}],"diagnostics":[]}"#,
+            r#"{"plugins":[{"id":"tokenless","status":"error"}],"diagnostics":[]}"#,
+        ] {
+            assert!(
+                !json_list_confirms_plugin_absent(
+                    &CliOutput {
+                        stdout: stdout.to_string(),
+                        ..output.clone()
+                    },
+                    "tokenless"
+                ),
+                "{stdout}"
+            );
+        }
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
@@ -255,6 +255,7 @@ const OWNED_ENV: &[&str] = &[
     "FAKE_OC_INSPECT_DIAG",
     "FAKE_OC_ARGV_LOG",
     "FAKE_OC_PROBE_FAIL",
+    "FAKE_OC_LIST_JSON",
     "FAKE_OC_VERSION_PREAMBLE",
     "FAKE_OC_CONFIG_FAIL_KEY",
     "FAKE_OC_CONFIG_FAIL_AFTER_KEY",
@@ -412,6 +413,9 @@ fn stage() -> World {
 ///   `loaded`).
 /// - `plugins uninstall <id> ...` removes the marker; `plugins list` prints
 ///   markers; `config set` echoes.
+/// - `FAKE_OPENCLAW_FAIL=untracked` refuses uninstall without changing the
+///   registry; `FAKE_OC_LIST_JSON` overrides JSON listing, and
+///   `FAKE_OC_PROBE_FAIL=list` makes listing fail.
 /// - `FAKE_OPENCLAW_FAIL=install|install_after_register|uninstall` forces that
 ///   verb to exit non-zero; `FAKE_OC_CONFIG_FAIL_KEY` fails `config set`
 ///   before mutation, while `FAKE_OC_CONFIG_FAIL_AFTER_KEY` fails after
@@ -495,12 +499,29 @@ case "$action" in
   uninstall)
     reg="$OPENCLAW_STATE_DIR/registry"; mkdir -p "$reg" 2>/dev/null
     if [ "${FAKE_OPENCLAW_FAIL:-}" = "uninstall" ]; then echo "boom-uninstall" >&2; exit 8; fi
+    if [ "${FAKE_OPENCLAW_FAIL:-}" = "untracked" ]; then
+      echo "Plugin \"$arg3\" is not associated with a tracked package install. Refresh the plugin registry, then reinstall the package or run openclaw doctor before retrying." >&2
+      exit 1
+    fi
     if [ ! -e "$reg/$arg3" ]; then echo "Plugin not found: $arg3" >&2; exit 1; fi
     rm -f "$reg/$arg3"
     echo "uninstalled $arg3"
     ;;
   list)
     reg="$OPENCLAW_STATE_DIR/registry"
+    if [ "${FAKE_OC_PROBE_FAIL:-}" = "list" ]; then echo "boom-list" >&2; exit 6; fi
+    if [ "$arg3" = "--json" ]; then
+      if [ "${FAKE_OC_LIST_JSON+x}" = x ]; then printf '%s\n' "$FAKE_OC_LIST_JSON"; exit 0; fi
+      printf '{"plugins":['
+      sep=""
+      for plugin in "$reg"/*; do
+        [ -f "$plugin" ] || continue
+        printf '%s{"id":"%s"}' "$sep" "${plugin##*/}"
+        sep=,
+      done
+      printf '],"diagnostics":[]}\n'
+      exit 0
+    fi
     ls "$reg" 2>/dev/null || true
     ;;
   *)
@@ -1501,6 +1522,171 @@ fn disable_keeps_receipt_when_uninstall_fails() {
         .find_adapter_claim(COMPONENT, FRAMEWORK)
         .expect("receipt kept");
     assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+}
+
+#[test]
+fn disable_untracked_plugin_requires_verified_absence_in_recorded_state_dir() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    configure_plugin_with_skill(&world, "sec-audit");
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+    // Include the persisted anchor used by externally rooted receipts.
+    let mut state = world.load_state();
+    state.upsert_adapter_trust_root(COMPONENT, FRAMEWORK, world.resource_root.clone());
+    state
+        .save(&world.layout.state_dir.join("installed.toml"))
+        .expect("persist trust anchor");
+    let skill = world.openclaw_home.join("skills/sec-audit");
+    guard.set("FAKE_OPENCLAW_FAIL", "untracked");
+
+    // An empty active instance must not hide the recorded instance's plugin.
+    let active_home = world._root.path().join("other-openclaw");
+    guard.set("OPENCLAW_STATE_DIR", &active_home);
+    let disabled = manager
+        .disable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("disable untracked but registered plugin");
+    assert!(!disabled.report.cleanup_complete);
+    assert!(!disabled.claim_removed);
+    assert!(world.registry_marker_exists());
+    assert!(skill.is_dir());
+
+    std::fs::remove_file(world.openclaw_home.join("registry").join(COMPONENT))
+        .expect("remove plugin out of band");
+    guard.set("FAKE_OC_PROBE_FAIL", "list");
+    let disabled = manager
+        .disable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("failed list probe");
+    assert!(!disabled.report.cleanup_complete);
+    assert!(!disabled.claim_removed);
+    guard.unset("FAKE_OC_PROBE_FAIL");
+
+    for json in [
+        "",
+        "No plugins found",
+        "{}",
+        r#"{"plugins":[{}],"diagnostics":[]}"#,
+        r#"{"plugins":[{"id":"tokenless","status":"disabled"}],"diagnostics":[]}"#,
+        r#"{"plugins":[],"diagnostics":[{"level":"error","message":"discovery failed"}]}"#,
+        r#"{"plugins":[],"diagnostics":[],"registry":{"diagnostics":[{"level":"warn","message":"stale registry"}]}}"#,
+    ] {
+        guard.set("FAKE_OC_LIST_JSON", json);
+        let disabled = manager
+            .disable(COMPONENT, Some(FRAMEWORK), false)
+            .expect("uncertain absence keeps receipt");
+        assert!(!disabled.report.cleanup_complete, "list output: {json}");
+        assert!(!disabled.claim_removed, "list output: {json}");
+        let state = world.load_state();
+        assert_eq!(
+            state
+                .find_adapter_claim(COMPONENT, FRAMEWORK)
+                .unwrap()
+                .status,
+            ClaimStatus::CleanupFailed
+        );
+        assert!(
+            state
+                .find_adapter_trust_root(COMPONENT, FRAMEWORK)
+                .is_some()
+        );
+        assert!(skill.is_dir());
+    }
+    guard.unset("FAKE_OC_LIST_JSON");
+
+    // A similar ID in the recorded instance and the exact ID in another
+    // instance must not prevent recovery of this receipt.
+    std::fs::write(world.openclaw_home.join("registry/tokenless-other"), b"")
+        .expect("other plugin");
+    std::fs::create_dir_all(active_home.join("registry")).expect("active registry");
+    let active_marker = active_home.join("registry").join(COMPONENT);
+    std::fs::write(&active_marker, b"").expect("active instance plugin");
+
+    let argv_log = world.argv_log();
+    guard.set("FAKE_OC_ARGV_LOG", &argv_log);
+    let preview = manager
+        .disable(COMPONENT, Some(FRAMEWORK), true)
+        .expect("preview recovery");
+    assert!(!preview.claim_removed);
+    assert!(!argv_log.exists(), "dry-run must not invoke the CLI");
+    assert!(world.has_claim());
+
+    // An unexpected file at a managed directory makes remove_tree fail.
+    std::fs::remove_dir_all(&skill).expect("replace skill directory");
+    std::fs::write(&skill, b"unexpected file").expect("block directory cleanup");
+    let disabled = manager
+        .disable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("skill cleanup failure");
+    assert!(!disabled.report.cleanup_complete);
+    assert!(!disabled.claim_removed);
+    assert!(
+        disabled
+            .report
+            .messages
+            .iter()
+            .any(|message| message.contains("failed to remove skill dir"))
+    );
+    std::fs::remove_file(&skill).expect("repair skill path");
+    std::fs::create_dir(&skill).expect("restore skill directory");
+
+    let disabled = manager
+        .disable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("recover missing plugin");
+    assert!(disabled.report.cleanup_complete, "{:?}", disabled.report);
+    assert!(disabled.claim_removed);
+    assert!(!world.has_claim());
+    assert!(
+        world
+            .load_state()
+            .find_adapter_trust_root(COMPONENT, FRAMEWORK)
+            .is_none()
+    );
+    assert!(!skill.exists());
+    assert!(active_marker.exists());
+    assert!(
+        manager
+            .disable(COMPONENT, Some(FRAMEWORK), false)
+            .expect("repeated disable")
+            .report
+            .cleanup_complete
+    );
+}
+
+#[test]
+fn disable_untracked_plugin_verifies_large_json_inventory() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+    guard.set("FAKE_OPENCLAW_FAIL", "untracked");
+
+    for registered in [true, false] {
+        let mut plugins = vec![serde_json::json!({
+            "id": "other-plugin",
+            "description": "x".repeat(80 * 1024),
+        })];
+        if registered {
+            plugins.push(serde_json::json!({"id": COMPONENT}));
+        } else {
+            std::fs::remove_file(world.openclaw_home.join("registry").join(COMPONENT))
+                .expect("remove plugin out of band");
+        }
+        let json = serde_json::json!({"plugins": plugins, "diagnostics": []}).to_string();
+        assert!(json.len() > 64 * 1024);
+        guard.set("FAKE_OC_LIST_JSON", json);
+
+        let disabled = manager
+            .disable(COMPONENT, Some(FRAMEWORK), false)
+            .expect("disable with a large inventory");
+        assert_eq!(disabled.report.cleanup_complete, !registered);
+        assert_eq!(disabled.claim_removed, !registered);
+        assert_eq!(world.has_claim(), registered);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Why

`anolisa adapter disable tokenless openclaw` cannot clear its cleanup receipt when OpenClaw reports an untracked package even though the plugin is already absent. The receipt then blocks component uninstall, forget, and changing the installation backend. An untracked-package error can also occur while the plugin remains registered, so that error alone cannot authorize dropping cleanup ownership.

## What changed

Recognize the exact plugin's untracked-package error and verify absence through `openclaw plugins list --json`, using the state directory recorded in the receipt and the existing structured-output runner with its 4 MiB stdout limit. Continue the existing skill cleanup only after a successful, usable inventory confirms the exact plugin ID is absent; retain the receipt for registered plugins, failed or uncertain probes, and incomplete skill cleanup. Reuse the existing manager state transitions and fake CLI tests without adding dependencies or changing receipt schemas.

## Related issue

Closes #3108

Related: #3109

## User / Agent impact

After upgrading ANOLISA, retry the existing `adapter disable` command to recover an already-absent plugin and unblock downstream lifecycle commands. No configuration migration or extra package is required; cleanup failures still preserve retry ownership. The change adds a read-only verification probe to the untracked-error path and does not interrupt other OpenClaw instances.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The existing disable command now recovers a previously stuck receipt. Receipt deletion remains conditional on confirmed cleanup: the new probe uses the receipt's state directory, requires a complete JSON response with valid plugin IDs and diagnostic arrays, and rejects timeouts, nonzero exits, stderr diagnostics, and non-informational discovery/registry diagnostics. Hosts without usable JSON listing, including inventories exceeding the 4 MiB capture limit, retain the receipt for repair and retry. The exact `plugin not found` behavior, lifecycle guards, configuration persistence, and dry-run behavior remain unchanged.

## Validation

Linux aarch64, Rust 1.93.1, isolated source tree containing the two changed files:

- `cargo +1.93.1 fmt --all -- --check`
- `cargo +1.93.1 check --locked`
- `cargo +1.93.1 clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.93.1 test --workspace --locked` — 2,463 passed, 0 failed, 1 ignored
- `cargo +1.93.1 doc --workspace --no-deps --locked`

macOS arm64, Rust 1.93.1:

- `cargo test -p anolisa-core --lib --locked adapter::openclaw` — 40 passed
- `cargo test -p anolisa-core --locked --test adapter_manager` — 82 passed
- `cargo check --locked` and formatting passed.
- Strict Clippy encounters existing unused `CapabilityProbeError::Read` / `Malformed` variants in unchanged `capability.rs`.
- The full workspace test run encounters the unchanged Linux-capability rollback test `raw_update_rollback_hydrates_legacy_required_capability` failing to read its central log on macOS. The same failure was reproduced from a pristine `c6b8063b8` source archive with a separate build directory.

The new manager regression fails on the original implementation and passes with this change. It covers large inventories above 64 KiB with the target present or absent, retained registrations, exact IDs, switched state directories, failed and malformed listing, discovery/registry diagnostics, persisted trust anchors, skill cleanup failure, dry-run, successful recovery, and repeated disable. Unit coverage also rejects timed-out or interrupted output and misleading untracked error text.

## Documentation and rollback

No command syntax, flags, configuration, or receipt schema changed; no user-guide changes are needed. Changelog aggregation remains with the release PR. Revert this commit to restore the previous fail-closed untracked behavior; no state migration is needed.

### Ship Note

- Changed: recover missing OpenClaw plugins without losing cleanup ownership for plugins still registered.
- Known limitations: uncertain or diagnostic-bearing inventories retain the receipt for repair and retry.
- Not covered: live OpenClaw/RPM recovery on ALinux; coverage uses a deterministic fake OpenClaw CLI.
- Verification: Linux workspace checks above passed; focused macOS tests passed, with unrelated platform failures recorded above.

