### PR TITLE
fix(anolisa): record post-hook file digests

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
@@ -1337,6 +1337,22 @@ impl OwnedOps for RawInstallOps<'_> {
                 write.label()
             )));
         }
+        let hooks = self.hooks()?;
+        if !hooks.post_install.is_empty() || !hooks.post_enable.is_empty() {
+            // Installation hooks may rewrite payload bytes. Capture their final
+            // content while retaining the declared modes and symlink referents.
+            for file in &mut self.placed {
+                if file.referent.is_none() {
+                    file.sha256 =
+                        installed_file_digest(self.layout, &file.path).map_err(|err| {
+                            OwnedOpError(format!(
+                                "failed to record post-hook digest for {}: {err}",
+                                file.path.display()
+                            ))
+                        })?;
+                }
+            }
+        }
         let prepared = self.prepared()?;
         let manifest_path = self.manifest_path.clone().ok_or_else(|| {
             OwnedOpError("internal: record commit ran before files were placed".to_string())
@@ -1491,6 +1507,38 @@ fn owned_file_rows(
         capabilities: Vec::new(),
     });
     files
+}
+
+fn installed_file_digest(layout: &FsLayout, path: &Path) -> std::io::Result<String> {
+    use sha2::{Digest, Sha256};
+    use std::io::{Error, Read};
+
+    validate_owned_path(layout, path).map_err(Error::other)?;
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        // Refuse replacement links and avoid blocking on a replacement FIFO.
+        options.custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK);
+    }
+    let file = options.open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(Error::other("installed path is not a regular file"));
+    }
+    let mut hasher = Sha256::new();
+    // Bound the read by the observed size, as the integrity probe does.
+    let bytes = std::io::copy(
+        &mut file.take(metadata.len().saturating_add(1)),
+        &mut hasher,
+    )?;
+    if bytes != metadata.len() {
+        return Err(Error::other(
+            "installed file changed size while recording its digest",
+        ));
+    }
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 fn expected_mode_for_path(path: &Path, contract_files: &[ResolvedInstallFile]) -> Option<String> {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
@@ -889,34 +889,104 @@ fn install_raw_end_to_end_records_declared_service() {
 
 #[test]
 #[cfg(unix)]
-fn install_raw_runs_post_install_hook() {
-    let tmp = tempdir().expect("tmpdir");
-    let prefix = tmp.path().join("sys");
-    let sentinel = tmp.path().join("post-install.ran");
-    let body = format!("#!/bin/sh\ntouch {}\n", sentinel.display());
-    let repo_url = write_local_repo_component_with_hook(
-        &tmp.path().join("repo"),
-        "agentsight",
-        "0.2.0",
-        "post_install",
-        false,
-        &body,
-    );
+fn install_raw_records_post_hook_bytes_and_detects_later_drift() {
+    use anolisa_core::integrity::{IntegrityStatus, check_owned_file};
 
-    let mut a = args("agentsight");
-    a.repo = Some(repo_url);
-    handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix.clone())))
-        .expect("install with a post_install hook must succeed");
+    for phase in ["post_install", "post_enable"] {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().join("sys");
+        let layout = FsLayout::system(Some(prefix.clone()));
+        let binary = layout.bin_dir.join("agentsight");
+        let body = format!("#!/bin/sh\necho '# hook edit' >> '{}'\n", binary.display());
+        let repo_url = write_local_repo_component_with_hook(
+            &tmp.path().join("repo"),
+            "agentsight",
+            "0.2.0",
+            phase,
+            true,
+            &body,
+        );
+        let mut a = args("agentsight");
+        a.repo = Some(repo_url);
+        handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix)))
+            .expect("install with a modifying hook must succeed");
 
