### PR TITLE
feat(anolisa): honor editable config files

### DIFF
--- a/docs/user-guide/en/user-entrypoint/anolisa-cli.md
+++ b/docs/user-guide/en/user-entrypoint/anolisa-cli.md
@@ -122,6 +122,16 @@ system root. It qualifies system repair suggestions with
 that root. `--fix` is reserved in this release; follow the reported `fix_plan`
 explicitly.
 
+For raw installations, `status` and `doctor` allow content edits to files
+declared as `type = "config"`. Missing files, unsafe paths, unexpected symlinks,
+and permission or capability drift still fail checks; ordinary data and
+executable files still undergo SHA-256 verification. Older installation records
+recover unambiguous config declarations from their saved component manifest in
+memory. If overlapping directory declarations mix config and immutable kinds,
+legacy files retain digest checking because their source mapping is unknown.
+Back up edited configs and reinstall the component to record accurate kinds.
+Diagnostics do not rewrite state.
+
 ### restart
 
 Restart services recorded for an installation in the selected scope:

--- a/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
+++ b/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
@@ -114,6 +114,13 @@ system root 时，它会在修复建议中补全
 `sudo anolisa --install-mode system`。`--fix` 在当前版本中仍为保留参数；请
 显式执行输出的 `fix_plan`。
 
+对于 raw 安装，`status` 和 `doctor` 允许修改声明为 `type = "config"` 的文件
+内容。文件缺失、不安全路径、意外符号链接、权限或 capability 偏移仍会检查失败；
+普通 data 和 executable 文件仍需通过 SHA-256 校验。旧安装记录会从保存的
+component manifest 在内存中恢复无歧义的 config 声明。若重叠的目录声明混合了
+config 和不可变类型，旧文件因缺少来源映射而继续进行摘要校验。
+请先备份编辑过的配置，再重新安装组件以记录准确类型。诊断不会改写状态文件。
+
 ### restart
 
 重启所选 scope 安装记录中的 service：

--- a/src/anolisa/README.md
+++ b/src/anolisa/README.md
@@ -39,6 +39,9 @@ anolisa update all
 | `adopt` | Record an existing system RPM as adopted without default removal authority |
 | `forget` | Drop state record without package operations |
 
+`status` and `doctor` allow content edits to raw-installed `type = "config"`
+files while continuing to check their presence, permissions, and path safety.
+
 ### Tier 2 — Management
 
 | Command | Description |

--- a/src/anolisa/README_zh.md
+++ b/src/anolisa/README_zh.md
@@ -39,6 +39,9 @@ anolisa update all
 | `adopt` | 将已有 system RPM 记录为已采纳安装 |
 | `forget` | 仅删除状态记录，不执行包操作 |
 
+`status` 和 `doctor` 允许修改 raw 安装中 `type = "config"` 文件的内容，
+同时继续检查文件是否存在、权限和路径安全。
+
 ### 二级命令 — 管理
 
 | 命令 | 说明 |

--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -861,7 +861,7 @@ pub fn migrate_v3_symlinks(store: &mut StateStore, layout: &FsLayout) -> usize {
     migrated
 }
 
-/// Enrich owned-file rows written before permission and capability metadata
+/// Enrich owned-file rows written before config, permission, and capability metadata
 /// was persisted in v5 state.
 ///
 /// The exact installed component manifest is the authority: explicit file
@@ -881,6 +881,8 @@ pub fn hydrate_owned_file_contracts(store: &mut StateStore, layout: &FsLayout) -
 
     #[derive(Default)]
     struct FileContract {
+        // None distinguishes capability-only entries from exact layout mappings.
+        config: Option<bool>,
         mode: Option<String>,
         capabilities: Vec<String>,
     }
@@ -920,17 +922,12 @@ pub fn hydrate_owned_file_contracts(store: &mut StateStore, layout: &FsLayout) -
         };
 
         let mut contracts: HashMap<PathBuf, FileContract> = HashMap::new();
