### PR TITLE
feat(anolisa): accept OpenClaw capabilities

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/en/token-saving/tokenless/framework-integration.md
@@ -209,6 +209,11 @@ DeepSeek Harness is profile-scoped and therefore requires at least one
 generic command without a profile is rejected. A later enable or re-enable
 must repeat every profile that should remain registered.
 
+Running OpenClaw adapter enable or the tokenless OpenClaw `install.sh` accepts
+the plugin's declared capabilities. Both entry points pass
+`--accept-capabilities` only when `plugins install --help` advertises that
+exact option, so older hosts keep working.
+
 For OpenClaw, anolisa first attempts a normal install and does not add an unsafe-install bypass by default. If OpenClaw rejects the plugin on its safety scan, read the reported findings. Only after accepting them, retry explicitly:
 
 ```bash

--- a/docs/user-guide/en/user-entrypoint/anolisa-cli.md
+++ b/docs/user-guide/en/user-entrypoint/anolisa-cli.md
@@ -177,6 +177,12 @@ anolisa adapter disable <component> [framework]
 anolisa adapter status [component]
 ```
 
+For OpenClaw plugins, executing `adapter enable` accepts the plugin's declared
+capabilities. ANOLISA adds `--accept-capabilities` only when the installer's
+help advertises it, including in the dry-run plan. Capability consent does
+not authorize `--allow-unsafe-plugin-install`; a consent rejection is reported
+separately from a plugin-safety rejection.
+
 ### logs and bug reports
 
 Inspect component logs or generate a diagnostic bundle:

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -190,6 +190,10 @@ DeepSeek Harness 按 profile 管理，因此必须至少提供一个 `--profile`
 `dsh --profile <profile>` 使用的名称一致，不带 profile 的通用命令会被拒绝。
 后续 enable 或 re-enable 必须再次列出需要保留的全部 profile。
 
+执行 OpenClaw adapter enable 或 tokenless 的 OpenClaw `install.sh` 即同意
+插件声明的能力。两个入口仅在 `plugins install --help` 列出完整的
+`--accept-capabilities` 参数时传递它，以兼容旧版宿主。
+
 对于 OpenClaw，anolisa 会先尝试普通安装，默认不会加入 unsafe-install 覆盖参数。如果 OpenClaw 的安全扫描拒绝此 Plugin，应先阅读其报告；确认接受风险后，才显式重试：
 
 ```bash

--- a/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
+++ b/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
@@ -167,6 +167,11 @@ anolisa adapter disable <component> [framework]
 anolisa adapter status [component]
 ```
 
+对于 OpenClaw 插件，执行 `adapter enable` 即同意插件声明的能力。ANOLISA
+仅在安装器 help 列出 `--accept-capabilities` 时添加该参数，dry-run 计划也
+遵循相同规则。Capability consent 不授予 `--allow-unsafe-plugin-install`
+权限；同意被拒绝时会单独诊断，不归为插件安全扫描拒绝。
+
 ### logs 与 bug report
 
 查看组件日志或生成诊断包：

--- a/src/anolisa/README.md
+++ b/src/anolisa/README.md
@@ -52,6 +52,10 @@ anolisa update all
 | `env` | Show environment detection results |
 | `bug` | Generate a bug report |
 
+Running `anolisa adapter enable <component> openclaw` accepts the plugin's
+declared capabilities when the host supports capability consent. This does
+not authorize an unsafe-install bypass.
+
 ## Install Modes
 
 | Mode | Prefix | When |

--- a/src/anolisa/README_zh.md
+++ b/src/anolisa/README_zh.md
@@ -52,6 +52,10 @@ anolisa update all
 | `env` | 显示环境检测结果 |
 | `bug` | 生成 bug 报告 |
 
+执行 `anolisa adapter enable <component> openclaw` 即同意插件声明的能力，
+CLI 会在宿主支持 capability consent 时传递对应参数。此操作不授予
+unsafe-install 覆盖权限。
+
 ## 安装模式
 
 | 模式 | 前缀 | 使用场景 |