-    let layout = FsLayout::system(Some(prefix));
-    assert!(
-        layout.bin_dir.join("agentsight").exists(),
-        "binary installed"
-    );
-    assert!(
-        sentinel.exists(),
-        "post_install hook must run after files are laid down"
-    );
+        let bytes = std::fs::read(&binary).expect("installed binary");
+        assert!(
+            bytes.ends_with(b"# hook edit\n"),
+            "{phase} must modify the file"
+        );
+        let store = load_v5_store(&layout);
+        let artifact = owned_artifact(
+            store
+                .find(ObjectKind::Component, "agentsight")
+                .expect("record"),
+        );
+        for file in &artifact.files {
+            assert_eq!(
+                check_owned_file(&layout, file),
+                IntegrityStatus::Ok,
+                "{phase}: {}",
+                file.path.display()
+            );
+        }
+
+        std::fs::write(&binary, b"external edit").expect("modify installed binary");
+        let file = artifact
+            .files
+            .iter()
+            .find(|file| file.path == binary)
+            .expect("binary record");
+        assert!(matches!(
+            check_owned_file(&layout, file),
+            IntegrityStatus::ShaMismatch { .. }
+        ));
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn install_raw_post_hook_digest_failure_rolls_back() {
+    for replacement in ["", "ln -s \"$0\"", "mkfifo"] {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().join("sys");
+        let layout = FsLayout::system(Some(prefix.clone()));
+        let binary = layout.bin_dir.join("agentsight");
+        let replace = if replacement.is_empty() {
+            String::new()
+        } else {
+            format!("{replacement} '{}'\n", binary.display())
+        };
+        let body = format!("#!/bin/sh\nset -e\nrm '{}'\n{replace}", binary.display());
+        let repo_url = write_local_repo_component_with_hook(
+            &tmp.path().join("repo"),
+            "agentsight",
+            "0.2.0",
+            "post_install",
+            true,
+            &body,
+        );
+        let mut a = args("agentsight");
+        a.repo = Some(repo_url);
+        let err = handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix)))
+            .expect_err("a removed or non-regular payload must abort record commit");
+        assert!(
+            err.reason().contains("failed to record post-hook digest"),
+            "{err}"
+        );
+        assert!(
+            std::fs::symlink_metadata(&binary).is_err(),
+            "rollback removes the replacement"
+        );
+        let snapshot = common::installed_component_manifest_path(&layout, "agentsight", COMMAND)
+            .expect("manifest path");
+        assert!(!snapshot.exists(), "rollback removes the manifest snapshot");
+        assert!(
+            load_v5_store(&layout)
+                .find(ObjectKind::Component, "agentsight")
+                .is_none()
+        );
+    }
 }
 
 #[test]

--- a/src/anolisa/docs/COMPONENT_CONTRACT.md
+++ b/src/anolisa/docs/COMPONENT_CONTRACT.md
@@ -176,6 +176,20 @@ Display behavior:
 - `--dry-run` previews the notices that a real operation would show, labeled
   as a preview; nothing is executed.
 
+## Installation Hook Integrity
+
+On a fresh raw install, `post_install` and `post_enable` hooks may rewrite
+regular files placed by the component layout. The installed digest records
+the content after those hooks, so later content changes remain detectable.
+Declared permissions, capabilities, and symlink referents still apply.
+A removed regular file or one replaced by a symlink or special file
+prevents the digest from being recorded and rolls back the install.
+Files created by hooks outside the layout are not added to the ownership record.
+
+Raw repair and update restore the package payload (including declared content
+rendering); they do not replay installation hooks. Use `render` for layout-path
+substitution that must also be reproduced by repair and update.
+
 ## Content Rendering (`render`)
 
 A `[[component.layout.files]]` entry may request that ANOLISA render the


### PR DESCRIPTION
## Why

A successful raw install can immediately report `sha256_mismatch` when its
`post_install` hook rewrites a placed file: the record still contains the
placement-time digest. The same gap affects `post_enable` during installation.

## What changed

Fresh raw installs with either hook phase now capture regular-file digests
after the installation hooks and before committing the ownership record.
The read streams through the existing SHA-256 dependency, validates owned
paths, refuses replacement symlinks and special files, and fails if the file
changes size during capture. Digest errors use the existing install rollback.
Installs without these hooks retain their placement-time digests.

## Related issue

closes #3136

Also addresses the original report in #2270.

## User / Agent impact

Hook-rewritten payloads pass subsequent integrity checks, while later external
content changes still report drift. Permissions, capabilities, declared symlink
referents, and the source manifest snapshot retain their existing contracts;
hook-generated files outside the layout are not automatically claimed.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

Hook-bearing fresh installs incur one extra streaming read of each installed
regular file, with constant memory usage. There is no state schema change and
existing records are not automatically rebaselined. Raw repair/update retain
their current package-replay behavior and do not execute installation hooks;
this PR does not extend those lifecycle contracts.

## Validation

Linux aarch64, Rust 1.97.1:

- The new modifying-hook regression failed with `ShaMismatch` before the fix
  and passes afterward for both `post_install` and `post_enable`.
- Regression coverage verifies later external drift and install rollback when
  a hook removes a regular payload or replaces it with a symlink or FIFO.
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 2480 passed, 1 ignored, 0 failed.
- `cargo check --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`

## Documentation and rollback

Updated `src/anolisa/docs/COMPONENT_CONTRACT.md` with the installation-hook
integrity behavior and repair/update boundary. Roll back by reverting this
commit; no state migration is required.
