### PR TITLE
feat(cosh-ng): add WSL2 preview launcher from Git Bash

### DIFF
--- a/docs/user-guide/en/user-entrypoint/cosh-ng/README.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/README.md
@@ -12,6 +12,7 @@ use the task-based links below for the feature or command you need.
 - [Model providers](core/providers.md) — configure authentication and select a provider.
 - [Configuration](configuration.md) — review files, settings, and precedence.
 - [Supported platforms](supported-distros.md) — check package and service backends.
+- [Windows WSL2 preview](wsl-preview.md) — start cosh-ng from Git Bash on Windows (community preview).
 
 ## Work in the terminal
 

--- a/docs/user-guide/en/user-entrypoint/cosh-ng/wsl-preview.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/wsl-preview.md
@@ -1,0 +1,68 @@
+# Run cosh-ng on Windows with WSL2 (preview)
+
+[中文版](../../../zh/user-entrypoint/cosh-ng/wsl-preview.md)
+
+Windows users can try cosh-ng through a community preview launcher. The
+launcher runs in Git Bash, enters WSL2 through `wsl.exe`, and starts the
+`cosh-shell` already installed inside a Linux distribution, in the directory
+that matches your current Windows working directory. This is a preview path,
+not a native Windows port: the supported platform matrix is unchanged.
+
+Keep these four points in mind. The launcher prints them on every start.
+
+- cosh-ng actually runs on Linux inside WSL2.
+- Git Bash is only the Windows-side entry point.
+- Directories under `/mnt/c` and other mounts may have performance and
+  permission differences.
+- Configuration and credentials stay in the WSL user environment.
+
+## Prerequisites
+
+- Windows with WSL2 enabled and a Linux distribution installed
+  (`wsl --install` from an elevated PowerShell sets up both; Ubuntu is the
+  default distribution).
+- cosh-ng installed inside that distribution. Follow the Linux steps in the
+  [quick start](QUICKSTART.md) from a WSL terminal.
+- The launcher script `cosh-wsl` from this repository. From Git Bash:
+
+```bash
+mkdir -p ~/bin
+curl -fsSL https://raw.githubusercontent.com/alibaba/anolisa/main/src/cosh-ng/scripts/cosh-wsl -o ~/bin/cosh-wsl
+chmod +x ~/bin/cosh-wsl
+export PATH="$HOME/bin:$PATH"
+```
+
+## Start a session
+
+From Git Bash, go to your project directory and run the launcher:
+
+```bash
+cd /c/work/your-project
+cosh-wsl
+```
+
+The launcher converts the Windows working directory with `wslpath` and starts
+`cosh-shell` in the matching directory inside WSL2. To use a different
+distribution, set `COSH_WSL_DISTRO`:
+
+```bash
+COSH_WSL_DISTRO=Debian cosh-wsl
+```
+
+## Preview scope
+
+The preview covers the interactive terminal, cosh-core, authentication, and
+common file tools. The `pkg` and `svc` system-operation commands, workspace
+checkpoints, and the Gateway are not part of this preview and are not
+supported on this path.
+
+Files under `/mnt/c` and other Windows drive mounts can be noticeably slower
+and may not preserve Linux permission bits. For the best experience, keep
+active work in the Linux filesystem (for example under `~/`) and treat
+`/mnt/c` as an exchange area.
+
+## Feedback
+
+This preview exists to validate real demand before any larger investment.
+Report problems or confirm that the path works for you on
+[GitHub issue #2770](https://github.com/alibaba/anolisa/issues/2770).

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/README.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/README.md
@@ -11,6 +11,7 @@ cosh-ng 是一个 AI 原生 Linux 终端，默认使用 Enhanced Assisted，也�
 - [模型提供商](core/providers.md)：配置认证并选择模型提供商。
 - [配置](configuration.md)：了解配置文件、设置项和优先级。
 - [支持的平台](supported-distros.md)：确认软件包和服务后端。
+- [Windows WSL2 预览](wsl-preview.md)：在 Windows 的 Git Bash 中启动 cosh-ng（社区预览）。
 
 ## 在终端工作
 

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/wsl-preview.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/wsl-preview.md
@@ -1,0 +1,62 @@
+# 在 Windows 上通过 WSL2 运行 cosh-ng（预览）
+
+[English](../../../en/user-entrypoint/cosh-ng/wsl-preview.md)
+
+Windows 用户可以通过社区预览 launcher 试用 cosh-ng。launcher 在 Git Bash
+中运行，通过 `wsl.exe` 进入 WSL2，并在与当前 Windows 工作目录对应的目录
+中启动已安装在 Linux 发行版内的 `cosh-shell`。这是一条预览路径，不是
+Windows 原生移植：平台支持矩阵保持不变。
+
+请牢记以下四点，launcher 每次启动时也会打印这些声明。
+
+- cosh-ng 实际运行在 WSL2 中的 Linux 上。
+- Git Bash 只提供 Windows 侧入口。
+- `/mnt/c` 等挂载目录可能存在性能和权限差异。
+- 配置与凭据保存在 WSL 用户环境中。
+
+## 前置条件
+
+- Windows 已启用 WSL2 并安装了一个 Linux 发行版（在管理员 PowerShell 中
+  运行 `wsl --install` 即可完成；默认发行版为 Ubuntu）。
+- 已在该发行版内安装 cosh-ng。在 WSL 终端中按照
+  [快速开始](QUICKSTART.md) 的 Linux 步骤操作。
+- 从本仓库获取 launcher 脚本 `cosh-wsl`。在 Git Bash 中执行：
+
+```bash
+mkdir -p ~/bin
+curl -fsSL https://raw.githubusercontent.com/alibaba/anolisa/main/src/cosh-ng/scripts/cosh-wsl -o ~/bin/cosh-wsl
+chmod +x ~/bin/cosh-wsl
+export PATH="$HOME/bin:$PATH"
+```
+
+## 启动会话
+
+在 Git Bash 中进入项目目录，然后运行 launcher：
+
+```bash
+cd /c/work/your-project
+cosh-wsl
+```
+
+launcher 会用 `wslpath` 转换 Windows 工作目录，并在 WSL2 内对应的目录
+启动 `cosh-shell`。如需使用其他发行版，设置 `COSH_WSL_DISTRO`：
+
+```bash
+COSH_WSL_DISTRO=Debian cosh-wsl
+```
+
+## 预览范围
+
+预览覆盖交互式终端、cosh-core、认证和常用文件工具。`pkg`、`svc` 系统
+操作命令、workspace checkpoint 和 Gateway 不在本次预览范围内，此路径
+不予支持。
+
+`/mnt/c` 等 Windows 盘符挂载目录上的文件访问可能明显变慢，且无法保留
+Linux 权限位。建议把日常工作放在 Linux 文件系统中（例如 `~/` 下），把
+`/mnt/c` 当作交换区使用。
+
+## 反馈
+
+本次预览用于在更大投入之前验证真实需求。如遇问题或确认该路径可用，
+请在 [GitHub issue #2770](https://github.com/alibaba/anolisa/issues/2770)
+上反馈。

--- a/src/cosh-ng/README.md
+++ b/src/cosh-ng/README.md
@@ -67,6 +67,11 @@ package supports macOS arm64, where Linux-only package and service operations
 remain unavailable. Source builds are for contributors; follow the
 [developer setup](../../docs/developer-guide/en/cosh-ng/getting-started.md).
 
+On Windows, a community preview launcher starts cosh-ng inside WSL2 from Git
+Bash: install cosh-ng in a WSL2 distribution, then run `scripts/cosh-wsl`
+from Git Bash. This is a preview path, not a native Windows target; see
+[Run cosh-ng on Windows with WSL2 (preview)](../../docs/user-guide/en/user-entrypoint/cosh-ng/wsl-preview.md).
+
 ## Start in 30 seconds
 
 ```bash

--- a/src/cosh-ng/README_zh.md
+++ b/src/cosh-ng/README_zh.md
@@ -64,6 +64,11 @@ Linux 安装路径。raw 包支持 macOS arm64，但依赖 Linux 的软件包和
 不可用。源码构建仅供贡献者使用，请参阅
 [开发者入门指南](../../docs/developer-guide/zh/cosh-ng/getting-started.md)。
 
+在 Windows 上，社区预览 launcher 可以从 Git Bash 启动 WSL2 内的
+cosh-ng：先在 WSL2 发行版中安装 cosh-ng，然后在 Git Bash 中运行
+`scripts/cosh-wsl`。这是一条预览路径，不是 Windows 原生 target；详见
+[在 Windows 上通过 WSL2 运行 cosh-ng（预览）](../../docs/user-guide/zh/user-entrypoint/cosh-ng/wsl-preview.md)。
+
 ## 30 秒开始使用
 
 ```bash

--- a/src/cosh-ng/scripts/cosh-wsl
+++ b/src/cosh-ng/scripts/cosh-wsl
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# cosh-wsl — community preview launcher: start cosh-shell inside WSL2 from
+# Git Bash on Windows. This is a preview entry point, not a native Windows
+# port of cosh-ng.
+set -euo pipefail
+
+if ! command -v wsl.exe >/dev/null 2>&1; then
+    {
+        echo "Error: wsl.exe was not found on PATH."
+        echo "cosh-ng on Windows requires WSL2. From an elevated PowerShell run:"
+        echo "  wsl --install"
+        echo "then install a Linux distribution and install cosh-ng inside it."
+        echo "See https://learn.microsoft.com/windows/wsl/install"
+    } >&2
+    exit 127
+fi
+
+distro="${COSH_WSL_DISTRO:-Ubuntu}"
+# `pwd -W` is a Git Bash/MSYS2 extension that prints the Windows form of the
+# current directory. It has no Linux equivalent, so a failure here means the
+# launcher is not running where it is designed to run; fail explicitly rather
+# than silently forwarding a Linux path that WSL cannot interpret.
+if ! windows_cwd="$(pwd -W 2>/dev/null)" || [ -z "$windows_cwd" ]; then
+    {
+        echo "Error: could not determine the Windows working directory (pwd -W failed)."
+        echo "Run cosh-wsl from Git Bash (MSYS2), where pwd -W prints the Windows path."
+    } >&2
+    exit 1
+fi
+
+{
+    echo "cosh-ng WSL2 preview"
+    echo "- cosh-ng runs on Linux inside WSL2; this is not a native Windows build."
+    echo "- Git Bash is only the Windows-side entry point."
+    echo "- Directories under /mnt/c and other mounts may have performance and permission differences."
+    echo "- Configuration and credentials stay in the WSL user environment."
+    echo "- pkg, svc, checkpoint, and Gateway are not part of this preview."
+} >&2
+
+# MSYS2_ARG_CONV_EXCL applies only to this wsl.exe invocation so Git Bash does
+# not rewrite the forwarded arguments. The Windows path travels as a
+# positional parameter ($1 in the inner script) so spaces, quotes, and
+# backslashes cannot break the command line or be reinterpreted.
+MSYS2_ARG_CONV_EXCL='*' exec wsl.exe -d "$distro" -- bash -lc '
+set -e
+windows_cwd="$1"
+if ! linux_cwd="$(wslpath "$windows_cwd" 2>/dev/null)"; then
+    echo "Error: wslpath could not convert: $windows_cwd" >&2
+    echo "Start cosh-wsl from a directory that maps into WSL." >&2
+    exit 1
+fi
+if ! cd "$linux_cwd" 2>/dev/null; then
+    echo "Error: directory is not accessible inside WSL: $linux_cwd (converted from $windows_cwd)" >&2
+    exit 1
+fi
+if ! command -v cosh-shell >/dev/null 2>&1; then
+    echo "Error: cosh-shell was not found on PATH inside the WSL distribution." >&2
+    echo "Install cosh-ng inside the distribution first; see the cosh-ng install documentation." >&2
+    exit 127
+fi
+exec cosh-shell
+' bash "$windows_cwd"

--- a/src/cosh-ng/scripts/run-test-gates.sh
+++ b/src/cosh-ng/scripts/run-test-gates.sh
@@ -128,6 +128,15 @@ run_rpm_packaging() {
   bash tests/test-package-rpm.sh
 }
 
+run_wsl_launcher() {
+  if ! command -v shellcheck >/dev/null 2>&1; then
+    echo "shellcheck is required by the WSL launcher gate" >&2
+    return 1
+  fi
+  shellcheck scripts/cosh-wsl tests/test-cosh-wsl.sh
+  bash tests/test-cosh-wsl.sh
+}
+
 case "${1:-all}" in
   fast)
     scripts/check-test-inventory.sh
@@ -135,6 +144,7 @@ case "${1:-all}" in
     crates/cosh-shell/scripts/check-layout.sh
     run_raw_packaging
     run_rpm_packaging
+    run_wsl_launcher
     cargo test --locked --workspace --exclude cosh-core --exclude cosh-shell
     run_canonical_units cosh-core cosh-core
     run_canonical_units cosh-shell cosh-shell 1
@@ -154,6 +164,7 @@ case "${1:-all}" in
     crates/cosh-shell/scripts/check-layout.sh
     run_raw_packaging
     run_rpm_packaging
+    run_wsl_launcher
     cargo test --locked --workspace --exclude cosh-core --exclude cosh-shell
     run_canonical_units cosh-core cosh-core
     run_core_integrations

--- a/src/cosh-ng/tests/test-cosh-wsl.sh
+++ b/src/cosh-ng/tests/test-cosh-wsl.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# Exercise the cosh-wsl preview launcher with stub wsl.exe/wslpath/cosh-shell
+# binaries so argument passing, cwd conversion, and failure branches stay
+# verifiable on Linux CI. `pwd -W` exists only in Git Bash/MSYS2, so the
+# launcher is invoked from a bash subprocess that exports a stub `pwd`
+# function returning a controlled Windows path; the production script keeps
+# its real failure semantics. These stubs do not replace real
+# Windows/Git Bash/WSL2 acceptance testing.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d /tmp/cosh-ng-wsl-test.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+LOG_ARGS="$TMP/wsl-args.log"
+LOG_ENV="$TMP/wsl-env.log"
+LOG_CWD="$TMP/cosh-cwd.log"
+
+BASE_BIN="$TMP/base-bin"
+install -d -m 0755 "$BASE_BIN"
+ln -s "$(command -v bash)" "$BASE_BIN/bash"
+
+make_stub_wsl() {
+    local dir="$1"
+    cat > "$dir/wsl.exe" <<'STUB'
+#!/usr/bin/env bash
+# Record argv and the argument-conversion guard, then emulate wsl.exe by
+# running the bash -lc payload without the login flag: a login shell would
+# reload the host profile and drop the stub PATH used by this test.
+printf '%s\n' "$@" >> "$COSH_WSL_STUB_ARGS"
+printf 'MSYS2_ARG_CONV_EXCL=%s\n' "${MSYS2_ARG_CONV_EXCL-UNSET}" >> "$COSH_WSL_STUB_ENV"
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-lc" ]; then
+        script="$2"
+        shift 2
+        exec bash -c "$script" "$@"
+    fi
+    shift
+done
+echo "stub wsl.exe: no -lc payload in arguments" >&2
+exit 2
+STUB
+    chmod 0755 "$dir/wsl.exe"
+}
+
+make_stub_wslpath() {
+    local dir="$1"
+    cat > "$dir/wslpath" <<'STUB'
+#!/usr/bin/env bash
+if [ -n "${COSH_WSL_STUB_WSLPATH_FAIL:-}" ]; then
+    echo "wslpath: stub conversion failure" >&2
+    exit 1
+fi
+printf '%s\n' "$COSH_WSL_STUB_WSLPATH_OUT"
+STUB
+    chmod 0755 "$dir/wslpath"
+}
+
+make_stub_cosh_shell() {
+    local dir="$1"
+    cat > "$dir/cosh-shell" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$(pwd -P)" >> "$COSH_WSL_STUB_CWD"
+exit "${COSH_WSL_STUB_COSH_EXIT:-0}"
+STUB
+    chmod 0755 "$dir/cosh-shell"
+}
+
+# run_launcher <stub-bin> <work-dir> <stderr-file> [extra-env ...]
+# Runs the launcher from a bash subprocess whose PATH only contains the stub
+# bin directory and a bare bash, with a stub `pwd` exported so that `pwd -W`
+# returns $COSH_WSL_STUB_WINDOWS_CWD (an MSYS2-only builtin simulated for the
+# test only). Extra arguments are NAME=VALUE assignments exported for the
+# launcher; plain `export` is used because the restricted PATH cannot resolve
+# an external `env`.
+run_launcher() {
+    local stub_bin="$1"
+    local work_dir="$2"
+    local stderr_file="$3"
+    shift 3
+    (
+        cd "$work_dir"
+        unset COSH_WSL_DISTRO
+        export PATH="$stub_bin:$BASE_BIN"
+        export COSH_WSL_STUB_ARGS="$LOG_ARGS"
+        export COSH_WSL_STUB_ENV="$LOG_ENV"
+        export COSH_WSL_STUB_CWD="$LOG_CWD"
+        pwd() {
+            if [ "${1:-}" = "-W" ]; then
+                printf '%s\n' "$COSH_WSL_STUB_WINDOWS_CWD"
+            else
+                command pwd "$@"
+            fi
+        }
+        export -f pwd
+        local assignment
+        for assignment in "$@"; do
+            export "$assignment"
+        done
+        bash "$ROOT/scripts/cosh-wsl" 2>"$stderr_file"
+    )
+}
+
+reset_logs() {
+    : >"$LOG_ARGS"
+    : >"$LOG_ENV"
+    : >"$LOG_CWD"
+}
+
+passed=0
+pass() {
+    passed=$((passed + 1))
+    echo "PASS $1"
+}
+
+# Case 1: the default distribution is Ubuntu.
+stub_bin="$TMP/case1"
+install -d -m 0755 "$stub_bin"
+make_stub_wsl "$stub_bin"
+make_stub_wslpath "$stub_bin"
+make_stub_cosh_shell "$stub_bin"
+reset_logs
+run_launcher "$stub_bin" "$TMP" "$TMP/case1.err" \
+    'COSH_WSL_STUB_WINDOWS_CWD=C:\work\case1' \
+    "COSH_WSL_STUB_WSLPATH_OUT=$TMP"
+test "$(awk 'prev == "-d" { print; exit } { prev = $0 }' "$LOG_ARGS")" = "Ubuntu"
+pass "default distro is Ubuntu"
+
+# Case 2: COSH_WSL_DISTRO overrides the default distribution.
+stub_bin="$TMP/case2"
+install -d -m 0755 "$stub_bin"
+make_stub_wsl "$stub_bin"
+make_stub_wslpath "$stub_bin"
+make_stub_cosh_shell "$stub_bin"
+reset_logs
+run_launcher "$stub_bin" "$TMP" "$TMP/case2.err" \
+    'COSH_WSL_STUB_WINDOWS_CWD=C:\work\case2' \
+    "COSH_WSL_STUB_WSLPATH_OUT=$TMP" \
+    "COSH_WSL_DISTRO=Debian"
+test "$(awk 'prev == "-d" { print; exit } { prev = $0 }' "$LOG_ARGS")" = "Debian"
+pass "COSH_WSL_DISTRO overrides the distro"
+
+# Case 3: MSYS2_ARG_CONV_EXCL='*' guards the wsl.exe invocation.
+stub_bin="$TMP/case3"
+install -d -m 0755 "$stub_bin"
+make_stub_wsl "$stub_bin"
+make_stub_wslpath "$stub_bin"
+make_stub_cosh_shell "$stub_bin"
+reset_logs
+run_launcher "$stub_bin" "$TMP" "$TMP/case3.err" \
+    'COSH_WSL_STUB_WINDOWS_CWD=C:\work\case3' \
+    "COSH_WSL_STUB_WSLPATH_OUT=$TMP"
+grep -Fxq 'MSYS2_ARG_CONV_EXCL=*' "$LOG_ENV"
+pass "MSYS2_ARG_CONV_EXCL guards the wsl.exe call"
+
+# Case 4: a Windows cwd with spaces, CJK, quotes, backslash, and substitution
+# metacharacters reaches the inner script byte-for-byte without word
+# splitting or injection.
+stub_bin="$TMP/case4"
+install -d -m 0755 "$stub_bin"
+make_stub_wsl "$stub_bin"
+make_stub_wslpath "$stub_bin"
+make_stub_cosh_shell "$stub_bin"
+tricky='C:\work\tricky dir 中文 '"'"' " \ `touch pwned` $(touch pwned2)'
+reset_logs
+run_launcher "$stub_bin" "$TMP" "$TMP/case4.err" \
+    "COSH_WSL_STUB_WINDOWS_CWD=$tricky" \
+    "COSH_WSL_STUB_WSLPATH_OUT=$TMP"
+test "$(tail -n 1 "$LOG_ARGS")" = "$tricky"
+test -z "$(find "$TMP" -name 'pwned*' -print -quit)"
+pass "tricky cwd arrives byte-for-byte without injection"
+
+# Case 5: the wslpath result, not the original cwd, becomes the cosh-shell
+# working directory.
+stub_bin="$TMP/case5"
+install -d -m 0755 "$stub_bin"
+make_stub_wsl "$stub_bin"
+make_stub_wslpath "$stub_bin"
+make_stub_cosh_shell "$stub_bin"
+converted_dir="$TMP/case5-mnt-c style"
+install -d -m 0755 "$converted_dir"
+reset_logs
+run_launcher "$stub_bin" "$TMP" "$TMP/case5.err" \
+    'COSH_WSL_STUB_WINDOWS_CWD=C:\work\case5' \
+    "COSH_WSL_STUB_WSLPATH_OUT=$converted_dir"
+test "$(tail -n 1 "$LOG_CWD")" = "$(cd "$converted_dir" && pwd -P)"
+pass "wslpath result becomes the cosh-shell cwd"
+
+# Case 6: exec semantics — the cosh-shell exit code propagates unchanged.
+stub_bin="$TMP/case6"
+install -d -m 0755 "$stub_bin"
+make_stub_wsl "$stub_bin"
+make_stub_wslpath "$stub_bin"
+make_stub_cosh_shell "$stub_bin"
+reset_logs
+rc=0
+run_launcher "$stub_bin" "$TMP" "$TMP/case6.err" \
+    'COSH_WSL_STUB_WINDOWS_CWD=C:\work\case6' \
+    "COSH_WSL_STUB_WSLPATH_OUT=$TMP" \
+    "COSH_WSL_STUB_COSH_EXIT=42" || rc=$?
+test "$rc" -eq 42
+pass "cosh-shell exit code propagates unchanged"
+
+# Case 7: a missing wsl.exe fails with an actionable install hint.
+rc=0
+(
+    cd "$TMP"
+    export PATH="$BASE_BIN"
+    bash "$ROOT/scripts/cosh-wsl" 2>"$TMP/case7.err"
+) || rc=$?
+test "$rc" -ne 0
+grep -Fq 'wsl --install' "$TMP/case7.err"
+pass "missing wsl.exe reports an install hint"
+
+# Case 8: a wslpath conversion failure reports the failed path.
+stub_bin="$TMP/case8"
+install -d -m 0755 "$stub_bin"
+make_stub_wsl "$stub_bin"
+make_stub_wslpath "$stub_bin"
+make_stub_cosh_shell "$stub_bin"
+failed_path='C:\work\case8-unconvertible'
+rc=0
+run_launcher "$stub_bin" "$TMP" "$TMP/case8.err" \
+    "COSH_WSL_STUB_WINDOWS_CWD=$failed_path" \
+    "COSH_WSL_STUB_WSLPATH_OUT=$TMP" \
+    "COSH_WSL_STUB_WSLPATH_FAIL=1" || rc=$?
+test "$rc" -ne 0
+grep -Fq "$failed_path" "$TMP/case8.err"
+pass "wslpath failure reports the failed path"
+
+# Case 9: an inaccessible converted directory reports the target path.
+stub_bin="$TMP/case9"
+install -d -m 0755 "$stub_bin"
+make_stub_wsl "$stub_bin"
+make_stub_wslpath "$stub_bin"
+make_stub_cosh_shell "$stub_bin"
+missing_dir="$TMP/case9-does-not-exist"
+rc=0
+run_launcher "$stub_bin" "$TMP" "$TMP/case9.err" \
+    'COSH_WSL_STUB_WINDOWS_CWD=C:\work\case9' \
+    "COSH_WSL_STUB_WSLPATH_OUT=$missing_dir" || rc=$?
+test "$rc" -ne 0
+grep -Fq "$missing_dir" "$TMP/case9.err"
+pass "inaccessible directory reports the target path"
+
+# Case 10: a missing cosh-shell reports an in-distro install hint.
+stub_bin="$TMP/case10"
+install -d -m 0755 "$stub_bin"
+make_stub_wsl "$stub_bin"
+make_stub_wslpath "$stub_bin"
+rc=0
+run_launcher "$stub_bin" "$TMP" "$TMP/case10.err" \
+    'COSH_WSL_STUB_WINDOWS_CWD=C:\work\case10' \
+    "COSH_WSL_STUB_WSLPATH_OUT=$TMP" || rc=$?
+test "$rc" -ne 0
+grep -Fq 'Install cosh-ng inside the distribution' "$TMP/case10.err"
+pass "missing cosh-shell reports an in-distro install hint"
+
+# Case 11: the startup banner declares the four preview status points.
+stub_bin="$TMP/case11"
+install -d -m 0755 "$stub_bin"
+make_stub_wsl "$stub_bin"
+make_stub_wslpath "$stub_bin"
+make_stub_cosh_shell "$stub_bin"
+reset_logs
+run_launcher "$stub_bin" "$TMP" "$TMP/case11.err" \
+    'COSH_WSL_STUB_WINDOWS_CWD=C:\work\case11' \
+    "COSH_WSL_STUB_WSLPATH_OUT=$TMP"
+grep -Fq 'runs on Linux inside WSL2' "$TMP/case11.err"
+grep -Fq 'Git Bash is only the Windows-side entry point' "$TMP/case11.err"
+grep -Fq '/mnt/c' "$TMP/case11.err"
+grep -Fq 'Configuration and credentials stay in the WSL user environment' "$TMP/case11.err"
+pass "startup banner declares the preview status"
+
+# Case 12: without the MSYS2 `pwd -W` extension the launcher fails
+# explicitly with an actionable hint instead of silently guessing a path.
+stub_bin="$TMP/case12"
+install -d -m 0755 "$stub_bin"
+make_stub_wsl "$stub_bin"
+rc=0
+(
+    cd "$TMP"
+    unset COSH_WSL_DISTRO
+    export PATH="$stub_bin:$BASE_BIN"
+    bash "$ROOT/scripts/cosh-wsl" 2>"$TMP/case12.err"
+) || rc=$?
+test "$rc" -ne 0
+grep -Fq 'pwd -W' "$TMP/case12.err"
+grep -Fq 'Git Bash' "$TMP/case12.err"
+pass "missing pwd -W fails explicitly with an actionable hint"
+
+echo "$passed tests passed"
+test "$passed" -eq 12


### PR DESCRIPTION
## Why

Windows users want to try cosh-ng, but a native Windows port (terminal,
process, local IPC differences) is too costly to commit to before demand is
validated. This adds a scoped preview path: a lightweight launcher run from
Git Bash enters WSL2 via `wsl.exe` and starts the `cosh-shell` already
installed in a Linux distribution, in the directory matching the current
Windows working directory.

## What changed

- `src/cosh-ng/scripts/cosh-wsl` (new): preview launcher. Preflights
  `wsl.exe`, resolves the Windows cwd with the MSYS2 `pwd -W` extension
  (fails explicitly outside Git Bash), prints the four preview status
  declarations plus the out-of-scope notice on every start, forwards the
  path as a positional parameter under `MSYS2_ARG_CONV_EXCL='*'`, and
  reports actionable errors for wslpath failure, an inaccessible directory,
  and a missing cosh-shell. `COSH_WSL_DISTRO` selects the distribution
  (default `Ubuntu`).
- `src/cosh-ng/tests/test-cosh-wsl.sh` (new): 12 stub-verifiable cases on
  Linux (distro default/override, arg-conversion guard, byte-exact tricky
  paths without injection, cwd mapping, exit-code propagation, all failure
  branches, explicit `pwd -W` failure).
- `src/cosh-ng/scripts/run-test-gates.sh`: registers `run_wsl_launcher` in
  the `fast` and `all` gates (shellcheck-missing handling mirrors the
  existing raw/rpm packaging gates).
- Bilingual docs: new `wsl-preview.md` pages under
  `docs/user-guide/{en,zh}/user-entrypoint/cosh-ng/`, linked from the
  user-guide "Start here" lists and summarized in the cosh-ng READMEs.

## Related issue

Refs #2770 (community preview; the issue stays open pending real
Windows/Git Bash/WSL2 acceptance — do not close on merge)