-        let mut directory_modes = Vec::new();
+        let mut directory_contracts = Vec::new();
         for spec in &manifest.install.files {
             if spec.kind == FileKind::Symlink {
                 continue;
             }
-            let Some(raw_mode) = spec.mode.as_deref() else {
-                continue;
-            };
-            let Some(mode) = normalized_mode(raw_mode) else {
-                continue;
-            };
+            let mode = spec.mode.as_deref().and_then(normalized_mode);
             let Some(template) = spec.install_path() else {
                 continue;
             };
@@ -947,9 +944,11 @@ pub fn hydrate_owned_file_contracts(store: &mut StateStore, layout: &FsLayout) -
                 .as_deref()
                 .is_some_and(|source| source.ends_with('/'))
             {
-                directory_modes.push((dest, mode));
+                directory_contracts.push((dest, mode, spec.kind == FileKind::Config));
             } else {
-                contracts.entry(dest).or_default().mode = Some(mode);
+                let contract = contracts.entry(dest).or_default();
+                contract.mode = mode;
+                contract.config = Some(spec.kind == FileKind::Config);
             }
         }
         for spec in &manifest.install.capabilities {
@@ -989,6 +988,10 @@ pub fn hydrate_owned_file_contracts(store: &mut StateStore, layout: &FsLayout) -
                 continue;
             }
             if let Some(contract) = contracts.get(&file.path) {
+                if contract.config == Some(true) && file.kind == anolisa_core::OwnedFileKind::File {
+                    file.kind = anolisa_core::OwnedFileKind::Config;
+                    hydrated += 1;
+                }
                 if file.mode.is_none()
                     && let Some(mode) = &contract.mode
                 {
@@ -1000,13 +1003,32 @@ pub fn hydrate_owned_file_contracts(store: &mut StateStore, layout: &FsLayout) -
                     hydrated += 1;
                 }
             }
-            if file.mode.is_none()
-                && let Some((_, mode)) = directory_modes
-                    .iter()
-                    .find(|(directory, _)| file.path.starts_with(directory))
-            {
-                file.mode = Some(mode.clone());
-                hydrated += 1;
+            let mut directory_matches = directory_contracts
+                .iter()
+                .filter(|(directory, _, _)| file.path.starts_with(directory));
+            if let Some((_, mode, config)) = directory_matches.next().filter(|_| {
+                contracts
+                    .get(&file.path)
+                    .is_none_or(|contract| contract.config.is_none())
+            }) {
+                // Legacy rows lack archive provenance. Only unanimous directory
+                // contracts can safely exempt content or reconstruct permissions.
+                let mut config = *config;
+                let mut mode = mode.as_ref();
+                for (_, other_mode, other_config) in directory_matches {
+                    config &= *other_config;
+                    if mode != other_mode.as_ref() {
+                        mode = None;
+                    }
+                }
+                if file.mode.is_none() && mode.is_some() {
+                    file.mode = mode.cloned();
+                    hydrated += 1;
+                }
+                if config && file.kind == anolisa_core::OwnedFileKind::File {
+                    file.kind = anolisa_core::OwnedFileKind::Config;
+                    hydrated += 1;
+                }
             }
         }
     }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
@@ -31,8 +31,8 @@ use anolisa_core::state::{FileOwner, ObjectKind, OwnedFile, OwnedFileKind, Servi
 use anolisa_core::state_store::StateStore;
 use anolisa_core::transaction::restore_backup_file;
 use anolisa_core::{
-    CapabilityRequest, FileKind, ResolvedInstallFile, ResolvedLifecycleHooks, ServiceActivation,
-    ServiceRequest, ServiceRunOutcome, ServiceScope, apply_capabilities, apply_services,
+    CapabilityRequest, FileKind, ResolvedLifecycleHooks, ServiceActivation, ServiceRequest,
+    ServiceRunOutcome, ServiceScope, apply_capabilities, apply_services,
     capability_for_install_mode, deactivate_services, run_hooks, service_for_install_mode,
     user_service_for_install_mode,
 };
@@ -67,7 +67,7 @@ fn rollback_capability_requests(
         .iter()
         .filter(|file| {
             file.owner == FileOwner::Anolisa
-                && file.kind == OwnedFileKind::File
+                && file.kind != OwnedFileKind::Symlink
                 && !file.capabilities.is_empty()
                 && backups.iter().any(|backup| backup.dest == file.path)
         })
@@ -440,7 +440,6 @@ impl OwnedOps for RawReplayOps<'_> {
                 &self.placed,
                 &manifest_path,
                 &prepared.manifest_toml,
-                &prepared.files,
                 &self.applied_capabilities,
             ),
             services: self.service_refs(&prepared.services),
@@ -1373,7 +1372,6 @@ impl OwnedOps for RawInstallOps<'_> {
                 &self.placed,
                 &manifest_path,
                 &prepared.manifest_toml,
-                &prepared.files,
                 &self.applied_capabilities,
             ),
             services: prepared
