### PR TITLE
fix(sight)!: align kernel event timestamps

### DIFF
--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -1410,51 +1410,10 @@ pub fn default_base_path() -> PathBuf {
     PathBuf::from(home).join(".agentsight")
 }
 
-/// Convert BPF ktime (nanoseconds since boot) to Unix timestamp (nanoseconds since epoch)
-///
-/// BPF's bpf_ktime_get_ns() returns nanoseconds since system boot.
-/// This function converts it to a proper Unix timestamp.
-///
-/// # How it works
-/// 1. Reads system uptime from /proc/uptime
-/// 2. Calculates boot_time = current_unix_time - uptime
-/// 3. Returns boot_time + ktime
-///
-/// # Performance
-/// Boot time is calculated once and cached, so subsequent calls are O(1).
-pub fn ktime_to_unix_ns(ktime_ns: u64) -> u64 {
-    use std::fs;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    static BOOT_TIME_NS: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
-
-    let boot_time_ns = *BOOT_TIME_NS.get_or_init(|| {
-        let now_unix = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos() as u64;
-
-        // Read /proc/uptime to get system uptime in seconds
-        let uptime_ns = match fs::read_to_string("/proc/uptime") {
-            Ok(content) => {
-                // Format: "123456.67 456.78" (uptime, idle_time)
-                let uptime_secs: f64 = content
-                    .split_whitespace()
-                    .next()
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(0.0);
-                (uptime_secs * 1_000_000_000.0) as u64
-            }
-            Err(_) => return 0,
-        };
-
-        // boot_time = current_unix_time - uptime
-        now_unix.saturating_sub(uptime_ns)
-    });
-
-    boot_time_ns.saturating_add(ktime_ns)
-}
-
+mod event_clock;
+pub use event_clock::{ClockConversionError, ktime_to_unix_ns};
+#[cfg(target_os = "linux")]
+pub(crate) use event_clock::{initialize_event_clock, report_clock_error};
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1547,20 +1506,6 @@ mod tests {
     fn test_default_base_path() {
         let path = default_base_path();
         assert_eq!(path, PathBuf::from("/var/log/sysak/.agentsight"));
-    }
-
-    #[test]
-    fn test_ktime_to_unix_ns_nonzero() {
-        // ktime_to_unix_ns should return a value > ktime_ns (boot time offset)
-        let result = ktime_to_unix_ns(1_000_000);
-        assert!(result >= 1_000_000);
-    }
-
-    #[test]
-    fn test_ktime_to_unix_ns_zero() {
-        let result = ktime_to_unix_ns(0);
-        // Should return the boot time itself
-        assert!(result > 0);
     }
 
     #[test]

--- a/src/agentsight/src/config/event_clock.rs
+++ b/src/agentsight/src/config/event_clock.rs
@@ -1,0 +1,529 @@
+//! Checked conversion between kernel monotonic and Unix event time.
+
+#[cfg(target_os = "linux")]
+use std::sync::atomic::Ordering;
+
+/// Failure to map a kernel monotonic timestamp into Unix time.
+#[derive(Debug, thiserror::Error)]
+pub enum ClockConversionError {
+    /// The kernel clock or namespace metadata could not be read.
+    #[error("event clock read failed ({operation}): {source}")]
+    Read {
+        /// Clock or metadata operation that failed.
+        operation: &'static str,
+        /// Operating-system error.
+        source: std::io::Error,
+    },
+    /// Namespace identity or offset metadata cannot be mapped safely.
+    #[error("event clock namespace identity or monotonic offset is invalid")]
+    Namespace,
+    /// Scheduling delays prevented a sufficiently tight clock sample.
+    #[error("event clock sampling exceeded the 5 ms bracket after three attempts")]
+    UnstableSample,
+    /// Clock arithmetic would produce an invalid Unix timestamp.
+    #[error("event clock value is outside the unsigned nanosecond range")]
+    Range,
+    /// No valid calibration is available, or its wall-clock age exceeds five seconds.
+    #[error("event clock calibration is unavailable or expired")]
+    Unavailable,
+    /// Kernel event time conversion is only supported on Linux.
+    #[error("kernel event clock conversion requires Linux")]
+    UnsupportedPlatform,
+}
+
+/// Map BPF CLOCK_MONOTONIC nanoseconds into Unix nanoseconds.
+///
+/// Container-visible `/proc/uptime` may have a different epoch and is not a
+/// substitute for the BPF clock. A process-wide worker refreshes the calibration
+/// once per second; conversion only reads the snapshot and current realtime.
+/// The first standalone call initializes the worker; probe pollers initialize it
+/// before registering callbacks. Failed refreshes invalidate the snapshot.
+/// A wall-clock step may affect events until the next refresh and cannot be
+/// reconstructed historically from a queued monotonic timestamp alone.
+///
+/// # Errors
+/// Rejects unreadable clocks, inconsistent/malformed time-namespace metadata, unstable
+/// samples, unavailable/expired calibration and arithmetic overflow.
+pub fn ktime_to_unix_ns(ktime_ns: u64) -> Result<u64, ClockConversionError> {
+    #[cfg(target_os = "linux")]
+    {
+        let sample = event_clock()?.snapshot()?;
+        sample.convert(ktime_ns, read_event_clock(libc::CLOCK_REALTIME)?)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = ktime_ns;
+        Err(ClockConversionError::UnsupportedPlatform)
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn unix_ns_from_sample(
+    ktime_ns: u64,
+    realtime_ns: u64,
+    monotonic_ns: u64,
+) -> Result<u64, ClockConversionError> {
+    u64::try_from(i128::from(realtime_ns) + i128::from(ktime_ns) - i128::from(monotonic_ns))
+        .map_err(|_| ClockConversionError::Range)
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy)]
+struct ClockSample {
+    realtime_ns: u64,
+    monotonic_ns: u64,
+}
+
+#[cfg(target_os = "linux")]
+impl ClockSample {
+    fn convert(self, ktime_ns: u64, now_ns: u64) -> Result<u64, ClockConversionError> {
+        // Realtime is shared across time namespaces. Clock steps outside this
+        // window invalidate the sample even if the calibration worker stalls.
+        if !matches!(now_ns.checked_sub(self.realtime_ns), Some(age) if age <= 5_000_000_000) {
+            return Err(ClockConversionError::Unavailable);
+        }
+        unix_ns_from_sample(ktime_ns, self.realtime_ns, self.monotonic_ns)
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct ClockCache(std::sync::RwLock<Option<ClockSample>>);
+
+#[cfg(target_os = "linux")]
+impl ClockCache {
+    fn snapshot(&self) -> Result<ClockSample, ClockConversionError> {
+        self.0
+            .read()
+            .map_err(|_| ClockConversionError::Unavailable)?
+            .ok_or(ClockConversionError::Unavailable)
+    }
+
+    fn refresh(
+        &self,
+        sample: impl FnOnce() -> Result<(u64, u64), ClockConversionError>,
+    ) -> Result<(), ClockConversionError> {
+        // Never hold the lock across procfs I/O or clock sampling.
+        let result = sample();
+        let mut cached = self
+            .0
+            .write()
+            .map_err(|_| ClockConversionError::Unavailable)?;
+        *cached = None;
+        let (realtime_ns, monotonic_ns) = result?;
+        *cached = Some(ClockSample {
+            realtime_ns,
+            monotonic_ns,
+        });
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn event_clock() -> Result<&'static std::sync::Arc<ClockCache>, ClockConversionError> {
+    use std::sync::{Arc, OnceLock};
+    static CLOCK: OnceLock<Result<Arc<ClockCache>, std::io::Error>> = OnceLock::new();
+    CLOCK
+        .get_or_init(|| {
+            let cache = Arc::new(ClockCache::default());
+            if let Err(error) = cache.refresh(sample_event_clock) {
+                report_clock_error("calibration", &error);
+            }
+            let worker = Arc::clone(&cache);
+            // One worker lasts for the process, independent of poller restarts.
+            std::thread::Builder::new()
+                .name("event-clock".into())
+                .spawn(move || {
+                    loop {
+                        std::thread::sleep(std::time::Duration::from_secs(1));
+                        if let Err(error) = worker.refresh(sample_event_clock) {
+                            report_clock_error("calibration", &error);
+                        }
+                    }
+                })?;
+            Ok(cache)
+        })
+        .as_ref()
+        .map_err(|source| ClockConversionError::Read {
+            operation: "spawn event clock worker",
+            source: std::io::Error::new(source.kind(), source.to_string()),
+        })
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn initialize_event_clock() -> Result<(), ClockConversionError> {
+    event_clock().map(|_| ())
+}
+
+#[cfg(target_os = "linux")]
+fn monotonic_namespace_offset(content: &str) -> Result<i128, ClockConversionError> {
+    let mut offset = None;
+    for line in content.lines() {
+        let mut fields = line.split_whitespace();
+        if fields.next() != Some("monotonic") {
+            continue;
+        }
+        let seconds = fields.next().and_then(|s| s.parse::<i64>().ok());
+        let nanos = fields.next().and_then(|s| s.parse::<u32>().ok());
+        match (seconds, nanos) {
+            (Some(seconds), Some(nanos))
+                if nanos < 1_000_000_000 && fields.next().is_none() && offset.is_none() =>
+            {
+                offset = Some(i128::from(seconds) * 1_000_000_000 + i128::from(nanos));
+            }
+            _ => return Err(ClockConversionError::Namespace),
+        }
+    }
+    offset.ok_or(ClockConversionError::Namespace)
+}
+
+#[cfg(target_os = "linux")]
+fn host_monotonic_ns(local_ns: u64, offset_ns: i128) -> Result<u64, ClockConversionError> {
+    u64::try_from(i128::from(local_ns) - offset_ns).map_err(|_| ClockConversionError::Range)
+}
+
+#[cfg(target_os = "linux")]
+fn read_event_clock(clock: libc::clockid_t) -> Result<u64, ClockConversionError> {
+    let mut value = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: value is a writable timespec and clock_gettime retains no pointer.
+    if unsafe { libc::clock_gettime(clock, &mut value) } != 0 {
+        return Err(ClockConversionError::Read {
+            operation: "clock_gettime",
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    if value.tv_sec < 0 || !(0..1_000_000_000).contains(&value.tv_nsec) {
+        return Err(ClockConversionError::Range);
+    }
+    u64::try_from(i128::from(value.tv_sec) * 1_000_000_000 + i128::from(value.tv_nsec))
+        .map_err(|_| ClockConversionError::Range)
+}
+
+#[cfg(target_os = "linux")]
+fn sample_clock_pair(
+    mut read: impl FnMut(libc::clockid_t) -> Result<u64, ClockConversionError>,
+) -> Result<(u64, u64), ClockConversionError> {
+    for _ in 0..3 {
+        let before = read(libc::CLOCK_MONOTONIC)?;
+        let realtime = read(libc::CLOCK_REALTIME)?;
+        let after = read(libc::CLOCK_MONOTONIC)?;
+        if let Some(width) = after
+            .checked_sub(before)
+            .filter(|width| *width <= 5_000_000)
+        {
+            return Ok((realtime, before + width / 2));
+        }
+    }
+    Err(ClockConversionError::UnstableSample)
+}
+
+#[cfg(target_os = "linux")]
+fn namespace_identity(path: &'static str) -> Result<Option<(u64, u64)>, ClockConversionError> {
+    use std::os::unix::fs::MetadataExt;
+    match std::fs::metadata(path) {
+        Ok(meta) => Ok(Some((meta.dev(), meta.ino()))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            // CONFIG_TIME_NS=n has no ns/time entry. A missing procfs must still
+            // fail: only accept absence when the namespace directory is readable.
+            std::fs::read_dir("/proc/thread-self/ns").map_err(|source| {
+                ClockConversionError::Read {
+                    operation: path,
+                    source,
+                }
+            })?;
+            Ok(None)
+        }
+        Err(source) => Err(ClockConversionError::Read {
+            operation: path,
+            source,
+        }),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn namespace_offset(
+    current: Option<(u64, u64)>,
+    leader: Option<(u64, u64)>,
+    children: Option<(u64, u64)>,
+    read_offsets: impl FnOnce() -> Result<String, ClockConversionError>,
+) -> Result<i128, ClockConversionError> {
+    // timens_offsets describes time_for_children, which may differ after unshare.
+    // The process leader can also have a different namespace from this thread.
+    if current != leader || current != children {
+        return Err(ClockConversionError::Namespace);
+    }
+    if current.is_none() {
+        return Ok(0);
+    }
+    monotonic_namespace_offset(&read_offsets()?)
+}
+
+#[cfg(target_os = "linux")]
+fn sample_event_clock() -> Result<(u64, u64), ClockConversionError> {
+    #[cfg(test)]
+    tests::SAMPLE_CALLS.with(|calls| calls.set(calls.get() + 1));
+    let current = namespace_identity("/proc/thread-self/ns/time")?;
+    let offset = namespace_offset(
+        current,
+        namespace_identity("/proc/self/ns/time")?,
+        namespace_identity("/proc/self/ns/time_for_children")?,
+        || {
+            std::fs::read_to_string("/proc/self/timens_offsets").map_err(|source| {
+                ClockConversionError::Read {
+                    operation: "read /proc/self/timens_offsets",
+                    source,
+                }
+            })
+        },
+    )?;
+    let (realtime, monotonic) = sample_clock_pair(read_event_clock)?;
+    // Another thread can change the leader's child namespace during the read.
+    for path in [
+        "/proc/thread-self/ns/time",
+        "/proc/self/ns/time",
+        "/proc/self/ns/time_for_children",
+    ] {
+        if namespace_identity(path)? != current {
+            return Err(ClockConversionError::Namespace);
+        }
+    }
+    Ok((realtime, host_monotonic_ns(monotonic, offset)?))
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn report_clock_error(probe: &str, error: &ClockConversionError) {
+    static REJECTED: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let count = REJECTED.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
+    // Exponential reporting keeps a broken environment from flooding the log.
+    if count.is_power_of_two() {
+        log::error!("event_clock_conversion_failed probe={probe} rejected={count}: {error}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn cached_clock_refresh_failure_expiry_and_recovery() {
+        let cache = ClockCache::default();
+        assert!(matches!(
+            cache.snapshot(),
+            Err(ClockConversionError::Unavailable)
+        ));
+        cache
+            .refresh(|| {
+                assert!(cache.0.try_read().is_ok());
+                Ok((10_000_000_000, 1_000))
+            })
+            .unwrap();
+        let old = cache.snapshot().unwrap();
+        assert_eq!(old.convert(900, 11_000_000_000).unwrap(), 9_999_999_900);
+        assert!(matches!(
+            old.convert(900, 15_000_000_001),
+            Err(ClockConversionError::Unavailable)
+        ));
+        assert!(matches!(
+            old.convert(900, 9_000_000_000),
+            Err(ClockConversionError::Unavailable)
+        ));
+        assert!(matches!(
+            old.convert(u64::MAX, 11_000_000_000),
+            Err(ClockConversionError::Range)
+        ));
+
+        assert!(
+            cache
+                .refresh(|| Err(ClockConversionError::Namespace))
+                .is_err()
+        );
+        assert!(matches!(
+            cache.snapshot(),
+            Err(ClockConversionError::Unavailable)
+        ));
+        // A successful refresh adopts a wall-clock step and restores conversion.
+        cache.refresh(|| Ok((20_000_000_000, 2_000))).unwrap();
+        assert_eq!(
+            cache
+                .snapshot()
+                .unwrap()
+                .convert(1_900, 20_000_000_001)
+                .unwrap(),
+            19_999_999_900
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    thread_local! {
+        pub(super) static SAMPLE_CALLS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn event_burst_reuses_calibration_without_sampling() {
+        initialize_event_clock().unwrap();
+        std::thread::scope(|scope| {
+            for _ in 0..4 {
+                scope.spawn(|| {
+                    for _ in 0..100_000 {
+                        assert!(ktime_to_unix_ns(1_000).is_ok());
+                    }
+                    SAMPLE_CALLS.with(|calls| assert_eq!(calls.get(), 0));
+                });
+            }
+        });
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn background_clock_refreshes_without_events() {
+        let cache = event_clock().unwrap();
+        let first = cache.snapshot().unwrap().realtime_ns;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(4);
+        while cache.snapshot().unwrap().realtime_ns == first {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "clock worker did not refresh"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+    }
+
+    #[test]
+    fn test_ktime_to_unix_ns_nonzero() {
+        assert_eq!(unix_ns_from_sample(100, 1_000, 150).unwrap(), 950);
+    }
+
+    #[test]
+    fn test_ktime_to_unix_ns_zero() {
+        assert_eq!(unix_ns_from_sample(0, 1_000, 150).unwrap(), 850);
+    }
+
+    #[test]
+    fn event_clock_ignores_container_uptime() {
+        let realtime = 2_000_000_000_000_000_000;
+        let monotonic = 287 * 86_400_000_000_000;
+        let container_uptime = 2 * 3_600_000_000_000;
+        let event = monotonic - 200_000_000;
+        let expected = realtime - 200_000_000;
+        assert_eq!(
+            unix_ns_from_sample(event, realtime, monotonic).unwrap(),
+            expected
+        );
+        assert_ne!(realtime - container_uptime + event, expected);
+        // A later calibration reflects a wall-clock adjustment, not cached state.
+        assert_eq!(
+            unix_ns_from_sample(event, realtime + 1_000, monotonic).unwrap(),
+            expected + 1_000
+        );
+        assert!(matches!(
+            unix_ns_from_sample(0, 1, 2),
+            Err(ClockConversionError::Range)
+        ));
+        assert!(matches!(
+            unix_ns_from_sample(u64::MAX, 1, 0),
+            Err(ClockConversionError::Range)
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn namespace_offsets_restore_the_bpf_clock() {
+        let host = 300_000_000_000_u64;
+        for (text, offset) in [
+            (
+                "monotonic 172800 0\nboottime 604800 0",
+                172_800_000_000_000_i128,
+            ),
+            ("monotonic -2 500000000", -1_500_000_000),
+            ("monotonic 0 1", 1),
+        ] {
+            let parsed = monotonic_namespace_offset(text).unwrap();
+            assert_eq!(parsed, offset);
+            let local = u64::try_from(i128::from(host) + offset).unwrap();
+            assert_eq!(host_monotonic_ns(local, parsed).unwrap(), host);
+            assert_eq!(
+                unix_ns_from_sample(
+                    host - 100,
+                    1_000_000_000_000,
+                    host_monotonic_ns(local, parsed).unwrap()
+                )
+                .unwrap(),
+                999_999_999_900,
+            );
+        }
+        assert!(host_monotonic_ns(0, 1).is_err());
+        assert!(host_monotonic_ns(u64::MAX, -1).is_err());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn namespace_metadata_must_match_the_sampling_thread() {
+        let current = Some((1, 2));
+        let other = Some((1, 3));
+        assert_eq!(
+            namespace_offset(None, None, None, || panic!(
+                "no offsets without CONFIG_TIME_NS"
+            ))
+            .unwrap(),
+            0
+        );
+        assert_eq!(
+            namespace_offset(current, current, current, || Ok("monotonic 42 0".into())).unwrap(),
+            42_000_000_000
+        );
+        for (leader, children) in [(other, current), (current, other), (None, current)] {
+            assert!(matches!(
+                namespace_offset(current, leader, children, || panic!("mismatched namespace")),
+                Err(ClockConversionError::Namespace)
+            ));
+        }
+        assert!(matches!(
+            namespace_offset(current, current, current, || Err(
+                ClockConversionError::Read {
+                    operation: "test offsets",
+                    source: std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+                }
+            )),
+            Err(ClockConversionError::Read { .. })
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn event_clock_namespace_and_sampling_errors() {
+        assert!(monotonic_namespace_offset("monotonic 0 0\nboottime 0 0\n").unwrap() == 0);
+        for invalid in [
+            "",
+            "monotonic 0 1000000000",
+            "monotonic 0 -1",
+            "monotonic bad 0",
+            "monotonic 0",
+            "monotonic 0 0\nmonotonic 0 0",
+        ] {
+            assert!(monotonic_namespace_offset(invalid).is_err());
+        }
+        let mut sample = [100, 1_000, 104].into_iter();
+        assert_eq!(
+            sample_clock_pair(|_| Ok(sample.next().unwrap())).unwrap(),
+            (1_000, 102)
+        );
+        let mut calls = 0;
+        assert!(matches!(
+            sample_clock_pair(|_| {
+                calls += 1;
+                Ok(calls * 10_000_000)
+            }),
+            Err(ClockConversionError::UnstableSample)
+        ));
+        assert_eq!(calls, 9);
+        assert!(matches!(
+            read_event_clock(i32::MAX),
+            Err(ClockConversionError::Read { .. })
+        ));
+    }
+}

--- a/src/agentsight/src/probes/filewatch.rs
+++ b/src/agentsight/src/probes/filewatch.rs
@@ -76,7 +76,9 @@ impl FileWatchEvent {
             pid: raw.pid,
             tid: raw.tid,
             uid: raw.uid,
-            timestamp_ns: config::ktime_to_unix_ns(raw.timestamp_ns),
+            timestamp_ns: config::ktime_to_unix_ns(raw.timestamp_ns)
+                .inspect_err(|error| config::report_clock_error("filewatch", error))
+                .ok()?,
             flags: raw.flags,
             comm,
             filename,

--- a/src/agentsight/src/probes/filewrite.rs
+++ b/src/agentsight/src/probes/filewrite.rs
@@ -82,7 +82,9 @@ impl FileWriteEvent {
             pid: raw.pid,
             tid: raw.tid,
             uid: raw.uid,
-            timestamp_ns: config::ktime_to_unix_ns(raw.timestamp_ns),
+            timestamp_ns: config::ktime_to_unix_ns(raw.timestamp_ns)
+                .inspect_err(|error| config::report_clock_error("filewrite", error))
+                .ok()?,
             write_size: raw.write_size,
             comm,
             filename,

--- a/src/agentsight/src/probes/probes.rs
+++ b/src/agentsight/src/probes/probes.rs
@@ -363,6 +363,7 @@ impl Probes {
     /// A single background thread polls the shared ring buffer and dispatches
     /// events as unified Event type to the channel.
     pub fn run(&self) -> Result<ProbesPoller> {
+        crate::config::initialize_event_clock().context("failed to initialize event clock")?;
         let proc_min_sz = mem::size_of::<ProcEventHeader>();
         let procmon_event_size = mem::size_of::<ProcMonEvent>();
         let filewatch_event_size = mem::size_of::<RawFileWatchEvent>();

--- a/src/agentsight/src/probes/procmon.rs
+++ b/src/agentsight/src/probes/procmon.rs
@@ -83,14 +83,18 @@ impl Event {
                 tid: raw.tid,
                 ppid: raw.ppid,
                 uid: raw.uid,
-                timestamp_ns: config::ktime_to_unix_ns(raw.timestamp_ns),
+                timestamp_ns: config::ktime_to_unix_ns(raw.timestamp_ns)
+                    .inspect_err(|error| config::report_clock_error("procmon", error))
+                    .ok()?,
                 comm,
             }),
             PROCMON_EVENT_EXIT => Some(Event::Exit {
                 pid: raw.pid,
                 tid: raw.tid,
                 uid: raw.uid,
-                timestamp_ns: config::ktime_to_unix_ns(raw.timestamp_ns),
+                timestamp_ns: config::ktime_to_unix_ns(raw.timestamp_ns)
+                    .inspect_err(|error| config::report_clock_error("procmon", error))
+                    .ok()?,
                 comm,
                 exit_code: raw.exit_code,
             }),

--- a/src/agentsight/src/probes/proctrace.rs
+++ b/src/agentsight/src/probes/proctrace.rs
@@ -82,7 +82,9 @@ impl VariableEvent {
 
         // Convert ktime to Unix timestamp
         let mut header = *raw_header;
-        header.timestamp_ns = config::ktime_to_unix_ns(raw_header.timestamp_ns);
+        header.timestamp_ns = config::ktime_to_unix_ns(raw_header.timestamp_ns)
+            .inspect_err(|error| config::report_clock_error("proctrace", error))
+            .ok()?;
 
         match header.event_type {
             PROCTRACE_EVENT_EXEC => Self::parse_exec(&header, data),
@@ -659,6 +661,7 @@ impl ProcTrace {
     /// Spawn a background thread that polls the BPF ring buffer
     /// Uses variable-length event parsing for efficiency
     pub fn run(&self) -> Result<ProcPoller> {
+        config::initialize_event_clock().context("failed to initialize event clock")?;
         let min_sz = std::mem::size_of::<ProcEventHeader>();
         let tx = self.tx.clone();
         let stop_flag = Arc::new(AtomicBool::new(false));

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -169,7 +169,9 @@ impl SslEvent {
 
         Some(Self {
             source: u32_at(mem::offset_of!(R, source)),
-            timestamp_ns: config::ktime_to_unix_ns(u64_at(mem::offset_of!(R, timestamp_ns))),
+            timestamp_ns: config::ktime_to_unix_ns(u64_at(mem::offset_of!(R, timestamp_ns)))
+                .inspect_err(|error| config::report_clock_error("sslsniff", error))
+                .ok()?,
             delta_ns: u64_at(mem::offset_of!(R, delta_ns)),
             pid: u32_at(mem::offset_of!(R, pid)),
             tid: u32_at(mem::offset_of!(R, tid)),
@@ -590,6 +592,7 @@ impl SslSniff {
     /// Returns a [`SslPoller`] handle.  Drop it (or call [`SslPoller::stop`])
     /// to signal the poll thread to exit.
     pub fn run(&self) -> Result<SslPoller> {
+        config::initialize_event_clock().context("failed to initialize event clock")?;
         let tx = self.tx.clone();
         let stop_flag = Arc::new(AtomicBool::new(false));
         let stop_flag_inner = Arc::clone(&stop_flag);

--- a/src/agentsight/src/probes/udpdns.rs
+++ b/src/agentsight/src/probes/udpdns.rs
@@ -151,7 +151,9 @@ impl UdpDnsEvent {
             pid: raw.pid,
             tid: raw.tid,
             uid: raw.uid,
-            timestamp_ns: config::ktime_to_unix_ns(raw.timestamp_ns),
+            timestamp_ns: config::ktime_to_unix_ns(raw.timestamp_ns)
+                .inspect_err(|error| config::report_clock_error("udpdns", error))
+                .ok()?,
             comm,
             domain,
         })

--- a/src/agentsight/tests/pipeline.rs
+++ b/src/agentsight/tests/pipeline.rs
@@ -15,6 +15,94 @@ use agentsight::genai::semantic::{GenAISemanticEvent, MessagePart};
 use agentsight::parser::Parser;
 use agentsight::response_map::ResponseSessionMapper;
 
+#[test]
+fn native_event_clock_reaches_semantic_output() {
+    use agentsight::probes::sslsniff::{SslEvent, bpf::probe_SSL_data_t as Raw};
+    use std::mem::offset_of;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let wall_ns = || {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64
+    };
+    // Allow the bounded clock-sampling bracket; a container-epoch shift is far larger.
+    let start = wall_ns();
+    let parser = Parser::new();
+    let mut aggregator = Aggregator::new();
+    let analyzer = Analyzer::new();
+    let builder = GenAIBuilder::new();
+    let mapper = ResponseSessionMapper::new();
+    let cache = HashMap::new();
+    let mut result = Vec::new();
+    for (rw, payload) in [
+        (
+            1_i32,
+            common::make_openai_request_bytes("clock-fixture", "clock-check", false),
+        ),
+        (
+            0_i32,
+            common::make_openai_json_response_bytes("clock-response", "clock-fixture", "ok", 5, 3),
+        ),
+    ] {
+        let mut ts = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        // SAFETY: a valid writable timespec is supplied to the clock syscall.
+        assert_eq!(
+            unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) },
+            0
+        );
+        let ktime = ts.tv_sec as u64 * 1_000_000_000 + ts.tv_nsec as u64;
+        let header_len = offset_of!(Raw, buf);
+        let mut bytes = vec![0_u8; header_len + payload.len()];
+        for (offset, value) in [
+            (offset_of!(Raw, timestamp_ns), ktime.to_ne_bytes().to_vec()),
+            (offset_of!(Raw, pid), 5070_u32.to_ne_bytes().to_vec()),
+            (offset_of!(Raw, tid), 5070_u32.to_ne_bytes().to_vec()),
+            (
+                offset_of!(Raw, len),
+                (payload.len() as u32).to_ne_bytes().to_vec(),
+            ),
+            (
+                offset_of!(Raw, buf_size),
+                (payload.len() as u32).to_ne_bytes().to_vec(),
+            ),
+            (offset_of!(Raw, rw), rw.to_ne_bytes().to_vec()),
+            (offset_of!(Raw, ssl_ptr), 0xCAFE_u64.to_ne_bytes().to_vec()),
+            (offset_of!(Raw, comm), b"python3\0".to_vec()),
+        ] {
+            bytes[offset..offset + value.len()].copy_from_slice(&value);
+        }
+        bytes[header_len..].copy_from_slice(&payload);
+        let ssl = SslEvent::from_bytes(&bytes).expect("native clock must decode");
+        assert!(ssl.timestamp_ns >= start.saturating_sub(5_000_000));
+        for aggregated in aggregator.process_result(parser.parse_event(Event::Ssl(ssl))) {
+            let analyzed = analyzer.analyze_aggregated(&aggregated);
+            result.extend(
+                builder
+                    .build_with_pending(&analyzed, &mapper, &cache)
+                    .0
+                    .events,
+            );
+        }
+    }
+    let end = wall_ns();
+    let calls: Vec<_> = result
+        .iter()
+        .filter_map(|e| match e {
+            GenAISemanticEvent::LLMCall(call) => Some(call),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(calls.len(), 1);
+    assert!(calls[0].start_timestamp_ns >= start.saturating_sub(5_000_000));
+    assert!(calls[0].end_timestamp_ns <= end + 5_000_000);
+    assert!(calls[0].end_timestamp_ns >= calls[0].start_timestamp_ns);
+}
+
 /// Run a sequence of SslEvents through the full pipeline, return any GenAI events produced.
 fn run_pipeline(ssl_events: Vec<(u32, u64, i32, Vec<u8>, &str)>) -> Vec<GenAISemanticEvent> {
     let parser = Parser::new();


### PR DESCRIPTION
## Why

AgentSight converts BPF monotonic timestamps using an offset derived from
`/proc/uptime`. When container-visible uptime has a different origin from the
kernel monotonic clock, newly captured events can be dated months into the future.

## What changed

Replace the uptime-based offset with paired `CLOCK_REALTIME` /
`CLOCK_MONOTONIC` samples, translating time-namespace offsets back to the host
clock. A single process-wide worker refreshes a shared snapshot once per second;
all three probe polling entrypoints initialize it before registering callbacks,
so event conversion performs no procfs access or recalibration. Sampling runs
outside the snapshot lock, failed refreshes invalidate the cache, and unavailable
or expired snapshots are rejected with rate-limited error reporting. Add clock
regressions, cache lifecycle and concurrent-burst tests, and SSL-to-GenAI coverage.

## Related issue

Closes #3121

## User / Agent impact

BPF-derived event timestamps align with wall time even when container uptime
differs from host monotonic time. Conversion failures are reported and their
events are discarded rather than persisted with fabricated timestamps.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The Rust API `ktime_to_unix_ns` now returns
`Result<u64, ClockConversionError>`; callers must handle conversion failure.
All in-repository callers are updated. No BPF producer, storage schema, CLI option
or deployment privilege changes are included.

Each conversion reads a snapshot under a short read lock and reads realtime
to validate its age. Namespace metadata and calibration are refreshed by one
worker that lasts for the process, including across poller restarts. Standalone
Rust callers initialize the worker lazily on the first conversion.

Snapshots outside the zero-to-five-second realtime age window are rejected.
Wall-clock steps within that window may affect timestamps until the next
refresh; historical steps while events are queued cannot be reconstructed from
a monotonic timestamp alone. Existing persisted records are not rewritten.

## Validation

Validated on Linux against base `f8b38d115dfd4d3c7a078d8b317ab3a8b29c960e`:

- `cargo fmt --all -- --check`: passed.
- `cargo test --locked -p agentsight`: 1,903 passed, 0 failed, 38 ignored,
  including existing doctest ignores.
- `cargo clippy --locked -p agentsight --all-targets -- -D warnings`: passed.
- `cargo doc --locked --workspace --no-deps`: passed with existing rustdoc warnings.
- `cargo test --locked -p agentsight --test pipeline native_event_clock_reaches_semantic_output -- --exact`:
  passed as part of the complete component test run.
- Local and tested versions of all ten changed files have matching SHA-256 hashes.

Additional validation of the calibration cache:

- Four threads perform 400,000 calls through `ktime_to_unix_ns`; instrumentation
  confirms zero calibration-sampler calls on the conversion threads.
- Tests cover background refresh without events, failed-refresh invalidation,
  expiry, clock steps, recovery, and overflow.
- An isolated Linux microbenchmark of this conversion code, compiled with
  `-C opt-level=3`, measured 22,714.8 ns/event for the previous per-event sampling
  path (10,000 iterations) and 42.8 ns/event for the initialized cache path
  (1,000,000 iterations), approximately 530x faster in this run. This measures
  conversion cost only; it is not an end-to-end capture throughput or loss test.

Known full-workspace failures from the earlier validation, accepted for submitting
this focused PR (the affected vendored code is unchanged):

- `cargo test --locked --workspace`: the unchanged vendored
  `actplane-ifc-compiler` corpus tests cannot find `test/policies`.
- `cargo clippy --locked --workspace --all-targets -- -D warnings`: existing
  vendored ActPlane lint findings, including `collapsible_if`, `type_complexity`,
  `needless_borrows_for_generic_args`, `len_zero`, and `nonminimal_bool`.

Positive and negative namespace offsets are covered by unit tests. Additional
live time-namespace testing was blocked by `unshare --time: Operation not permitted`;
no successful live nonzero-namespace validation is claimed. This PR does not claim
new deployment or real-model acceptance.

## Documentation and rollback

The conversion API rustdoc documents errors and the queued-event clock-step
limitation. Rust callers must migrate to the fallible return type. Reverting this
commit restores the previous API and behavior, including the original timestamp
bug. Correcting historical data requires a separately reviewed migration; a blanket
offset must not be applied to fields that already use correct wall-clock time.