## User / Agent impact

New opt-in preview entry point for Windows users. On every start the
launcher prints: cosh-ng actually runs on Linux inside WSL2; Git Bash is
only the Windows-side entry point; `/mnt/c` and other mounts may have
performance and permission differences; configuration and credentials stay
in the WSL user environment; `pkg`, `svc`, checkpoint, and Gateway are not
part of this preview. No existing command, exit code, or output changes.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: additive script + tests + docs only. `component.toml` platform
declarations unchanged; no new dependencies; the launcher is not part of
any packaging manifest.

## Validation

- `bash tests/test-cosh-wsl.sh`: 12/12 PASS, exit 0 (Linux stub level —
  stub wsl.exe/wslpath/cosh-shell; this is **not** real Windows/WSL2
  acceptance).
- `bash -n` on the launcher, test, and gate script: exit 0.
- `node website/scripts/validate-locales.mjs`: PASS (en/zh parity).
- NOT CHECKED here (left to CI): `shellcheck` (not installed on the dev
  node), `website/scripts/check-links.mjs` (needs the docusaurus build).
- PRE-EXISTING environment blocker (present at base, untouched by this
  change, follow-up needed): the dev node's Python 3.8 breaks
  `packaging/raw/verify-release.py` (`import tomllib`) and
  `scripts/check_test_necessity.py` (`str.removesuffix`), so
  `tests/test-package-raw.sh` cannot complete on that node.
- Manual acceptance still required on real Windows + Git Bash + WSL2
  (NOT VERIFIED): start/exit of cosh-shell, real cwd mapping between the
  Windows workspace and the WSL filesystem, Ctrl+C/Ctrl+D, window resize,
  CJK input and paste, Bash command boundaries, OSC markers, approval
  interaction, authentication and session recovery, common file tools,
  real `/mnt/c` performance/permissions, and prompt quality for real
  wsl.exe errors (e.g. distribution not installed).

## Documentation and rollback

Docs added bilingually (`wsl-preview.md` en/zh) and summarized in
`src/cosh-ng/README.md` / `README_zh.md`. Rollback: revert this commit;
the launcher, its tests, its gate registration, and the docs are fully
self-contained.