@@ -1470,7 +1468,6 @@ fn owned_file_rows(
     placed: &[InstalledFile],
     manifest_path: &Path,
     manifest_toml: &str,
-    contract_files: &[ResolvedInstallFile],
     applied_capabilities: &[CapabilityRequest],
 ) -> Vec<OwnedFile> {
     let mut files: Vec<OwnedFile> = placed
@@ -1485,15 +1482,13 @@ fn owned_file_rows(
             },
             kind: if f.referent.is_some() {
                 OwnedFileKind::Symlink
+            } else if f.kind == FileKind::Config {
+                OwnedFileKind::Config
             } else {
                 OwnedFileKind::File
             },
             referent: f.referent.clone(),
-            mode: expected_mode_for_path(&f.path, contract_files).or_else(|| {
-                (f.referent.is_none())
-                    .then(|| recorded_mode(&f.path))
-                    .flatten()
-            }),
+            mode: expected_mode(f),
             capabilities: capabilities_for_path(&f.path, applied_capabilities),
         })
         .collect();
@@ -1541,36 +1536,16 @@ fn installed_file_digest(layout: &FsLayout, path: &Path) -> std::io::Result<Stri
     Ok(format!("{:x}", hasher.finalize()))
 }
 
-fn expected_mode_for_path(path: &Path, contract_files: &[ResolvedInstallFile]) -> Option<String> {
-    contract_files
-        .iter()
-        .filter(|file| file.kind != FileKind::Symlink)
-        .find(|file| {
-            file.dest == path
-                || (file
-                    .source
-                    .as_deref()
-                    .is_some_and(|source| source.ends_with('/'))
-                    && path.starts_with(&file.dest))
-        })
-        .and_then(|file| {
-            let raw = match file.mode.as_deref() {
-                Some(raw) => raw,
-                None if file
-                    .source
-                    .as_deref()
-                    .is_some_and(|source| source.ends_with('/')) =>
-                {
-                    return None;
-                }
-                None => "0755",
-            };
-            let octal = raw.trim().strip_prefix("0o").unwrap_or(raw.trim());
-            u32::from_str_radix(octal, 8)
-                .ok()
-                .filter(|mode| *mode <= 0o7777)
-                .map(|mode| format!("{mode:04o}"))
-        })
+fn expected_mode(file: &InstalledFile) -> Option<String> {
+    if file.referent.is_some() {
+        return None;
+    }
+    let raw = file.mode.as_deref().unwrap_or("0755");
+    let octal = raw.trim().strip_prefix("0o").unwrap_or(raw.trim());
+    u32::from_str_radix(octal, 8)
+        .ok()
+        .filter(|mode| *mode <= 0o7777)
+        .map(|mode| format!("{mode:04o}"))
 }
 
 #[cfg(unix)]
@@ -1672,6 +1647,8 @@ mod tests {
         fs::write(&manifest, b"[component]\nname = \"tool\"\n").expect("manifest");
         let placed = vec![InstalledFile {
             path: binary.clone(),
+            kind: FileKind::Executable,
+            mode: Some("0755".into()),
             sha256: "deadbeef".to_string(),
             referent: None,
         }];
@@ -1685,13 +1662,6 @@ mod tests {
             &placed,
             &manifest,
             "[component]\nname = \"tool\"\n",
-            &[ResolvedInstallFile {
-                source: Some("bin/tool".to_string()),
-                dest: binary.clone(),
-                mode: Some("0755".to_string()),
-                kind: FileKind::Executable,
-                render: None,
-            }],
             &capabilities,
         );
         let row = rows
@@ -1728,11 +1698,15 @@ mod tests {
         let placed = vec![
             InstalledFile {
                 path: script.clone(),
+                kind: FileKind::Data,
+                mode: Some("0755".into()),
                 sha256: sha256_hex(b"#!/usr/bin/env python3\n"),
                 referent: None,
             },
             InstalledFile {
                 path: hooks.clone(),
+                kind: FileKind::Data,
+                mode: Some("0644".into()),
                 sha256: sha256_hex(br#"{"hooks":{}}"#),
                 referent: None,
             },
@@ -1742,13 +1716,6 @@ mod tests {
             &placed,
             &manifest,
             "[component]\nname = \"tokenless\"\n",
-            &[ResolvedInstallFile {
-                source: Some("adapters/tokenless/codex/".to_string()),
-                dest: adapter_root,
-                mode: None,
-                kind: FileKind::Data,
-                render: None,
-            }],
             &[],
         );
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
@@ -451,6 +451,176 @@ sha256 = "{sha}"
 }
 
 #[test]
+fn config_edits_pass_doctor_but_data_edits_fail() {
+    use crate::commands::tier1::doctor::{DoctorArgs, handle as doctor};
+    use sha2::{Digest, Sha256};
+
+    for reverse in [false, true] {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().join("sys");
+        let repo = tmp.path().join("repo");
+        let repo_url = write_local_repo(&repo);
+        let manifest = format!(
+            "{}\n{}",
+            component_manifest_toml("agentsight", "0.2.0", &["system"]),
+            r#"[[component.layout.files]]
+source = "share/settings.toml"
+target = "{datadir}/components/agentsight/settings.toml"
+mode = "0644"
+type = "config"
+
+[[component.layout.files]]
+source = "conf.d/"
+target = "{datadir}/components/agentsight/conf.d"
+type = "config"
+
+[[component.layout.files]]
+source = "data/"
+target = "{datadir}/components/agentsight"
+mode = "0644"
+
+[[component.layout.files]]
+source = "bin/tool"
+target = "{datadir}/components/agentsight/conf.d/tool"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "immutable/"
+target = "{datadir}/components/agentsight/conf.d/assets"
+mode = "0644"
+
+[[component.layout.files]]
+source = "shared-data/"
+target = "{datadir}/components/agentsight/shared"
+mode = "0600"
+
+[[component.layout.files]]
+source = "shared-config/"
+target = "{datadir}/components/agentsight/shared"
+mode = "0644"
+type = "config"
+
+[[component.layout.files]]
+source = "unambiguous/"
+target = "{datadir}/isolated-config"
+type = "config"
+"#
+        );
+        let mut manifest: toml::Value = toml::from_str(&manifest).expect("manifest");
+        if reverse {
+            manifest["component"]["layout"]["files"]
+                .as_array_mut()
+                .expect("files")
+                .reverse();
+        }
+        let manifest = toml::to_string(&manifest).expect("serialize manifest");
+        let artifact = build_tar_gz(&[
+            (".anolisa/component.toml", manifest.as_bytes()),
+            ("bin/agentsight", b"#!/bin/sh\necho agentsight\n"),
+            ("share/settings.toml", b"enabled = true\n"),
+            ("conf.d/extra.toml", b"enabled = true\n"),
+            ("data/plain.dat", b"immutable\n"),
+            ("data/conf.d/from-data.dat", b"immutable\n"),
+            ("shared-data/plain.dat", b"immutable\n"),
+            ("shared-config/settings.toml", b"enabled = true\n"),
+            ("unambiguous/settings.toml", b"enabled = true\n"),
+            ("bin/tool", b"#!/bin/sh\necho tool\n"),
+            ("immutable/plain.dat", b"immutable\n"),
+        ]);
+        std::fs::write(repo.join("v1/agentsight.tar.gz"), &artifact).expect("artifact");
+        let index_path = repo.join("v1/index.toml");
+        let mut index: toml::Value =
+            toml::from_str(&std::fs::read_to_string(&index_path).expect("index")).expect("parse");
+        index["entries"][0]["sha256"] = format!("{:x}", Sha256::digest(&artifact)).into();
+        std::fs::write(index_path, toml::to_string(&index).expect("serialize")).expect("index");
+
+        let ctx = ctx_with_prefix(false, Some(prefix.clone()));
+        let mut a = args("agentsight");
+        a.repo = Some(repo_url);
+        handle_with_fake_rpm(a, &ctx).expect("install");
+        let layout = FsLayout::system(Some(prefix));
+        let files_dir = layout.datadir.join("components/agentsight");
+        std::fs::write(
+            layout.datadir.join("isolated-config/settings.toml"),
+            b"enabled = false\n",
+        )
+        .expect("edit unambiguous directory config");
+        let store = load_v5_store(&layout);
+        let installed = store
+            .find(ObjectKind::Component, "agentsight")
+            .expect("installed");
+        for name in ["settings.toml", "conf.d/extra.toml", "shared/settings.toml"] {
+            let row = owned_artifact(installed)
+                .files
+                .iter()
+                .find(|file| file.path == files_dir.join(name))
+                .expect("config row");
+            assert_eq!(row.kind, anolisa_core::OwnedFileKind::Config);
+            assert!(row.sha256.is_some(), "retain the install-time digest");
+            std::fs::write(&row.path, b"enabled = false\n").expect("edit config");
+        }
+        for name in [
+            "plain.dat",
+            "conf.d/tool",
+            "conf.d/assets/plain.dat",
+            "conf.d/from-data.dat",
+            "shared/plain.dat",
+        ] {
+            let row = owned_artifact(installed)
+                .files
+                .iter()
+                .find(|file| file.path == files_dir.join(name))
+                .expect("immutable row");
+            assert_eq!(row.kind, anolisa_core::OwnedFileKind::File);
+        }
+        let diagnose = || {
+            doctor(
+                DoctorArgs {
+                    component: Some("agentsight".into()),
+                    fix: false,
+                },
+                &ctx,
+            )
+        };
+        diagnose().expect("operator config edits must stay healthy");
+
+        // Legacy directory rows have no source provenance; ambiguous kinds must
+        // retain hashing. Exact config mappings remain safe to recover.
+        for name in ["conf.d/extra.toml", "shared/settings.toml"] {
+            std::fs::write(files_dir.join(name), b"enabled = true\n").expect("restore config");
+        }
+        let state_path = layout.state_dir.join("installed.toml");
+        let legacy = std::fs::read_to_string(&state_path)
+            .expect("state")
+            .replace("kind = \"config\"\n", "");
+        std::fs::write(&state_path, &legacy).expect("legacy state");
+        diagnose().expect("exact legacy config edits must stay healthy");
+        assert_eq!(std::fs::read_to_string(&state_path).expect("state"), legacy);
+
+        for name in [
+            "plain.dat",
+            "conf.d/tool",
+            "conf.d/assets/plain.dat",
+            "conf.d/from-data.dat",
+            "shared/plain.dat",
+            "conf.d/extra.toml",
+            "shared/settings.toml",
+        ] {
+            let path = files_dir.join(name);
+            let original = std::fs::read(&path).expect("read original");
+            std::fs::write(&path, b"tampered\n").expect("tamper hash-checked file");
+            assert!(
+                matches!(diagnose(), Err(CliError::DiagnosticsFound { .. })),
+                "{name}"
+            );
+            std::fs::write(&path, original).expect("restore original");
+            diagnose().expect("restored file is healthy");
+        }
+    }
+}
+
+#[test]
 fn install_raw_end_to_end_from_local_repo() {
     let tmp = tempdir().expect("tmpdir");
     let prefix = tmp.path().join("sys");

--- a/src/anolisa/crates/anolisa-core/src/adapter/managed_files.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/managed_files.rs
@@ -79,7 +79,7 @@ pub fn inventory_for_installation(
             .iter()
             .filter(|file| file.owner == FileOwner::Anolisa)
             .map(|file| match file.kind {
-                OwnedFileKind::File => ManagedFile {
+                OwnedFileKind::File | OwnedFileKind::Config => ManagedFile {
                     path: file.path.clone(),
                     kind: ManagedInventoryKind::File,
                     sha256: file.sha256.clone(),

--- a/src/anolisa/crates/anolisa-core/src/install_runner.rs
+++ b/src/anolisa/crates/anolisa-core/src/install_runner.rs
@@ -56,6 +56,10 @@ pub const SUPPORTED_ARTIFACT_TYPES: &[&str] = &["tar_gz"];
 pub struct InstalledFile {
     /// Absolute destination path actually written.
     pub path: PathBuf,
+    /// Role from the mapping that supplied this file, before source provenance is lost.
+    pub kind: FileKind,
+    /// Mode applied from that mapping or archive entry; `None` uses the runner default.
+    pub mode: Option<String>,
     /// Lowercase-hex sha256 of the installed bytes. Empty for symlink
     /// entries (they record a [`referent`](Self::referent) instead).
     pub sha256: String,
@@ -859,12 +863,16 @@ impl PreparedFileSet {
             .iter()
             .map(|staged| InstalledFile {
                 path: staged.file.dest.clone(),
+                kind: staged.file.kind,
+                mode: staged.file.mode.clone(),
                 sha256: staged.sha256.clone(),
                 referent: None,
             })
             .collect::<Vec<_>>();
         files.extend(self.links.iter().map(|link| InstalledFile {
             path: link.dest.clone(),
+            kind: FileKind::Symlink,
+            mode: None,
             sha256: String::new(),
             referent: Some(link.referent.clone()),
         }));
@@ -1385,6 +1393,8 @@ fn create_symlink(link: &PreparedSymlink) -> Result<InstalledFile, InstallError>
     })?;
     Ok(InstalledFile {
         path: link.dest.clone(),
+        kind: FileKind::Symlink,
+        mode: None,
         sha256: String::new(),
         referent: Some(link.referent.clone()),
     })
@@ -1406,9 +1416,8 @@ fn place_staged_file(staged: &PreparedRegularFile) -> Result<InstalledFile, Inst
         source,
     })?;
     write_dest_atomic(
-        &staged.file.dest,
+        &staged.file,
         &mut source,
-        staged.file.mode.as_deref(),
         StagedContent {
             sha256: &staged.sha256,
             size: staged.size,
@@ -1428,13 +1437,13 @@ struct StagedContent<'a> {
 /// during preparation; a mismatch removes the temporary sibling and fails
 /// before anything is renamed over the destination.
 fn write_dest_atomic(
-    dest: &Path,
+    file: &ResolvedInstallFile,
     source: &mut impl Read,
-    mode: Option<&str>,
     expected: StagedContent<'_>,
 ) -> Result<InstalledFile, InstallError> {
+    let dest = &file.dest;
     #[cfg(unix)]
-    let parsed_mode = parse_unix_mode(mode, dest)?;
+    let parsed_mode = parse_unix_mode(file.mode.as_deref(), dest)?;
 
     if let Some(parent) = dest.parent() {
         fs::create_dir_all(parent).map_err(|source| InstallError::Io {
@@ -1481,6 +1490,8 @@ fn write_dest_atomic(
     })?;
     Ok(InstalledFile {
         path: dest.to_path_buf(),
+        kind: file.kind,
+        mode: file.mode.clone(),
         sha256: sha,
         referent: None,
     })

--- a/src/anolisa/crates/anolisa-core/src/integrity.rs
+++ b/src/anolisa/crates/anolisa-core/src/integrity.rs
@@ -71,7 +71,7 @@ const MAX_PROBE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 /// < CapabilityMismatch < ShaMismatch`.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrityStatus {
-    /// File exists and sha256 matches the recorded value.
+    /// File satisfies its contract; config content is intentionally mutable.
     Ok,
     /// Owner is not ANOLISA-managed — we deliberately don't probe.
     Skipped,
@@ -199,10 +199,11 @@ impl IntegrityStatus {
 /// stat, follow, or read that path.
 ///
 /// Returns [`IntegrityStatus::Skipped`] for non-ANOLISA-owned entries so
-/// the caller never accidentally hashes a third-party config file. For
-/// ANOLISA-owned entries with no recorded sha256 it returns
+/// the caller never accidentally hashes a third-party config file.
+/// Immutable ANOLISA-owned entries with no recorded sha256 return
 /// [`IntegrityStatus::Unverified`] rather than `Ok` — the absence of a
 /// recorded hash is a degradation signal, not a clean state.
+/// Config entries skip hashing after path, type, mode, and capability checks.
 pub fn check_owned_file(layout: &FsLayout, file: &OwnedFile) -> IntegrityStatus {
     if file.owner != FileOwner::Anolisa {
         return IntegrityStatus::Skipped;
@@ -273,6 +274,10 @@ pub fn check_owned_file(layout: &FsLayout, file: &OwnedFile) -> IntegrityStatus 
             Err(err) => return IntegrityStatus::ReadError(err.to_string()),
         }
     }
+    if file.kind == OwnedFileKind::Config {
+        return IntegrityStatus::Ok;
+    }
+
     // Digest gate BEFORE the size gate, so each label keeps the meaning its
     // documentation promises: `Unverified` means no digest was ever
     // recorded, `ProbeLimitExceeded` means one was recorded but this run
@@ -533,6 +538,60 @@ mod tests {
         assert_eq!(
             check_owned_file(&layout, &owned),
             IntegrityStatus::Unverified,
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn config_skips_only_content_checks() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let tmp = tempdir().expect("tempdir");
+        let layout = layout_under(tmp.path());
+        let path = layout.bin_dir.join("settings.toml");
+        fs::write(&path, b"operator edit").expect("write");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).expect("chmod");
+        let mut owned = anolisa_owned(path.clone(), Some("old digest".into()));
+        owned.kind = OwnedFileKind::Config;
+        owned.mode = Some("0644".into());
+        assert_eq!(check_owned_file(&layout, &owned), IntegrityStatus::Ok);
+        owned.sha256 = None;
+        assert_eq!(check_owned_file(&layout, &owned), IntegrityStatus::Ok);
+
+        #[cfg(target_os = "linux")]
+        {
+            owned.capabilities.push("CAP_NET_BIND_SERVICE".into());
+            assert!(matches!(
+                check_owned_file(&layout, &owned),
+                IntegrityStatus::CapabilityMismatch { .. }
+            ));
+            owned.capabilities.clear();
+        }
+
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).expect("chmod");
+        assert!(matches!(
+            check_owned_file(&layout, &owned),
+            IntegrityStatus::ModeMismatch { .. }
+        ));
+        fs::remove_file(&path).expect("remove");
+        assert_eq!(
+            check_owned_file(&layout, &owned),
+            IntegrityStatus::MissingFile
+        );
+        fs::create_dir(&path).expect("directory");
+        assert_eq!(
+            check_owned_file(&layout, &owned),
+            IntegrityStatus::NotRegularFile
+        );
+        fs::remove_dir(&path).expect("remove directory");
+        let target = layout.bin_dir.join("target");
+        fs::write(&target, b"target").expect("target");
+        symlink(&target, &path).expect("symlink");
+        assert_eq!(check_owned_file(&layout, &owned), IntegrityStatus::Symlink);
+        owned.path = tmp.path().join("outside-owned-roots");
+        assert_eq!(
+            check_owned_file(&layout, &owned),
+            IntegrityStatus::OutOfBounds
         );
     }
 

--- a/src/anolisa/crates/anolisa-core/src/state.rs
+++ b/src/anolisa/crates/anolisa-core/src/state.rs
@@ -202,9 +202,11 @@ pub enum FileOwner {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum OwnedFileKind {
-    /// Regular file (data, executable, config, library).
+    /// Immutable regular file (data, executable, library).
     #[default]
     File,
+    /// Administrator-editable regular file; integrity checks skip its digest.
+    Config,
     /// Symbolic link created by the install runner. The integrity probe
     /// verifies `readlink` against the recorded [`OwnedFile::referent`]
     /// instead of hashing content through the link.
@@ -229,8 +231,8 @@ pub struct OwnedFile {
     /// instead.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sha256: Option<String>,
-    /// Regular file vs. managed symlink. Defaults to `File` for backward
-    /// compatibility with state written before schema v4.
+    /// Immutable file, editable config, or managed symlink. Defaults to `File`
+    /// for backward compatibility with state written before schema v4.
     #[serde(default, skip_serializing_if = "is_default_owned_file_kind")]
     pub kind: OwnedFileKind,
     /// Expected symlink target (only meaningful when `kind == Symlink`).

--- a/src/anolisa/docs/COMPONENT_CONTRACT.md
+++ b/src/anolisa/docs/COMPONENT_CONTRACT.md
@@ -190,6 +190,27 @@ Raw repair and update restore the package payload (including declared content
 rendering); they do not replay installation hooks. Use `render` for layout-path
 substitution that must also be reproduced by repair and update.
 
+## Editable Files (`type = "config"`)
+
+The raw backend records config layout entries, including files expanded from
+directory sources, as `kind = "config"` in owned-file state. Their install-time
+digest remains recorded, but integrity probes skip content hashing after checking
+path boundaries, file type, permissions, and applied capabilities. Other regular
+files remain immutable. This does not change update or uninstall behavior.
+
+The runner carries the kind and mode from the actual source mapping through
+directory expansion and placement. Distinct sources can share or overlap a
+destination without changing each other's file contracts.
+
+Legacy records recover config kinds from exact file declarations or when every
+matching directory declaration is config. Mixed directory kinds are ambiguous
+without source provenance, so those legacy files retain digest checking.
+Back up edited configs and reinstall to record their kinds accurately; directory
+permissions are inferred only when all matching declarations agree.
+Read-only diagnostics do not rewrite state. Older CLI binaries cannot deserialize
+the new `config` kind; before downgrading, back up state and change owned-file
+`kind = "config"` entries to `kind = "file"`, restoring the old digest-check behavior.
+
 ## Content Rendering (`render`)
 
 A `[[component.layout.files]]` entry may request that ANOLISA render the


### PR DESCRIPTION
## Why

Editing a raw-installed `type = "config"` file makes `doctor` report
`sha256_mismatch` because installation drops the manifest file kind.

## What changed

Carry each file's kind and mode from its actual source mapping through archive
expansion, placement, and state recording. Remove destination-based inference,
which cannot distinguish separate source directories sharing or overlapping a
destination. Config files skip content hashing only after the shared integrity
probe's path, type, permission, and capability checks.

Legacy hydration recovers exact config declarations and directory declarations
only when every matching directory agrees on config semantics. Ambiguous legacy
files retain digest checking; conflicting directory modes are not guessed.
The rebase preserves main's post-install-hook digest refresh.

## Related issue

Closes #3137

## User / Agent impact

New raw installs retain accurate file kinds regardless of declaration order.
Config edits remain healthy; ordinary data and executable tampering is detected.
Legacy exact and unambiguous config declarations work without reinstalling.
For ambiguous legacy directory mappings, back up edited configs and reinstall to
record accurate kinds. Diagnostics remain read-only and do not interrupt services.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [x] Migration or rollback guidance is needed

Owned state gains `kind = "config"`; older binaries cannot deserialize it.
File digests, capability rollback, and managed adapter inventory are retained.
No CLI flags, dependencies, or update/uninstall policy change.

## Validation

Linux ARM64, Rust 1.93.1, rebased onto `89c45da03`:

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 2,483 passed, 1 existing ignored test
- `cargo doc --workspace --no-deps --locked`

The expanded local-repository install/doctor regression reproduced the review
finding before the fix (`Config` instead of `File`). It covers both declaration
orders, distinct sources sharing a destination, overlapping destinations,
different source modes, exact mappings, config edits, immutable tampering,
unambiguous legacy recovery, conservative ambiguous legacy checks, and unchanged
state bytes after diagnostics. Core tests preserve missing-file, mode, Linux
capability, symlink, non-regular-file, and out-of-bounds failures.

macOS ARM64: the expanded regression, check, and docs pass. Workspace Clippy
reports only the existing unused capability error variants. Full-suite testing
encounters existing platform failures: the capability rollback missing-log test
and the managed-source symlink-root test. The latter was also reproduced on
unmodified `89c45da03`; Linux workspace gates pass without exclusions.

## Documentation and rollback

Updated both README languages, both user-guide languages, and the component
contract. Before downgrading, back up state and convert owned-file
`kind = "config"` entries to `kind = "file"`, restoring the old digest behavior.
Changelog and version changes remain release work.

### Ship Note

- Changed: editable raw config content no longer fails integrity checks.
- Known limitations: legacy recovery requires the installed manifest; mixed
  directory declarations without source provenance retain hashing until reinstall.
- Not covered: native RPM config policy and preserving edited configs on update.
- Verification: Linux workspace gates and install/doctor regression above.