--- a/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
@@ -152,9 +152,11 @@ pub enum PreparedEnable {
     #[default]
     None,
     /// OpenClaw install/verify capabilities resolved before the first
-    /// mutation. `apply_enable` uses these to decide the unsafe-retry hint and
-    /// the runtime-inspect form without a second probe.
+    /// mutation. `apply_enable` uses these to choose consent arguments, the
+    /// unsafe-retry hint, and the runtime-inspect form without a second probe.
     OpenClaw {
+        /// The host's installer supports accepting the plugin's declared capabilities.
+        supports_accept_capabilities: bool,
         /// The host's `plugins install --help` exposes the unsafe flag.
         supports_unsafe_install: bool,
         /// The host's `plugins inspect --help` exposes `--json`.

--- a/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
@@ -20,8 +20,10 @@
 //! `plugins install --help`, `plugins inspect --help`). From it the driver
 //! gates on the adapter's declared framework version, chooses
 //! version-conditioned config, decides the install argv (`--force`, and
+//! `--accept-capabilities` when advertised, because enable consents to the
+//! plugin's declared capabilities), adds
 //! `--dangerously-force-unsafe-install` only when both authorized and
-//! advertised as effective by the host), and records the inspect capabilities.
+//! advertised as effective by the host, and records the inspect capabilities.
 //! The install/verify capabilities flow to `apply_enable` as typed
 //! [`PreparedEnable`] state, so
 //! apply performs no probe of its own — each probe runs exactly once per
@@ -261,6 +263,7 @@ impl FrameworkDriver for OpenClawDriver {
         } else {
             let preflight = self.plugin_preflight(&bundle.resource_root, ctx)?;
             PreparedEnable::OpenClaw {
+                supports_accept_capabilities: preflight.supports_accept_capabilities,
                 supports_unsafe_install: preflight.supports_unsafe_install,
                 supports_inspect_json: preflight.supports_inspect_json,
                 supports_inspect_runtime: preflight.supports_inspect_runtime,
@@ -417,8 +420,8 @@ impl FrameworkDriver for OpenClawDriver {
         // and all gating were resolved and validated by `prepare_enable`, which
         // probed the host once and handed the results forward as `prepared`.
         // `apply_enable` therefore does NOT probe at all: the install argv is
-        // rebuilt from the typed `ctx` (required `--force`, plus the unsafe
-        // flag iff the caller authorized it), config selection comes from
+        // rebuilt from the typed `ctx` and prepared consent support; the unsafe
+        // flag still requires explicit authorization. Config selection comes from
         // prepared state, and runtime verification uses the prepared
         // `--runtime` capability. Each probe (`--version`, install `--help`,
         // inspect `--help`) thus runs exactly once per enable, all in prepare,
@@ -430,9 +433,12 @@ impl FrameworkDriver for OpenClawDriver {
         // first mutation, failing closed on any mismatch rather than silently
         // degrading (which could skip the `--json` precondition, verify without
         // `--runtime`, or add the unsafe flag on an unverified host).
-        let (host_supports_unsafe, verify_with_runtime, selected_config_indices) = if ctx
-            .is_skill_bundle()
-        {
+        let (
+            accept_capabilities,
+            host_supports_unsafe,
+            verify_with_runtime,
+            selected_config_indices,
+        ) = if ctx.is_skill_bundle() {
             if !matches!(prepared, PreparedEnable::None) {
                 return Err(prepared_state_mismatch(
                     "skill_bundle adapters carry no prepared host capabilities",
@@ -440,10 +446,11 @@ impl FrameworkDriver for OpenClawDriver {
             }
             // Skill bundles run no plugin install and no runtime verification;
             // these values are unused for them.
-            (false, false, Vec::new())
+            (false, false, false, Vec::new())
         } else {
             match prepared {
                 PreparedEnable::OpenClaw {
+                    supports_accept_capabilities,
                     supports_unsafe_install,
                     supports_inspect_json,
                     supports_inspect_runtime,
@@ -467,6 +474,7 @@ impl FrameworkDriver for OpenClawDriver {
                     }
                     validate_prepared_config_indices(selected_config_indices, ctx)?;
                     (
+                        *supports_accept_capabilities,
                         *supports_unsafe_install,
                         *supports_inspect_runtime,
                         selected_config_indices.clone(),
@@ -496,7 +504,11 @@ impl FrameworkDriver for OpenClawDriver {
             })?;
             validate_plugin_id(&plugin_id)?;
             let cmd = base_cmd(
-                install_argv(&claim.resource_root, ctx.allow_unsafe_plugin_install),
+                install_argv(
+                    &claim.resource_root,
+                    ctx.allow_unsafe_plugin_install,
+                    accept_capabilities,
+                ),
                 &home,
                 user_home,
             );
@@ -508,7 +520,12 @@ impl FrameworkDriver for OpenClawDriver {
                 // it could actually help: the host exposes the unsafe flag, the
                 // user did not already authorize it, and the failure looks like
                 // a plugin-safety rejection. Never retry automatically.
-                if host_supports_unsafe
+                if install_output_requires_capability_consent(&output) {
+                    reason.push_str(
+                        "; OpenClaw capability consent was not accepted; inspect the reported \
+                         capability requirements and the host's --accept-capabilities support",
+                    );
+                } else if host_supports_unsafe
                     && !ctx.allow_unsafe_plugin_install
                     && install_output_looks_like_safety_rejection(&output)
                 {
@@ -860,6 +877,8 @@ struct OpenClawHostProfile {
     version_display: String,
     /// `openclaw plugins install --help` exposes `--force`.
     supports_install_force: bool,
+    /// `openclaw plugins install --help` exposes `--accept-capabilities`.
+    supports_accept_capabilities: bool,
     /// `openclaw plugins install --help` exposes
     /// `--dangerously-force-unsafe-install`, including whether the advertised
     /// option is still effective or has become a deprecated no-op.
@@ -889,6 +908,8 @@ impl UnsafeInstallSupport {
 /// selected config, the single install command, and the install/verify
 /// capabilities to hand forward as [`PreparedEnable`].
 struct PluginPreflight<'a> {
+    /// The host's installer supports accepting declared plugin capabilities.
+    supports_accept_capabilities: bool,
     /// The host's `plugins install --help` exposes the unsafe flag.
     supports_unsafe_install: bool,
     /// The host's `plugins inspect --help` exposes `--json`.
@@ -979,6 +1000,7 @@ impl OpenClawDriver {
             "openclaw plugins install --help",
         )?;
         let supports_install_force = help_lists_flag(&install_help, "--force");
+        let supports_accept_capabilities = help_lists_flag(&install_help, "--accept-capabilities");
         let unsafe_install_support = unsafe_install_support(&install_help);
 
         let inspect_help = self.run_read_probe(
@@ -993,6 +1015,7 @@ impl OpenClawDriver {
             version,
             version_display,
             supports_install_force,
+            supports_accept_capabilities,
             unsafe_install_support,
             supports_inspect_json,
             supports_inspect_runtime,
@@ -1121,6 +1144,7 @@ impl OpenClawDriver {
         )?;
         let selected_config = self.select_config(ctx, &profile)?;
         Ok(PluginPreflight {
+            supports_accept_capabilities: profile.supports_accept_capabilities,
             supports_unsafe_install: profile.unsafe_install_support.is_effective(),
             supports_inspect_json: profile.supports_inspect_json,
             supports_inspect_runtime: profile.supports_inspect_runtime,
@@ -1698,6 +1722,16 @@ fn install_output_looks_like_safety_rejection(output: &CliOutput) -> bool {
         .any(|marker| haystack.contains(marker))
 }
 
+fn install_output_requires_capability_consent(output: &CliOutput) -> bool {
+    format!(
+        "{}\n{}",
+        strip_ansi(&output.stdout),
+        strip_ansi(&output.stderr)
+    )
+    .to_ascii_lowercase()
+    .contains("capability consent")
+}
+
 // ---------------------------------------------------------------------------
 // OpenClaw version parsing and comparison
 // ---------------------------------------------------------------------------
@@ -2207,8 +2241,7 @@ fn base_cmd(args: Vec<String>, home: &Path, user_home: Option<&Path>) -> Framewo
     }
 }
 
-/// Build the single `openclaw plugins install <resource_root> --force
-/// [--dangerously-force-unsafe-install]` command for the current host.
+/// Build a host-compatible `openclaw plugins install` command.
 ///
 /// `--force` is a required capability of the driver contract; if the host's
 /// install help does not expose it, this fails before any mutation. The
@@ -2216,6 +2249,8 @@ fn base_cmd(args: Vec<String>, home: &Path, user_home: Option<&Path>) -> Framewo
 /// (`allow_unsafe`) and the host's help describes it as effective. An
 /// authorized request fails when the option is absent or advertised as a
 /// deprecated no-op, and a normal install never carries it.
+/// Enabling a plugin accepts its declared capabilities, so the consent flag
+/// is included whenever the installer advertises it.
 ///
 /// # Errors
 ///
@@ -2260,18 +2295,27 @@ fn build_install_cmd(
         }
     }
     Ok(base_cmd(
-        install_argv(resource_root, allow_unsafe),
+        install_argv(
+            resource_root,
+            allow_unsafe,
+            profile.supports_accept_capabilities,
+        ),
         home,
         user_home,
     ))
 }
 
 /// Build the `plugins install <root> --force [--dangerously-force-unsafe-install]`
-/// argv. `--force` is always present (a required capability); the unsafe flag
+/// argv, accepting declared capabilities when the host supports consent.
+/// `--force` is always present (a required capability); the unsafe flag
 /// is appended iff `allow_unsafe`. Capability support is the caller's concern
 /// ([`build_install_cmd`] verifies it during preflight); `apply_enable` builds
 /// this directly from the authorized decision without re-probing.
-fn install_argv(resource_root: &Path, allow_unsafe: bool) -> Vec<String> {
+fn install_argv(
+    resource_root: &Path,
+    allow_unsafe: bool,
+    accept_capabilities: bool,
+) -> Vec<String> {
     let mut args = vec![
         "plugins".to_string(),
         "install".to_string(),
@@ -2280,6 +2324,9 @@ fn install_argv(resource_root: &Path, allow_unsafe: bool) -> Vec<String> {
     ];
     if allow_unsafe {
         args.push("--dangerously-force-unsafe-install".to_string());
+    }
+    if accept_capabilities {
+        args.push("--accept-capabilities".to_string());
     }
     args
 }
@@ -3244,6 +3291,7 @@ mod tests {
             version: OpenClawVersion::parse("2026.4.14"),
             version_display: "2026.4.14".to_string(),
             supports_install_force: force,
+            supports_accept_capabilities: false,
             unsafe_install_support: if unsafe_install {
                 UnsafeInstallSupport::Effective
             } else {
@@ -3980,6 +4028,7 @@ mod tests {
             driver.apply_enable(
                 &mut skill_claim,
                 &PreparedEnable::OpenClaw {
+                    supports_accept_capabilities: false,
                     supports_unsafe_install: true,
                     supports_inspect_json: true,
                     supports_inspect_runtime: true,
@@ -3996,6 +4045,7 @@ mod tests {
             driver.apply_enable(
                 &mut plugin_claim,
                 &PreparedEnable::OpenClaw {
+                    supports_accept_capabilities: false,
                     supports_unsafe_install: true,
                     supports_inspect_json: false,
                     supports_inspect_runtime: false,
@@ -4013,6 +4063,7 @@ mod tests {
             driver.apply_enable(
                 &mut plugin_claim,
                 &PreparedEnable::OpenClaw {
+                    supports_accept_capabilities: false,
                     supports_unsafe_install: false,
                     supports_inspect_json: true,
                     supports_inspect_runtime: false,

--- a/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
@@ -247,6 +247,7 @@ const OWNED_ENV: &[&str] = &[
     "FAKE_OPENCLAW_FAIL",
     "FAKE_OC_VERSION",
     "FAKE_OC_INSTALL_FORCE",
+    "FAKE_OC_INSTALL_ACCEPT",
     "FAKE_OC_INSTALL_UNSAFE",
     "FAKE_OC_INSTALL_UNSAFE_NOOP",
     "FAKE_OC_INSPECT_JSON",
@@ -458,6 +459,8 @@ case "$action" in
     if [ "$arg3" = "--help" ]; then
       echo "Usage: openclaw plugins install <path> [options]"
       [ "${FAKE_OC_INSTALL_FORCE:-1}" = "1" ] && echo "  --force                             overwrite an existing plugin"
+      [ "${FAKE_OC_INSTALL_ACCEPT:-0}" = "1" ] && echo "  --accept-capabilities               accept declared capabilities"
+      [ "${FAKE_OC_INSTALL_ACCEPT:-0}" = "near_match" ] && echo "  --accept-capabilities-only          unrelated option"
       if [ "${FAKE_OC_INSTALL_UNSAFE:-0}" = "1" ]; then
         if [ "${FAKE_OC_INSTALL_UNSAFE_NOOP:-0}" = "1" ]; then
           echo "  --dangerously-force-unsafe-install  Deprecated no-op; security.installPolicy may still block"
@@ -470,6 +473,19 @@ case "$action" in
     fi
     reg="$OPENCLAW_STATE_DIR/registry"; mkdir -p "$reg" 2>/dev/null
     if [ "${FAKE_OPENCLAW_FAIL:-}" = "install" ]; then echo "boom-install" >&2; exit 7; fi
+    case "${FAKE_OPENCLAW_FAIL:-}" in
+      install_consent*)
+        [ "$FAKE_OPENCLAW_FAIL" = "install_consent_warning" ] && echo "--dangerously-force-unsafe-install is deprecated and no longer affects plugin installs"
+        echo 'Plugin requires capability consent. Use --accept-capabilities, then retry.' >&2
+        exit 15 ;;
+    esac
+    accepted=0
+    for option in "$@"; do [ "$option" = "--accept-capabilities" ] && accepted=1; done
+    if [ "${FAKE_OC_INSTALL_ACCEPT:-0}" = "1" ]; then
+      if [ "$accepted" != 1 ]; then echo "Plugin requires capability consent" >&2; exit 15; fi
+    elif [ "$accepted" = 1 ]; then
+      echo "unknown option --accept-capabilities" >&2; exit 2
+    fi
     if [ "${FAKE_OPENCLAW_FAIL:-}" = "install_unsafe_policy" ]; then
       echo "refusing install: plugin failed safety checks (pass --dangerously-force-unsafe-install to override)" >&2
       exit 11
@@ -3256,6 +3272,79 @@ fn each_probe_runs_exactly_once_per_enable() {
         1,
         "one inspect --help probe: {lines:?}"
     );
+}
+
+#[test]
+fn enable_accepts_capabilities_only_when_install_help_supports_it() {
+    let guard = OpenClawEnvGuard::acquire();
+    for support in ["1", "0", "near_match"] {
+        let world = stage();
+        world.apply_env(&guard, None);
+        guard.set("FAKE_OC_INSTALL_ACCEPT", support);
+        let argv_log = world.argv_log();
+        guard.set("FAKE_OC_ARGV_LOG", &argv_log);
+        let manager = world.manager();
+        let preview = manager
+            .enable(COMPONENT, Some(FRAMEWORK), true)
+            .expect("preview");
+        let EnableOutcome::Planned { plan, .. } = preview else {
+            panic!("expected preview")
+        };
+        assert_eq!(
+            plan.register_command
+                .unwrap()
+                .contains("--accept-capabilities"),
+            support == "1"
+        );
+        assert!(!world.has_claim());
+        assert!(!world.registry_marker_exists());
+        std::fs::write(&argv_log, "").expect("reset probe log");
+        manager
+            .enable(COMPONENT, Some(FRAMEWORK), false)
+            .expect("enable");
+        let log = std::fs::read_to_string(&argv_log).expect("argv log");
+        assert_eq!(
+            log.lines()
+                .filter(|line| *line == "plugins install --help")
+                .count(),
+            1
+        );
+        let install = log
+            .lines()
+            .find(|line| line.starts_with("plugins install ") && !line.ends_with("--help"))
+            .expect("install argv");
+        assert_eq!(install.contains("--accept-capabilities"), support == "1");
+        assert!(!install.contains("--dangerously-force-unsafe-install"));
+        assert!(world.registry_marker_exists());
+    }
+}
+
+#[test]
+fn capability_consent_failure_takes_precedence_over_safety_warning() {
+    let guard = OpenClawEnvGuard::acquire();
+    for failure in ["install_consent", "install_consent_warning"] {
+        let world = stage();
+        world.apply_env(&guard, Some(failure));
+        guard.set("FAKE_OC_INSTALL_UNSAFE", "1");
+        let err = world
+            .manager()
+            .enable(COMPONENT, Some(FRAMEWORK), false)
+            .expect_err("consent rejection");
+        let reason = err.to_string();
+        assert!(reason.contains("OpenClaw capability consent"), "{reason}");
+        assert!(
+            !reason.contains("--allow-unsafe-plugin-install"),
+            "{reason}"
+        );
+        assert_eq!(
+            world
+                .load_state()
+                .find_adapter_claim(COMPONENT, FRAMEWORK)
+                .unwrap()
+                .status,
+            ClaimStatus::CleanupFailed
+        );
+    }
 }
 
 /// P2 (negative): when the host does NOT expose the unsafe flag, a plain

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -281,6 +281,8 @@ test-hook-parity:
 	python3 tests/test_hook_parity.py
 
 test-adapters: build-openclaw-plugin build-dsh-plugin
+	@echo "==> Testing OpenClaw adapter installer..."
+	bash tests/test-openclaw-adapter-install.sh
 	@echo "==> Testing openclaw Protocol v2 lifecycle..."
 	node --test tests/test-openclaw-lifecycle-v2.mjs
 	@echo "==> Testing native dsh adapter bundle..."

--- a/src/tokenless/adapters/tokenless/openclaw/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/openclaw/scripts/install.sh
@@ -46,6 +46,7 @@ fi
 
 if [ "$DRY_RUN" = "1" ]; then
     echo "DRY-RUN: env -u OPENCLAW_HOME OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR $OPENCLAW_BIN plugins install $PLUGIN_SRC --force --dangerously-force-unsafe-install"
+    echo "DRY-RUN: add --accept-capabilities only if advertised by plugins install --help"
     exit 0
 fi
 
@@ -53,6 +54,17 @@ if ! command -v "$OPENCLAW_BIN" &>/dev/null; then
     echo "[${COMPONENT}] openclaw CLI not found (OPENCLAW_BIN=${OPENCLAW_BIN}) — skipping plugin installation."
     echo "[${COMPONENT}] Install OpenClaw first, then run this script again."
     exit 0
+fi
+
+INSTALL_ARGS=(plugins install "$PLUGIN_SRC" --force --dangerously-force-unsafe-install)
+if ! INSTALL_HELP="$(env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install --help 2>&1)"; then
+    printf '[%s] Cannot inspect OpenClaw installer options: %s\n' "$COMPONENT" "$INSTALL_HELP" >&2
+    exit 1
+fi
+# Invoking this installer accepts declared capabilities. Older hosts must
+# never receive an unsupported flag or a similarly named option.
+if [[ "$INSTALL_HELP" =~ (^|[^[:alnum:]_.-])--accept-capabilities([^[:alnum:]_.-]|$) ]]; then
+    INSTALL_ARGS+=(--accept-capabilities)
 fi
 
 # OpenClaw's built-in security scanner flags child_process imports as "dangerous
@@ -65,8 +77,7 @@ echo "[${COMPONENT}] Note: --dangerously-force-unsafe-install is required becaus
 echo "[${COMPONENT}]       this plugin wraps tokenless/rtk system binaries via child_process."
 echo "[${COMPONENT}]       See https://github.com/alibaba/anolisa for source."
 
-env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install "$PLUGIN_SRC" \
-    --force --dangerously-force-unsafe-install || {
+env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" "${INSTALL_ARGS[@]}" || {
     echo "[${COMPONENT}] openclaw CLI install failed — check OpenClaw version >= 5.0.0" >&2
     exit 1
 }

--- a/src/tokenless/tests/test-openclaw-adapter-install.sh
+++ b/src/tokenless/tests/test-openclaw-adapter-install.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Check capability-consent negotiation without installing a real plugin.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_SH="$SCRIPT_DIR/../adapters/tokenless/openclaw/scripts/install.sh"
+SANDBOX="$(mktemp -d -t tokenless-openclaw-install.XXXXXX)"
+trap 'rm -r -- "$SANDBOX"' EXIT
+mkdir -p "$SANDBOX/adapter root/openclaw/dist"
+: > "$SANDBOX/adapter root/openclaw/dist/index.js"
+
+cat > "$SANDBOX/openclaw" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+[ -z "${OPENCLAW_HOME+x}" ]
+[ "$OPENCLAW_STATE_DIR" = "$TEST_STATE_DIR" ]
+printf '%s\n' "$*" >> "$TEST_ARGV_LOG"
+if [ "$*" = "plugins install --help" ]; then
+    echo "--force"
+    case "$TEST_SUPPORT" in
+        modern) echo "--accept-capabilities" ;;
+        near_match) echo "--accept-capabilities-only" ;;
+        failed) echo "cannot inspect --accept-capabilities" >&2; exit 3 ;;
+    esac
+    exit 0
+fi
+[ "$1" = plugins ] && [ "$2" = install ]
+[ "$3" = "$ANOLISA_ADAPTER_DIR/openclaw" ]
+accepted=0
+for arg in "$@"; do
+    [ "$arg" != --accept-capabilities ] || accepted=1
+done
+if [ "$TEST_SUPPORT" = modern ]; then
+    [ "$accepted" = 1 ] || { echo 'Plugin requires capability consent' >&2; exit 1; }
+else
+    [ "$accepted" = 0 ] || { echo 'unknown option --accept-capabilities' >&2; exit 2; }
+fi
+: > "$TEST_INSTALLED"
+STUB
+chmod +x "$SANDBOX/openclaw"
+
+export ANOLISA_ADAPTER_DIR="$SANDBOX/adapter root"
+export OPENCLAW_BIN="$SANDBOX/openclaw"
+export OPENCLAW_STATE_DIR="$SANDBOX/state root"
+export OPENCLAW_HOME="$SANDBOX/ignored home"
+export TEST_STATE_DIR="$OPENCLAW_STATE_DIR"
+export TEST_ARGV_LOG="$SANDBOX/argv"
+export TEST_INSTALLED="$SANDBOX/installed"
+export ANOLISA_DRY_RUN=0
+
+for TEST_SUPPORT in modern legacy near_match; do
+    export TEST_SUPPORT
+    : > "$TEST_ARGV_LOG"
+    bash "$INSTALL_SH" > "$SANDBOX/output" 2>&1 || { cat "$SANDBOX/output" >&2; exit 1; }
+    [ -f "$TEST_INSTALLED" ]
+    [ "$(grep -c '^plugins install --help$' "$TEST_ARGV_LOG")" = 1 ]
+    rm "$TEST_INSTALLED"
+    echo "PASS: $TEST_SUPPORT installer"
+done
+
+export TEST_SUPPORT=failed
+if bash "$INSTALL_SH" > "$SANDBOX/output" 2>&1; then
+    echo 'FAIL: failed help probe allowed installation' >&2
+    exit 1
+fi
+[ ! -f "$TEST_INSTALLED" ]
+echo 'PASS: failed help probe stops installation'
+
+: > "$TEST_ARGV_LOG"
+ANOLISA_DRY_RUN=1 bash "$INSTALL_SH" > "$SANDBOX/output" 2>&1
+[ ! -s "$TEST_ARGV_LOG" ]
+[ ! -f "$TEST_INSTALLED" ]
+grep -q -- '--accept-capabilities' "$SANDBOX/output"
+echo 'PASS: dry-run describes consent without invoking OpenClaw'
+
+OPENCLAW_BIN="$SANDBOX/missing-openclaw" bash "$INSTALL_SH" > "$SANDBOX/output" 2>&1
+grep -q 'skipping plugin installation' "$SANDBOX/output"
+echo 'PASS: missing CLI preserves the existing skip behavior'


### PR DESCRIPTION
## Why

OpenClaw hosts that require capability consent reject plugin installs from the Rust adapter driver and tokenless installer because neither passes `--accept-capabilities`. A consent error mixed with an unsafe-install deprecation warning can also produce a misleading unsafe retry hint.

## What changed

Treat invoking adapter enable or the dedicated tokenless installer as consent to the plugin's declared capabilities, and pass `--accept-capabilities` only when installer help advertises the exact option. The Rust driver carries the existing preflight result into apply and dry-run without another probe, and diagnoses capability consent before safety rejection. The shell installer uses the same help-gated behavior; regression tests and bilingual documentation cover both paths.

## Related issue

Closes #3119. #3120 is its closed duplicate.

Based on main at `70348760b`, which includes merged #3118.

## User / Agent impact

`anolisa adapter enable <component> openclaw` accepts declared capabilities automatically on supporting hosts. Older hosts receive no unsupported consent option. Capability consent does not grant the Rust driver's separate `--allow-unsafe-plugin-install` authorization; the tokenless script retains its existing unsafe-install arguments.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The documented enable action now authorizes declared capabilities. Host support is detected from help, including whole-token matching, with no version assumptions. `PreparedEnable::OpenClaw` carries one additional capability field across preflight/apply; receipt and configuration formats do not change. Existing unsafe authorization checks remain in place. A failed shell help probe stops installation before invoking install.

## Validation

Linux arm64, Rust 1.93.1, from `src/anolisa`:

- `cargo +1.93.1 fmt --all -- --check`
- `cargo +1.93.1 check --locked`
- `cargo +1.93.1 clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.93.1 test --workspace --locked` — 2465 passed, 1 ignored
- `cargo +1.93.1 doc --workspace --no-deps --locked`

macOS arm64, from `src/anolisa`:

- `cargo test -p anolisa-core --lib --locked adapter::openclaw` — 40 passed
- `cargo test -p anolisa-core --locked --test adapter_manager` — 84 passed

From the repository root, on Linux and macOS:

- `bash -n src/tokenless/adapters/tokenless/openclaw/scripts/install.sh src/tokenless/tests/test-openclaw-adapter-install.sh`
- `bash src/tokenless/tests/test-openclaw-adapter-install.sh` — 6 cases passed
- `git diff --check`

Regression coverage includes modern/legacy hosts, similarly named unsupported options, matching dry-run/apply arguments, a single help probe, no implicit unsafe authorization, consent failures mixed with unsafe warnings, failed shell probes, paths with spaces, dry-run isolation, and missing CLI behavior. The new Rust consent test failed before the fix. Tests use fake host CLIs; no live OpenClaw 2026.9.2 end-to-end installation was performed.

## Documentation and rollback

Updated English and Chinese ANOLISA READMEs, CLI guides, and tokenless framework integration guides to describe consent and old-host compatibility. Revert this commit to restore the previous installer behavior; there is no data migration, though hosts requiring consent will reject installs again.

### Ship Note

- Changed: both remaining installer paths negotiate capability consent with OpenClaw.
- Known limitations: support detection depends on the host's advertised help contract.
- Not covered: live OpenClaw 2026.9.2 end-to-end installation.
- Verification: Linux workspace gates, 2465 Rust tests, macOS targeted tests, and 6 shell cases passed.
