### PR TITLE
feat(cosh-ng): [core] discover raw skills

### DIFF
--- a/docs/user-guide/en/agent-security/agent-sec-core/skill-ledger.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/skill-ledger.md
@@ -459,7 +459,17 @@ Codex and Qoder CLI are low-level integrity gates that run `skill-ledger check <
 
 All six adapters enable Skill Ledger by default. Hermes uses policy `observe`; the other adapters retain policy `ask`. copilot-shell, Codex, Qoder CLI, and Qwen Code register their corresponding hook boundaries in their default manifests. OpenClaw and Hermes can also take capability configuration, while `SKILL_LEDGER_MODE` remains the deployment-level override. Apart from the explicitly documented Qoder CLI low-level gate above, the other compatibility hooks remain fail-open when the CLI infrastructure misbehaves, avoiding blocked Skill loads.
 
-The copilot-shell hook currently covers three directory classes — project / user / system: `<cwd>/.copilot-shell/skills/`, `~/.copilot-shell/skills/`, and the RPM and raw-install system roots `/usr/share/anolisa/skills/` and `/usr/local/share/anolisa/skills/`. Skills from custom, extension, remote, or other paths make the hook fail open and skip the skill-ledger check; the OpenClaw plugin extracts the Skill directory from the `SKILL.md` path it reads.
+The built-in Ledger discovery entries also include the raw user root.
+For this root, an unset, empty, relative, or dot-segment `XDG_DATA_HOME` uses
+`~/.local/share`, matching ANOLISA and cosh. `enableDefaultSkillDirs=false`
+also disables this built-in entry. The hook keeps the existing policy and
+unmanaged-skill behavior; recognizing a directory does not certify its contents.
+
+`agent-sec-cli capabilities --agent cosh --capability skill-ledger --output json`
+reports the effective XDG data-root setting without resolving the user's home
+or reading Agent configuration. Its fallback is displayed as `~/.local/share`.
+
+The copilot-shell hook currently covers three directory classes — project / user / system: `<cwd>/.copilot-shell/skills/`, `~/.copilot-shell/skills/`, the raw user root `$XDG_DATA_HOME/anolisa/skills/` (default `~/.local/share/anolisa/skills/`), and the RPM and raw-install system roots `/usr/share/anolisa/skills/` and `/usr/local/share/anolisa/skills/`. Skills from custom, extension, remote, or other paths make the hook fail open and skip the skill-ledger check; the OpenClaw plugin extracts the Skill directory from the `SKILL.md` path it reads.
 
 For batch certification or post-install certification, complete directory resolution and certification before letting the Agent read uncertified Skill content: avoid proactively reading an uncertified Skill's `SKILL.md` or auxiliary files before batch certification; after a successful install, locate the final local directory, confirm it contains `SKILL.md`, then run quick-scan certification.
 

--- a/docs/user-guide/en/user-entrypoint/cosh-ng/core/skills.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/core/skills.md
@@ -24,13 +24,15 @@ The first matching name wins, in this order:
 1. `<workspace>/.copilot-shell/skills/`
 2. Paths in `skills.custom_paths`
 3. `~/.copilot-shell/skills/`
-4. Skill directories from Extensions
-5. `/usr/local/share/anolisa/skills/`
-6. `/usr/share/anolisa/skills/`
+4. `$XDG_DATA_HOME/anolisa/skills/` (default `~/.local/share/anolisa/skills/`)
+5. Skill directories from Extensions
+6. `/usr/local/share/anolisa/skills/`
+7. `/usr/share/anolisa/skills/`
 
-The raw backend of `anolisa install os-skills` uses
-`/usr/local/share/anolisa/skills/` for system installs. Raw user data directories
-are not searched automatically. Within custom or Extension directories,
+The raw backend of `anolisa install os-skills` uses the user data directory
+for user installs and `/usr/local/share/anolisa/skills/` for system installs.
+An unset, empty, or relative `XDG_DATA_HOME`, or one containing `.` or `..`
+path segments, uses the default above. Within custom or Extension directories,
 the first directory containing a name wins for both listing and loading.
 
 For a custom system prefix, run the cosh installed under that same prefix.

--- a/docs/user-guide/en/user-entrypoint/cosh-ng/core/skills.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/core/skills.md
@@ -25,7 +25,20 @@ The first matching name wins, in this order:
 2. Paths in `skills.custom_paths`
 3. `~/.copilot-shell/skills/`
 4. Skill directories from Extensions
-5. `/usr/share/anolisa/skills/`
+5. `/usr/local/share/anolisa/skills/`
+6. `/usr/share/anolisa/skills/`
+
+The raw backend of `anolisa install os-skills` uses
+`/usr/local/share/anolisa/skills/` for system installs. Raw user data directories
+are not searched automatically. Within custom or Extension directories,
+the first directory containing a name wins for both listing and loading.
+
+For a custom system prefix, run the cosh installed under that same prefix.
+For example, an installation under `/opt/x` searches
+`/opt/x/usr/local/share/anolisa/skills/` before
+`/opt/x/usr/share/anolisa/skills/`. These replace the host system roots;
+user and project paths keep their priority. Use `skills.custom_paths` to
+include skills installed under a different prefix.
 
 Existing directories are watched and rescanned after changes.
 

--- a/docs/user-guide/zh/agent-security/agent-sec-core/skill-ledger.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/skill-ledger.md
@@ -424,7 +424,16 @@ Codex 和 Qoder CLI 是低层完整性门禁，均在完成 canonical path 和�
 
 六个 adapter 均默认启用 Skill Ledger；Hermes 使用 `observe`，其它 adapter 保持 `ask`。copilot-shell、Codex、Qoder CLI 和 Qwen Code 在默认 manifest 注册各自的 hook 边界。OpenClaw 和 Hermes 还可使用 capability 配置，`SKILL_LEDGER_MODE` 仍作为部署级覆盖。除上述明确说明的 Qoder CLI 低层门禁外，其它兼容 hook 在 CLI 基础设施异常时保持 fail-open，避免阻断 Skill 加载。
 
-copilot-shell hook 当前仅覆盖 project / user / system 三类目录：`<cwd>/.copilot-shell/skills/`、`~/.copilot-shell/skills/`，以及 RPM 与 raw install 对应的 system 根目录 `/usr/share/anolisa/skills/` 和 `/usr/local/share/anolisa/skills/`。若 Skill 来自 custom、extension、remote 或其它路径，hook 会 fail-open 并跳过 skill-ledger 检查；OpenClaw 插件则按读取到的 `SKILL.md` 路径提取 Skill 目录。
+Ledger 内置发现项也包含 raw 用户目录。对此目录，`XDG_DATA_HOME`
+未设置、为空、为相对路径或包含 `.`、`..` 路径段时使用 `~/.local/share`，
+与 ANOLISA 和 cosh 保持一致。`enableDefaultSkillDirs=false` 也会禁用此内置项。
+hook 保留现有 policy 和未管理 Skill 的处理规则；识别目录不代表认证其内容。
+
+`agent-sec-cli capabilities --agent cosh --capability skill-ledger --output json`
+会显示生效的 XDG 数据根目录设置，不解析用户 home，也不读取 Agent 配置；
+回退值显示为 `~/.local/share`。
+
+copilot-shell hook 当前仅覆盖 project / user / system 三类目录：`<cwd>/.copilot-shell/skills/`、`~/.copilot-shell/skills/`、raw 用户目录 `$XDG_DATA_HOME/anolisa/skills/`（默认 `~/.local/share/anolisa/skills/`），以及 RPM 与 raw install 对应的 system 根目录 `/usr/share/anolisa/skills/` 和 `/usr/local/share/anolisa/skills/`。若 Skill 来自 custom、extension、remote 或其它路径，hook 会 fail-open 并跳过 skill-ledger 检查；OpenClaw 插件则按读取到的 `SKILL.md` 路径提取 Skill 目录。
 
 批量认证或安装后认证场景中，建议先完成目录定位和认证，再让 Agent 读取未认证 Skill 内容：批量认证前避免主动读取未认证 Skill 的 `SKILL.md` 或辅助文件；安装成功后应先定位最终本地目录，确认包含 `SKILL.md`，再执行快速扫描认证。
 
@@ -511,7 +520,7 @@ agent-sec-cli skill-ledger decide /path/to/skill --clear
 
 #### 配置 Skill 目录（批量扫描使用）
 
-默认已包含六个内置目录：`~/.openclaw/skills/*`、`~/.copilot-shell/skills/*`、`~/.hermes/skills/**`、`~/.qoder/skills/*`、`/usr/share/anolisa/skills/*`、`/usr/local/share/anolisa/skills/*`。项目级 Qoder 目录不作为相对默认项；对项目 Skill 显式执行 `scan` 或 `certify` 后，其绝对目录会沿用自动记忆机制写入 `managedSkillDirs`。如需添加其它目录，创建或编辑 `~/.config/agent-sec/skill-ledger/config.json`：
+默认已包含以下静态目录及 raw 用户目录：`~/.openclaw/skills/*`、`~/.copilot-shell/skills/*`、`~/.hermes/skills/**`、`~/.qoder/skills/*`、`/usr/share/anolisa/skills/*`、`/usr/local/share/anolisa/skills/*`。项目级 Qoder 目录不作为相对默认项；对项目 Skill 显式执行 `scan` 或 `certify` 后，其绝对目录会沿用自动记忆机制写入 `managedSkillDirs`。如需添加其它目录，创建或编辑 `~/.config/agent-sec/skill-ledger/config.json`：
 
 ```json
 {

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/core/skills.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/core/skills.md
@@ -22,12 +22,14 @@ Skills 是可复用的操作指令，用于处理重复任务。添加 Skill 后
 1. `<workspace>/.copilot-shell/skills/`
 2. `skills.custom_paths` 中的路径
 3. `~/.copilot-shell/skills/`
-4. Extensions 提供的 Skill 目录
-5. `/usr/local/share/anolisa/skills/`
-6. `/usr/share/anolisa/skills/`
+4. `$XDG_DATA_HOME/anolisa/skills/`（默认 `~/.local/share/anolisa/skills/`）
+5. Extensions 提供的 Skill 目录
+6. `/usr/local/share/anolisa/skills/`
+7. `/usr/share/anolisa/skills/`
 
-`anolisa install os-skills` 的 raw backend 在系统级安装时使用
-`/usr/local/share/anolisa/skills/`。raw 用户数据目录不会被自动搜索。
+`anolisa install os-skills` 的 raw backend 在用户级安装时使用上述用户数据目录，
+在系统级安装时使用 `/usr/local/share/anolisa/skills/`。
+`XDG_DATA_HOME` 未设置、为空、为相对路径或包含 `.`、`..` 路径段时使用上述默认值。
 在自定义或 Extension 目录中，同名 Skill 均采用第一个包含该名称的目录，列表与加载结果一致。
 
 使用自定义系统前缀时，应运行安装在同一前缀下的 cosh。

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/core/skills.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/core/skills.md
@@ -23,7 +23,19 @@ Skills 是可复用的操作指令，用于处理重复任务。添加 Skill 后
 2. `skills.custom_paths` 中的路径
 3. `~/.copilot-shell/skills/`
 4. Extensions 提供的 Skill 目录
-5. `/usr/share/anolisa/skills/`
+5. `/usr/local/share/anolisa/skills/`
+6. `/usr/share/anolisa/skills/`
+
+`anolisa install os-skills` 的 raw backend 在系统级安装时使用
+`/usr/local/share/anolisa/skills/`。raw 用户数据目录不会被自动搜索。
+在自定义或 Extension 目录中，同名 Skill 均采用第一个包含该名称的目录，列表与加载结果一致。
+
+使用自定义系统前缀时，应运行安装在同一前缀下的 cosh。
+例如，安装在 `/opt/x` 下的 cosh 会依次搜索
+`/opt/x/usr/local/share/anolisa/skills/` 和
+`/opt/x/usr/share/anolisa/skills/`，替代宿主机的系统目录；
+用户和项目目录的优先级保持不变。若需加载其他前缀下安装的技能，
+可使用 `skills.custom_paths`。
 
 已有目录会被监视，文件变化后自动重新扫描。
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/capabilities/view.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/capabilities/view.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import Any, Mapping
 
+from agent_sec_cli.skill_ledger.paths import valid_anolisa_data_home
+
 CANONICAL_CAPABILITIES = (
     "code-scan",
     "prompt-scan",
@@ -356,6 +358,14 @@ AGENT_SPECS: dict[str, dict[str, CapabilitySpec]] = {
         include_prompt_mode=False,
     ),
 }
+AGENT_SPECS["cosh"]["skill-ledger"] = CapabilitySpec(
+    _COSH_HOOKS["skill-ledger"],
+    (
+        *AGENT_SPECS["cosh"]["skill-ledger"].env,
+        EnvSpec("XDG_DATA_HOME", "~/.local/share", value_kind="anolisa_data_home"),
+    ),
+    "ask",
+)
 AGENT_SPECS["hermes"]["pii-check"] = CapabilitySpec(
     _HERMES_HOOKS["pii-check"],
     (
@@ -576,6 +586,10 @@ def _resolve_env(
             effective = _resolve_bool(spec, raw, diagnostics)
         elif spec.name.endswith("_TIMEOUT"):
             effective = _resolve_timeout(spec, raw, diagnostics)
+        elif spec.value_kind == "anolisa_data_home":
+            effective = raw if valid_anolisa_data_home(raw) else spec.default
+            if raw and effective == spec.default:
+                diagnostics.append(_fallback_diagnostic(spec))
         elif spec.value_kind == "identifier":
             engine_default, known = _engine_l2_backends()
             default = engine_default or spec.default

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/config.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/config.py
@@ -28,7 +28,10 @@ from agent_sec_cli.skill_ledger.path_identity import (
     normalize_canonical_skill_dir,
     validate_path_root_syntax,
 )
-from agent_sec_cli.skill_ledger.paths import get_config_dir
+from agent_sec_cli.skill_ledger.paths import (
+    get_anolisa_skill_dir,
+    get_config_dir,
+)
 from agent_sec_cli.skill_ledger.scanner.names import (
     CODE_SCANNER_NAME,
     STATIC_SCANNER_NAME,
@@ -156,11 +159,16 @@ def _validate_managed_skill_dir_entries(entries: list[str]) -> None:
             raise ConfigError(str(exc)) from exc
 
 
+def default_skill_dir_entries() -> list[str]:
+    """Resolve built-in discovery entries in the current installation environment."""
+    return [*DEFAULT_SKILL_DIRS, f"{get_anolisa_skill_dir()}/*"]
+
+
 def effective_skill_dir_entries(config: dict[str, Any]) -> list[str]:
     """Return built-in plus managed skill directory entries for discovery."""
     entries: list[str] = []
     if config.get("enableDefaultSkillDirs", True):
-        entries.extend(DEFAULT_SKILL_DIRS)
+        entries.extend(default_skill_dir_entries())
     entries.extend(str(v) for v in config.get("managedSkillDirs", []))
     return _compact_skill_dirs(entries)
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/status.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/status.py
@@ -10,8 +10,8 @@ import logging
 from typing import Any
 
 from agent_sec_cli.skill_ledger.config import (
-    DEFAULT_SKILL_DIRS,
     config_path,
+    default_skill_dir_entries,
     deprecated_skill_dir_entries,
     effective_skill_dir_entries,
     load_config,
@@ -74,7 +74,7 @@ def _config_info() -> dict[str, Any]:
         "configPath": str(cp),
         "customized": cp.is_file(),
         "defaultSkillDirsEnabled": bool(cfg.get("enableDefaultSkillDirs", True)),
-        "defaultSkillDirPatterns": len(DEFAULT_SKILL_DIRS),
+        "defaultSkillDirPatterns": len(default_skill_dir_entries()),
         "managedSkillDirPatterns": len(cfg.get("managedSkillDirs", [])),
         "ignoredDeprecatedSkillDirPatterns": len(deprecated_skill_dirs),
         "effectiveSkillDirPatterns": len(effective_skill_dirs),

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/paths.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/paths.py
@@ -38,3 +38,24 @@ def get_config_dir() -> Path:
     if not base:
         base = str(Path.home() / ".config")
     return Path(base) / _APP_NAME
+
+
+def valid_anolisa_data_home(value: str | None) -> bool:
+    """Match ANOLISA's absolute data-root syntax without resolving the filesystem."""
+    return (
+        bool(value)
+        and Path(value).is_absolute()
+        and not any(segment in (".", "..") for segment in value.split("/"))
+    )
+
+
+def get_anolisa_skill_dir() -> Path:
+    """Return the raw user skill root using ANOLISA's XDG fallback rules."""
+    value = os.environ.get("XDG_DATA_HOME")
+    # Match ANOLISA's root spelling; pathlib otherwise preserves exactly two slashes.
+    data_home = (
+        Path("/" + value.lstrip("/"))
+        if valid_anolisa_data_home(value)
+        else Path.home() / ".local/share"
+    )
+    return data_home / "anolisa/skills"

--- a/src/agent-sec-core/cosh-extension/hooks/skill_ledger_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/skill_ledger_hook.py
@@ -211,16 +211,17 @@ def _validate_skill_context(input_data: dict[str, Any], skill_name: str) -> str 
 
 
 def _supported_skill_bases(cwd: str) -> list[Path]:
-    """Return the skill roots currently covered by this hook.
-
-    Current scope is intentionally limited to:
-    project (.copilot-shell/skills/) → user (~/.copilot-shell/skills/)
-    → system (/usr/share/anolisa/skills/) → raw system
-    (/usr/local/share/anolisa/skills/).
-    """
+    """Return project, legacy/raw user, and RPM/raw system skill roots."""
+    data_home = os.environ.get("XDG_DATA_HOME", "")
+    # Keep this standalone hook aligned with ANOLISA and the Ledger CLI.
+    if not Path(data_home).is_absolute() or any(
+        segment in (".", "..") for segment in data_home.split("/")
+    ):
+        data_home = str(Path.home() / ".local/share")
     return [
         Path(cwd) / ".copilot-shell" / "skills",
         Path.home() / ".copilot-shell" / "skills",
+        Path(data_home) / "anolisa/skills",
         Path("/usr/share/anolisa/skills"),
         Path("/usr/local/share/anolisa/skills"),
     ]
@@ -300,10 +301,8 @@ def _resolve_skill_dir_from_context(
 def _resolve_skill_dir(skill_name: str, cwd: str) -> tuple[str | None, bool]:
     """Resolve a skill name to its on-disk directory.
 
-    Current hook scope is intentionally limited to:
-    project (.copilot-shell/skills/) → user (~/.copilot-shell/skills/)
-    → system (/usr/share/anolisa/skills/) → raw system
-    (/usr/local/share/anolisa/skills/).
+    Searches the same project, legacy/raw user, and system roots as
+    context-based resolution.
 
     Returns ``(path, traversal_detected)``:
     - ``(str, False)`` — resolved successfully.

--- a/src/agent-sec-core/docs/design/SKILL_LEDGER_zh.md
+++ b/src/agent-sec-core/docs/design/SKILL_LEDGER_zh.md
@@ -254,7 +254,7 @@ class SigningBackend(Protocol):
 
 不存在的目录会被静默忽略。
 
-**默认值**：内置六个默认目录（`~/.openclaw/skills/*`、`~/.copilot-shell/skills/*`、`~/.hermes/skills/**`、`~/.qoder/skills/*`、`/usr/share/anolisa/skills/*`、`/usr/local/share/anolisa/skills/*`），覆盖 OpenClaw、copilot-shell、Hermes、Qoder 用户级，以及 RPM 与 raw install 系统级 Skill。项目级 Qoder 目录不使用相对默认项，由 Qoder hook 根据事件中的绝对 `cwd` 运行时解析；显式 `scan` / `certify` 后再通过自动记忆写入绝对 `managedSkillDirs`。
+**默认值**：内置六个静态默认目录及 raw 用户目录 `$XDG_DATA_HOME/anolisa/skills/*`（未设置或非法时为 `~/.local/share/anolisa/skills/*`）。静态目录（`~/.openclaw/skills/*`、`~/.copilot-shell/skills/*`、`~/.hermes/skills/**`、`~/.qoder/skills/*`、`/usr/share/anolisa/skills/*`、`/usr/local/share/anolisa/skills/*`），覆盖 OpenClaw、copilot-shell、Hermes、Qoder 用户级，以及 RPM 与 raw install 系统级 Skill。项目级 Qoder 目录不使用相对默认项，由 Qoder hook 根据事件中的绝对 `cwd` 运行时解析；显式 `scan` / `certify` 后再通过自动记忆写入绝对 `managedSkillDirs`。
 
 **合并策略**：默认目录默认启用，由 `enableDefaultSkillDirs` 控制；`managedSkillDirs` 存放 skill-ledger 动态管理或用户额外配置的目录，不再兼容旧的 `skillDirs` 字段。解析时默认目录在前，`managedSkillDirs` 在后，自动去重。`scanners` 按 `name` 合并，用户配置可覆盖同名扫描器；`activationPolicy` 是全局运行态策略，当前只执行 `pass_warn_only` 行为，历史配置值 `pass_only` / `latest_scanned` 会兼容读取并归一化；`signingBackend` 当前会被读取到配置摘要中，但不会改变实际签名后端。
 
@@ -754,6 +754,7 @@ OpenClaw、Cosh（Legacy 与 NG）、Hermes、Codex 和 Qwen Code 遇到 CLI 不
 **Skill 目录定位（当前版本范围）**：两种 Cosh 输入协议共用同一目录边界，hook 仅覆盖 project → user → system 三类 Skill：
 - project：`<cwd>/.copilot-shell/skills/<skill>/`
 - user：`~/.copilot-shell/skills/<skill>/`
+- raw user：`$XDG_DATA_HOME/anolisa/skills/<skill>/`（默认 `~/.local/share/anolisa/skills/<skill>/`）
 - system（RPM）：`/usr/share/anolisa/skills/<skill>/`
 - system（raw install）：`/usr/local/share/anolisa/skills/<skill>/`
 

--- a/src/agent-sec-core/tests/unit-test/capabilities/test_view.py
+++ b/src/agent-sec-core/tests/unit-test/capabilities/test_view.py
@@ -770,3 +770,14 @@ def test_renderers_emit_stable_shapes() -> None:
     assert "HOOKS" not in lines[1]
     assert "SOURCE" not in lines[1]
     assert "code-scan" in table
+
+
+@pytest.mark.parametrize(
+    "data_home", [None, "", "relative", "/x/./y", "/x/../y", "/Data With Spaces"]
+)
+def test_cosh_ledger_xdg_view_preserves_paths_and_fallback(data_home):
+    env = {} if data_home is None else {"XDG_DATA_HOME": data_home}
+    record = query_capabilities(agent="cosh", capability="skill-ledger", env=env)[0]
+    expected = data_home if data_home == "/Data With Spaces" else "~/.local/share"
+    assert record.env["XDG_DATA_HOME"]["effective"] == expected
+    assert record.mode == "ask"

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_skill_ledger_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_skill_ledger_hook.py
@@ -918,3 +918,33 @@ def test_invalid_mode_reports_ask_fallback(monkeypatch, capsys):
 
     assert skill_ledger_hook._read_policy() == "ask"
     assert "invalid SKILL_LEDGER_MODE; using ask" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "data_home", [None, "", "relative", "/x/./y", "/x/../y", "absolute"]
+)
+@pytest.mark.parametrize("with_context", [False, True])
+def test_raw_user_skill_reaches_block_policy(
+    mock_cli_env, tmp_path, data_home, with_context
+):
+    env = mock_cli_env["make_env"](json.dumps({"message": "raw skill denied"}))
+    home = tmp_path / "home"
+    root = tmp_path / "XDG Data" if data_home == "absolute" else home / ".local/share"
+    skill = root / "anolisa/skills/raw-probe"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: raw-probe\n---\n")
+    env.update(
+        HOME=str(home),
+        XDG_DATA_HOME=str(root) if data_home == "absolute" else data_home or "",
+        SKILL_LEDGER_MODE="block",
+    )
+    output = _run_hook(
+        _make_ng_skill_event(
+            "raw-probe",
+            mock_cli_env["cwd"],
+            skill / "SKILL.md" if with_context else None,
+        ),
+        env_override=env,
+    )
+    assert output["decision"] == "block"
+    assert "raw skill denied" in output["reason"]

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_config.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_config.py
@@ -23,6 +23,7 @@ from agent_sec_cli.skill_ledger.config import (
     DEFAULT_SKILL_DIRS,
     _compact_skill_dirs,
     _deep_merge_config,
+    default_skill_dir_entries,
     deprecated_skill_dir_entries,
     effective_skill_dir_entries,
     is_covered,
@@ -152,7 +153,7 @@ class TestConfigMerge(unittest.TestCase):
     def test_effective_entries_include_defaults_by_default(self):
         config = {"enableDefaultSkillDirs": True, "managedSkillDirs": ["/opt/custom/*"]}
         entries = effective_skill_dir_entries(config)
-        self.assertEqual(entries, [*DEFAULT_SKILL_DIRS, "/opt/custom/*"])
+        self.assertEqual(entries, [*default_skill_dir_entries(), "/opt/custom/*"])
 
     def test_managed_resolver_excludes_default_skill_dirs(self):
         tmpdir = Path(tempfile.mkdtemp())
@@ -564,6 +565,49 @@ class TestIsCovered(unittest.TestCase):
 
         self.assertFalse(hidden.exists())
         self.assertTrue(is_managed_covered(hidden, config))
+
+
+def test_raw_user_defaults_follow_xdg_and_default_opt_out(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    for data_home in [
+        None,
+        str(tmp_path / "XDG Data"),
+        "",
+        "relative",
+        "/x/./y",
+        "/x/../y",
+    ]:
+        if data_home is None:
+            monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        else:
+            monkeypatch.setenv("XDG_DATA_HOME", data_home)
+        root = (
+            Path(data_home)
+            if data_home == str(tmp_path / "XDG Data")
+            else home / ".local/share"
+        )
+        skill = root / "anolisa/skills/raw-probe"
+        skill.mkdir(parents=True, exist_ok=True)
+        (skill / "SKILL.md").write_text("---\nname: raw-probe\n---\n")
+        assert skill in resolve_skill_dirs({"enableDefaultSkillDirs": True})
+        assert not resolve_skill_dirs({"enableDefaultSkillDirs": False})
+
+
+def test_raw_user_defaults_normalize_leading_slashes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    for count in (2, 3):
+        root = tmp_path / f"data-{count}"
+        monkeypatch.setenv("XDG_DATA_HOME", "/" * count + str(root).lstrip("/"))
+        config = {"enableDefaultSkillDirs": True}
+        assert not root.exists()
+        assert f"{root}/anolisa/skills/*" in effective_skill_dir_entries(config)
+        skill = root / "anolisa/skills/raw-probe"
+        assert skill not in resolve_skill_dirs(config)
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("---\nname: raw-probe\n---\n")
+        assert skill in resolve_skill_dirs(config)
+        assert is_covered(skill, config)
 
 
 if __name__ == "__main__":

--- a/src/cosh-ng/crates/cosh-core/src/extension.rs
+++ b/src/cosh-ng/crates/cosh-core/src/extension.rs
@@ -18,7 +18,7 @@ pub mod state;
 pub mod variables;
 
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
@@ -36,12 +36,6 @@ use crate::skill::COPILOT_CONFIG_DIR;
 
 /// Sub-directory under `~/.copilot-shell/` containing installed extensions.
 pub const USER_EXTENSIONS_DIR: &str = "extensions";
-
-/// System-wide extensions directory installed by the host package manager.
-pub const SYSTEM_EXTENSIONS_DIR: &str = "/usr/share/anolisa/extensions";
-
-/// System-wide extensions directory used by raw installations.
-pub(crate) const LOCAL_SYSTEM_EXTENSIONS_DIR: &str = "/usr/local/share/anolisa/extensions";
 
 /// Canonical extension manifest file name.
 pub const EXTENSION_CONFIG_FILENAME: &str = "cosh-extension.json";
@@ -206,73 +200,9 @@ pub fn user_extensions_dir() -> Option<PathBuf> {
 }
 
 /// Returns system extension directories for the running installation.
-///
-/// Installed binaries derive both raw and package-managed roots from their
-/// FHS libexec location. Development binaries fall back to the host defaults.
 pub(crate) fn system_extensions_dirs() -> Vec<PathBuf> {
-    system_extensions_dirs_for_executable(std::env::current_exe().ok().as_deref())
-}
-
-fn system_extensions_dirs_for_executable(executable: Option<&Path>) -> Vec<PathBuf> {
-    let Some(prefix) = executable.and_then(anolisa_prefix_from_executable) else {
-        return vec![
-            PathBuf::from(LOCAL_SYSTEM_EXTENSIONS_DIR),
-            PathBuf::from(SYSTEM_EXTENSIONS_DIR),
-        ];
-    };
-    vec![
-        prefix.join("usr/local/share/anolisa/extensions"),
-        prefix.join("usr/share/anolisa/extensions"),
-    ]
-}
-
-fn anolisa_prefix_from_executable(executable: &Path) -> Option<&Path> {
-    let cosh_ng_dir = executable.parent()?;
-    let anolisa_dir = cosh_ng_dir.parent()?;
-    let libexec_dir = anolisa_dir.parent()?;
-    if executable.file_name()? != "cosh-core"
-        || cosh_ng_dir.file_name()? != "cosh-ng"
-        || anolisa_dir.file_name()? != "anolisa"
-        || libexec_dir.file_name()? != "libexec"
-    {
-        return None;
-    }
-
-    let fhs_tree = libexec_dir.parent()?;
-    if fhs_tree.ends_with("usr/local") {
-        fhs_tree.parent()?.parent()
-    } else if fhs_tree.ends_with("usr") {
-        fhs_tree.parent()
-    } else {
-        None
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn system_extension_roots_prefer_raw_installations() {
-        assert_eq!(
-            system_extensions_dirs_for_executable(None),
-            vec![
-                PathBuf::from("/usr/local/share/anolisa/extensions"),
-                PathBuf::from("/usr/share/anolisa/extensions"),
-            ]
-        );
-    }
-
-    #[test]
-    fn system_extension_roots_follow_custom_prefix() {
-        let executable = Path::new("/opt/anolisa/usr/local/libexec/anolisa/cosh-ng/cosh-core");
-
-        assert_eq!(
-            system_extensions_dirs_for_executable(Some(executable)),
-            vec![
-                PathBuf::from("/opt/anolisa/usr/local/share/anolisa/extensions"),
-                PathBuf::from("/opt/anolisa/usr/share/anolisa/extensions"),
-            ]
-        );
-    }
+    crate::paths::system_data_dirs()
+        .into_iter()
+        .map(|dir| dir.join("extensions"))
+        .collect()
 }

--- a/src/cosh-ng/crates/cosh-core/src/main.rs
+++ b/src/cosh-ng/crates/cosh-core/src/main.rs
@@ -18,6 +18,7 @@ mod logging;
 mod loop_detect;
 mod metrics;
 mod migrate;
+mod paths;
 mod process;
 mod protocol;
 mod redaction;

--- a/src/cosh-ng/crates/cosh-core/src/paths.rs
+++ b/src/cosh-ng/crates/cosh-core/src/paths.rs
@@ -1,0 +1,83 @@
+//! Shared ANOLISA data roots for installed skills and extensions.
+
+use std::path::{Path, PathBuf};
+
+/// Returns raw and package-managed data roots for the running installation.
+/// Installed binaries follow their FHS libexec prefix; development binaries
+/// and user installations use the host system roots.
+pub(crate) fn system_data_dirs() -> Vec<PathBuf> {
+    system_data_dirs_for_executable(std::env::current_exe().ok().as_deref())
+}
+
+fn system_data_dirs_for_executable(executable: Option<&Path>) -> Vec<PathBuf> {
+    let prefix = executable
+        .and_then(anolisa_prefix_from_executable)
+        .unwrap_or_else(|| Path::new("/"));
+    vec![
+        prefix.join("usr/local/share/anolisa"),
+        prefix.join("usr/share/anolisa"),
+    ]
+}
+
+fn anolisa_prefix_from_executable(executable: &Path) -> Option<&Path> {
+    let cosh_ng_dir = executable.parent()?;
+    let anolisa_dir = cosh_ng_dir.parent()?;
+    let libexec_dir = anolisa_dir.parent()?;
+    if executable.file_name()? != "cosh-core"
+        || cosh_ng_dir.file_name()? != "cosh-ng"
+        || anolisa_dir.file_name()? != "anolisa"
+        || libexec_dir.file_name()? != "libexec"
+    {
+        return None;
+    }
+
+    let fhs_tree = libexec_dir.parent()?;
+    if fhs_tree.ends_with("usr/local") {
+        fhs_tree.parent()?.parent()
+    } else if fhs_tree.ends_with("usr") {
+        fhs_tree.parent()
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_data_roots_follow_installation_prefix() {
+        for executable in [
+            "/opt/anolisa/usr/local/libexec/anolisa/cosh-ng/cosh-core",
+            "/opt/anolisa/usr/libexec/anolisa/cosh-ng/cosh-core",
+        ] {
+            assert_eq!(
+                system_data_dirs_for_executable(Some(Path::new(executable))),
+                vec![
+                    PathBuf::from("/opt/anolisa/usr/local/share/anolisa"),
+                    PathBuf::from("/opt/anolisa/usr/share/anolisa"),
+                ]
+            );
+        }
+    }
+
+    #[test]
+    fn system_data_roots_default_to_host() {
+        for executable in [
+            None,
+            Some("/usr/local/libexec/anolisa/cosh-ng/cosh-core"),
+            Some("/usr/libexec/anolisa/cosh-ng/cosh-core"),
+            Some("/home/user/.local/lib/anolisa/libexec/cosh-ng/cosh-core"),
+            Some("/work/target/debug/cosh-core"),
+            Some("/opt/anolisa/usr/local/libexec/other/cosh-ng/cosh-core"),
+        ] {
+            assert_eq!(
+                system_data_dirs_for_executable(executable.map(Path::new)),
+                vec![
+                    PathBuf::from("/usr/local/share/anolisa"),
+                    PathBuf::from("/usr/share/anolisa"),
+                ]
+            );
+        }
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/skill/manager.rs
+++ b/src/cosh-ng/crates/cosh-core/src/skill/manager.rs
@@ -6,7 +6,7 @@ use tokio::sync::{broadcast, RwLock};
 
 use super::loader;
 use super::types::{SkillConfig, SkillLevel};
-use super::{COPILOT_CONFIG_DIR, SKILLS_DIR, SYSTEM_SKILLS_DIR};
+use super::{COPILOT_CONFIG_DIR, SKILLS_DIR};
 
 /// Central manager for skill discovery, caching, hot-reload and priority
 /// merging. Mirrors the role of copilot-shell's `SkillManager`.
@@ -18,9 +18,8 @@ pub struct SkillManager {
     change_tx: broadcast::Sender<()>,
     #[allow(dead_code)]
     watcher_handle: RwLock<Option<notify::RecommendedWatcher>>,
-    /// Test-only overrides for user / system directories.
-    user_dir_override: Option<PathBuf>,
-    system_dir_override: Option<PathBuf>,
+    user_paths: Vec<PathBuf>,
+    system_paths: Vec<PathBuf>,
 }
 
 impl SkillManager {
@@ -44,8 +43,14 @@ impl SkillManager {
             extension_paths,
             change_tx,
             watcher_handle: RwLock::new(None),
-            user_dir_override: None,
-            system_dir_override: None,
+            user_paths: dirs::home_dir()
+                .map(|home| home.join(COPILOT_CONFIG_DIR).join(SKILLS_DIR))
+                .into_iter()
+                .collect(),
+            system_paths: crate::paths::system_data_dirs()
+                .into_iter()
+                .map(|dir| dir.join(SKILLS_DIR))
+                .collect(),
         })
     }
 
@@ -58,17 +63,15 @@ impl SkillManager {
         user_dir: Option<PathBuf>,
         system_dir: Option<PathBuf>,
     ) -> Arc<Self> {
-        let (change_tx, _) = broadcast::channel(16);
-        Arc::new(Self {
-            cache: RwLock::new(HashMap::new()),
-            project_root,
-            custom_paths,
-            extension_paths: Vec::new(),
-            change_tx,
-            watcher_handle: RwLock::new(None),
-            user_dir_override: user_dir,
-            system_dir_override: system_dir,
-        })
+        let mut manager = Self::new(project_root, custom_paths, Vec::new());
+        let inner = Arc::get_mut(&mut manager).unwrap();
+        if let Some(dir) = user_dir {
+            inner.user_paths = vec![dir];
+        }
+        if let Some(dir) = system_dir {
+            inner.system_paths = vec![dir];
+        }
+        manager
     }
 
     /// Rescan all skill directories and update the internal cache.
@@ -76,44 +79,13 @@ impl SkillManager {
         let mut new_cache: HashMap<SkillLevel, Vec<SkillConfig>> = HashMap::new();
 
         for &level in SkillLevel::all() {
-            if level == SkillLevel::Custom || level == SkillLevel::Extension {
-                continue; // handled separately below
-            }
-            if let Some(dir) = self.base_dir_of(level) {
-                if dir.exists() {
-                    let skills = loader::load_skills_from_dir(&dir, level);
-                    if !skills.is_empty() {
-                        new_cache.insert(level, skills);
-                    }
-                }
-            }
-        }
-
-        // Custom level: multiple paths
-        if !self.custom_paths.is_empty() {
-            let mut custom_skills: Vec<SkillConfig> = Vec::new();
-            for custom_path in &self.custom_paths {
-                if custom_path.exists() {
-                    let skills = loader::load_skills_from_dir(custom_path, SkillLevel::Custom);
-                    custom_skills.extend(skills);
-                }
-            }
-            if !custom_skills.is_empty() {
-                new_cache.insert(SkillLevel::Custom, custom_skills);
-            }
-        }
-
-        // Extension level: multiple paths from loaded extensions
-        if !self.extension_paths.is_empty() {
-            let mut ext_skills: Vec<SkillConfig> = Vec::new();
-            for ext_path in &self.extension_paths {
-                if ext_path.exists() {
-                    let skills = loader::load_skills_from_dir(ext_path, SkillLevel::Extension);
-                    ext_skills.extend(skills);
-                }
-            }
-            if !ext_skills.is_empty() {
-                new_cache.insert(SkillLevel::Extension, ext_skills);
+            let skills: Vec<_> = self
+                .dirs_of(level)
+                .iter()
+                .flat_map(|dir| loader::load_skills_from_dir(dir, level))
+                .collect();
+            if !skills.is_empty() {
+                new_cache.insert(level, skills);
             }
         }
 
@@ -132,7 +104,8 @@ impl SkillManager {
         // overwrite lower ones.
         for &level in SkillLevel::all().iter().rev() {
             if let Some(skills) = cache.get(&level) {
-                for skill in skills {
+                // Earlier directories within a level also win, matching load().
+                for skill in skills.iter().rev() {
                     merged.insert(skill.name.clone(), skill.clone());
                 }
             }
@@ -217,45 +190,30 @@ impl SkillManager {
 
     // ── private helpers ──────────────────────────────────────────────
 
-    fn base_dir_of(&self, level: SkillLevel) -> Option<PathBuf> {
+    fn dirs_of(&self, level: SkillLevel) -> Vec<PathBuf> {
         match level {
             SkillLevel::Project => {
                 // Skip if project_root is the same as home (avoids double-scan)
                 let home = dirs::home_dir().and_then(|h| h.canonicalize().ok());
                 let project = self.project_root.canonicalize().ok();
                 if home.is_some() && home == project {
-                    None
+                    Vec::new()
                 } else {
-                    Some(self.project_root.join(COPILOT_CONFIG_DIR).join(SKILLS_DIR))
+                    vec![self.project_root.join(COPILOT_CONFIG_DIR).join(SKILLS_DIR)]
                 }
             }
-            SkillLevel::Custom => None, // custom paths are iterated separately
-            SkillLevel::Extension => None, // extension paths are iterated separately
-            SkillLevel::User => {
-                if let Some(ref p) = self.user_dir_override {
-                    return Some(p.clone());
-                }
-                dirs::home_dir().map(|h| h.join(COPILOT_CONFIG_DIR).join(SKILLS_DIR))
-            }
-            SkillLevel::System => {
-                if let Some(ref p) = self.system_dir_override {
-                    return Some(p.clone());
-                }
-                Some(PathBuf::from(SYSTEM_SKILLS_DIR))
-            }
+            SkillLevel::Custom => self.custom_paths.clone(),
+            SkillLevel::Extension => self.extension_paths.clone(),
+            SkillLevel::User => self.user_paths.clone(),
+            SkillLevel::System => self.system_paths.clone(),
         }
     }
 
     fn watch_dirs(&self) -> Vec<PathBuf> {
-        let mut dirs = Vec::new();
-        for &level in SkillLevel::all() {
-            if let Some(d) = self.base_dir_of(level) {
-                dirs.push(d);
-            }
-        }
-        dirs.extend(self.custom_paths.iter().cloned());
-        dirs.extend(self.extension_paths.iter().cloned());
-        dirs
+        SkillLevel::all()
+            .iter()
+            .flat_map(|&level| self.dirs_of(level))
+            .collect()
     }
 }
 
@@ -442,40 +400,99 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ordered_directories_agree_for_list_load_and_watch() {
+        let root = tempfile::tempdir().unwrap();
+        let mut mgr = SkillManager::new(
+            root.path().join("project"),
+            vec![root.path().join("custom-1"), root.path().join("custom-2")],
+            vec![
+                root.path().join("extension-1"),
+                root.path().join("extension-2"),
+            ],
+        );
+        let inner = Arc::get_mut(&mut mgr).unwrap();
+        assert_eq!(
+            inner.system_paths,
+            vec![
+                PathBuf::from("/usr/local/share/anolisa/skills"),
+                PathBuf::from("/usr/share/anolisa/skills"),
+            ]
+        );
+        inner.user_paths = vec![root.path().join("home/.copilot-shell/skills")];
+        inner.system_paths = inner
+            .system_paths
+            .iter()
+            .map(|path| root.path().join(path.strip_prefix("/").unwrap()))
+            .collect();
+        let dirs = mgr.watch_dirs();
+        assert_eq!(dirs.len(), 8);
+        for (i, dir) in dirs.iter().enumerate() {
+            std::fs::create_dir_all(dir).unwrap();
+            for name in ["shared".to_string(), format!("only-{i}")] {
+                std::fs::write(
+                    dir.join(format!("{name}.md")),
+                    format!("---\nname: {name}\ndescription: directory {i}\n---\nBody {i}"),
+                )
+                .unwrap();
+            }
+        }
+        // Removing each winner exposes the next directory without hiding
+        // skills unique to any lower-priority root.
+        for dir in &dirs {
+            mgr.refresh().await;
+            let listed = mgr.list().await;
+            assert_eq!(listed.len(), dirs.len() + 1);
+            let listed = listed.iter().find(|skill| skill.name == "shared").unwrap();
+            let loaded = mgr.load("shared").await.unwrap();
+            assert_eq!(listed.file_path, dir.join("shared.md"));
+            assert_eq!(loaded.file_path, listed.file_path);
+            assert_eq!(loaded.body, listed.body);
+            std::fs::remove_file(dir.join("shared.md")).unwrap();
+        }
+        // Missing roots are normal when only one install mode is in use.
+        std::fs::remove_dir_all(&dirs[0]).unwrap();
+        mgr.refresh().await;
+        assert!(mgr.load("shared").await.is_none());
+        assert_eq!(mgr.list().await.len(), dirs.len() - 1);
+    }
+
+    #[tokio::test]
     async fn watcher_triggers_refresh() {
         let project_dir = tempfile::tempdir().unwrap();
         let custom_dir = tempfile::tempdir().unwrap();
 
-        let mgr = isolated_manager(project_dir.path(), vec![custom_dir.path().to_path_buf()]);
+        let mut mgr = isolated_manager(project_dir.path(), vec![custom_dir.path().to_path_buf()]);
+        let inner = Arc::get_mut(&mut mgr).unwrap();
+        inner.user_paths = vec![project_dir.path().join("home/.copilot-shell/skills")];
+        inner.system_paths = vec![project_dir.path().join("usr/local/share/anolisa/skills")];
+        let dirs = mgr.watch_dirs();
+        for dir in &dirs {
+            std::fs::create_dir_all(dir).unwrap();
+        }
         mgr.refresh().await;
         assert!(mgr.list().await.is_empty());
 
         mgr.start_watching().await;
 
-        // Create a new skill file in the custom dir
-        let new_skill_dir = custom_dir.path().join("new-skill");
-        std::fs::create_dir_all(&new_skill_dir).unwrap();
-        std::fs::write(
-            new_skill_dir.join("SKILL.md"),
-            "---\nname: new-skill\ndescription: dynamic\n---\n\nDynamic body.",
-        )
-        .unwrap();
+        for (i, dir) in dirs.iter().enumerate() {
+            let name = format!("new-skill-{i}");
+            let new_skill_dir = dir.join(&name);
+            std::fs::create_dir_all(&new_skill_dir).unwrap();
+            std::fs::write(
+                new_skill_dir.join("SKILL.md"),
+                format!("---\nname: {name}\ndescription: dynamic\n---\n\nDynamic body."),
+            )
+            .unwrap();
 
-        // Wait for the watcher to pick up the new skill (poll up to 5s).
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
-        loop {
-            let all = mgr.list().await;
-            if all.iter().any(|s| s.name == "new-skill") {
-                break;
-            }
-            if tokio::time::Instant::now() >= deadline {
-                let names: Vec<&String> = all.iter().map(|s| &s.name).collect();
-                panic!(
-                    "watcher did not pick up new-skill within 5s, found: {:?}",
-                    names
+            let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+            while mgr.load(&name).await.is_none() {
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "watcher did not pick up {} within 5s",
+                    new_skill_dir.display()
                 );
+                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
             }
-            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         }
     }
 

--- a/src/cosh-ng/crates/cosh-core/src/skill/manager.rs
+++ b/src/cosh-ng/crates/cosh-core/src/skill/manager.rs
@@ -43,10 +43,10 @@ impl SkillManager {
             extension_paths,
             change_tx,
             watcher_handle: RwLock::new(None),
-            user_paths: dirs::home_dir()
-                .map(|home| home.join(COPILOT_CONFIG_DIR).join(SKILLS_DIR))
-                .into_iter()
-                .collect(),
+            user_paths: user_skill_dirs(
+                dirs::home_dir(),
+                std::env::var_os("XDG_DATA_HOME").map(PathBuf::from),
+            ),
             system_paths: crate::paths::system_data_dirs()
                 .into_iter()
                 .map(|dir| dir.join(SKILLS_DIR))
@@ -215,6 +215,25 @@ impl SkillManager {
             .flat_map(|&level| self.dirs_of(level))
             .collect()
     }
+}
+
+// ANOLISA uses the XDG layout on both Linux and macOS, rather than the
+// platform-specific data directory returned by dirs::data_dir(). Match its
+// install layout by ignoring relative roots and explicit dot segments.
+fn user_skill_dirs(home: Option<PathBuf>, data_home: Option<PathBuf>) -> Vec<PathBuf> {
+    let data_home = data_home
+        .filter(|path| {
+            path.is_absolute()
+                && !path
+                    .to_string_lossy()
+                    .split(std::path::MAIN_SEPARATOR)
+                    .any(|segment| segment == "." || segment == "..")
+        })
+        .or_else(|| home.as_ref().map(|home| home.join(".local/share")));
+    home.into_iter()
+        .map(|home| home.join(COPILOT_CONFIG_DIR).join(SKILLS_DIR))
+        .chain(data_home.map(|data| data.join("anolisa/skills")))
+        .collect()
 }
 
 /// Expand `~`, `${VAR}`, and `$VAR` in a path string.
@@ -418,14 +437,21 @@ mod tests {
                 PathBuf::from("/usr/share/anolisa/skills"),
             ]
         );
-        inner.user_paths = vec![root.path().join("home/.copilot-shell/skills")];
+        inner.user_paths = user_skill_dirs(Some(root.path().join("home")), None);
+        assert_eq!(
+            inner.user_paths,
+            vec![
+                root.path().join("home/.copilot-shell/skills"),
+                root.path().join("home/.local/share/anolisa/skills"),
+            ]
+        );
         inner.system_paths = inner
             .system_paths
             .iter()
             .map(|path| root.path().join(path.strip_prefix("/").unwrap()))
             .collect();
         let dirs = mgr.watch_dirs();
-        assert_eq!(dirs.len(), 8);
+        assert_eq!(dirs.len(), 9);
         for (i, dir) in dirs.iter().enumerate() {
             std::fs::create_dir_all(dir).unwrap();
             for name in ["shared".to_string(), format!("only-{i}")] {
@@ -436,8 +462,8 @@ mod tests {
                 .unwrap();
             }
         }
-        // Removing each winner exposes the next directory without hiding
-        // skills unique to any lower-priority root.
+        // Removing each winner exposes the next directory, including both
+        // raw roots, without hiding skills unique to any lower-priority root.
         for dir in &dirs {
             mgr.refresh().await;
             let listed = mgr.list().await;
@@ -463,7 +489,7 @@ mod tests {
 
         let mut mgr = isolated_manager(project_dir.path(), vec![custom_dir.path().to_path_buf()]);
         let inner = Arc::get_mut(&mut mgr).unwrap();
-        inner.user_paths = vec![project_dir.path().join("home/.copilot-shell/skills")];
+        inner.user_paths = user_skill_dirs(Some(project_dir.path().join("home")), None);
         inner.system_paths = vec![project_dir.path().join("usr/local/share/anolisa/skills")];
         let dirs = mgr.watch_dirs();
         for dir in &dirs {

--- a/src/cosh-ng/crates/cosh-core/src/skill/mod.rs
+++ b/src/cosh-ng/crates/cosh-core/src/skill/mod.rs
@@ -12,5 +12,3 @@ pub const COPILOT_CONFIG_DIR: &str = ".copilot-shell";
 pub const SKILLS_DIR: &str = "skills";
 /// Canonical skill manifest file name inside a skill directory.
 pub const SKILL_MANIFEST: &str = "SKILL.md";
-/// System-wide skills installed by the os-skills RPM package.
-pub const SYSTEM_SKILLS_DIR: &str = "/usr/share/anolisa/skills";

--- a/src/cosh-ng/crates/cosh-core/tests/registry_protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/registry_protocol.rs
@@ -163,6 +163,7 @@ fn run_registry_request_with_args_and_env(
         .arg("--registry")
         .args(args)
         .env("HOME", home)
+        .env_remove("XDG_DATA_HOME")
         .env_remove("COSH_AI_PROVIDER")
         .env_remove("COSH_MODEL")
         .env_remove("OPENAI_BASE_URL")
@@ -178,9 +179,13 @@ fn run_registry_request_with_args_and_env(
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
     }
+    registry_command_response(command, request)
+}
+
+fn registry_command_response(mut command: Command, request: Value) -> Value {
     let mut child = command
         .spawn()
-        .unwrap_or_else(|e| panic!("Failed to spawn {}: {e}", bin.display()));
+        .unwrap_or_else(|e| panic!("Failed to spawn registry command: {e}"));
 
     {
         let stdin = child.stdin.as_mut().unwrap();
@@ -836,6 +841,114 @@ fn registry_skills_list_returns_success() {
     assert_eq!(resp["request_id"], "test-1");
     assert_eq!(resp["success"], true);
     assert!(resp["data"].is_array(), "data should be array: {resp}");
+}
+
+#[test]
+fn registry_skills_does_not_autodiscover_raw_user_roots() {
+    let xdg = tempfile::tempdir().unwrap();
+    for data_home in [None, Some(xdg.path().to_str().unwrap())] {
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let data_dir = data_home
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| home.path().join(".local/share"));
+        let skill_dir = data_dir.join("anolisa/skills/raw-install-probe");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: raw-install-probe\ndescription: raw user install\n---\nRaw skill body.",
+        )
+        .unwrap();
+        let legacy = home.path().join(".copilot-shell/skills/legacy-probe");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(
+            legacy.join("SKILL.md"),
+            "---\nname: legacy-probe\ndescription: legacy user install\n---\nLegacy body.",
+        )
+        .unwrap();
+        let env: Vec<_> = data_home
+            .map(|value| ("XDG_DATA_HOME", value))
+            .into_iter()
+            .collect();
+        let response = run_registry_request_with_args_and_env(
+            "skills",
+            "list",
+            Value::Null,
+            home.path(),
+            Some(project.path()),
+            &[],
+            &env,
+        );
+        assert_eq!(response["success"], true);
+        let skills = response["data"].as_array().unwrap();
+        assert!(skills.iter().any(|skill| skill["name"] == "legacy-probe"));
+        assert!(!skills
+            .iter()
+            .any(|skill| skill["name"] == "raw-install-probe"));
+        let detail = run_registry_request_with_args_and_env(
+            "skills",
+            "detail",
+            serde_json::json!({"name": "raw-install-probe"}),
+            home.path(),
+            Some(project.path()),
+            &[],
+            &env,
+        );
+        assert_eq!(detail["success"], false);
+    }
+}
+
+#[test]
+fn registry_skills_discovers_custom_system_prefix() {
+    let binary = binary_path();
+    let prefix = tempfile::tempdir_in(binary.parent().unwrap()).unwrap();
+    let home = tempfile::tempdir().unwrap();
+    for (data_root, description) in [
+        ("usr/local/share/anolisa", "raw"),
+        ("usr/share/anolisa", "package"),
+    ] {
+        let skill = prefix.path().join(data_root).join("skills/prefix-probe");
+        std::fs::create_dir_all(&skill).unwrap();
+        std::fs::write(
+            skill.join("SKILL.md"),
+            format!("---\nname: prefix-probe\ndescription: {description}\n---\nBody."),
+        )
+        .unwrap();
+    }
+    for runtime in [
+        "usr/local/libexec/anolisa/cosh-ng",
+        "usr/libexec/anolisa/cosh-ng",
+    ] {
+        let executable = prefix.path().join(runtime).join("cosh-core");
+        std::fs::create_dir_all(executable.parent().unwrap()).unwrap();
+        // Relocate without opening the executable for writing during parallel spawns.
+        std::fs::hard_link(&binary, &executable).unwrap();
+        let mut command = Command::new(executable);
+        command
+            .arg("--registry")
+            .env_clear()
+            .env("HOME", home.path())
+            .current_dir(home.path())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let response = registry_command_response(
+            command,
+            serde_json::json!({
+                "type": "registry_request", "request_id": "prefix-probe",
+                "domain": "skills", "action": "list", "params": null,
+            }),
+        );
+        assert_eq!(response["success"], true);
+        let skill = response["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|skill| skill["name"] == "prefix-probe")
+            .unwrap_or_else(|| panic!("skill missing for runtime {runtime}"));
+        assert_eq!(skill["level"], "system");
+        assert_eq!(skill["description"], "raw");
+    }
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-core/tests/registry_protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/registry_protocol.rs
@@ -844,26 +844,30 @@ fn registry_skills_list_returns_success() {
 }
 
 #[test]
-fn registry_skills_does_not_autodiscover_raw_user_roots() {
+fn registry_skills_discovers_raw_user_data_directory() {
     let xdg = tempfile::tempdir().unwrap();
-    for data_home in [None, Some(xdg.path().to_str().unwrap())] {
+    let dot = xdg.path().join("./data");
+    let parent = xdg.path().join("../data");
+    for (data_home, use_xdg) in [
+        (None, false),
+        (Some(xdg.path().to_str().unwrap()), true),
+        (Some(""), false),
+        (Some("relative-data"), false),
+        (Some(dot.to_str().unwrap()), false),
+        (Some(parent.to_str().unwrap()), false),
+    ] {
         let home = tempfile::tempdir().unwrap();
         let project = tempfile::tempdir().unwrap();
-        let data_dir = data_home
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|| home.path().join(".local/share"));
+        let data_dir = if use_xdg {
+            xdg.path().to_path_buf()
+        } else {
+            home.path().join(".local/share")
+        };
         let skill_dir = data_dir.join("anolisa/skills/raw-install-probe");
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
             "---\nname: raw-install-probe\ndescription: raw user install\n---\nRaw skill body.",
-        )
-        .unwrap();
-        let legacy = home.path().join(".copilot-shell/skills/legacy-probe");
-        std::fs::create_dir_all(&legacy).unwrap();
-        std::fs::write(
-            legacy.join("SKILL.md"),
-            "---\nname: legacy-probe\ndescription: legacy user install\n---\nLegacy body.",
         )
         .unwrap();
         let env: Vec<_> = data_home
@@ -880,21 +884,13 @@ fn registry_skills_does_not_autodiscover_raw_user_roots() {
             &env,
         );
         assert_eq!(response["success"], true);
-        let skills = response["data"].as_array().unwrap();
-        assert!(skills.iter().any(|skill| skill["name"] == "legacy-probe"));
-        assert!(!skills
+        let skill = response["data"]
+            .as_array()
+            .unwrap()
             .iter()
-            .any(|skill| skill["name"] == "raw-install-probe"));
-        let detail = run_registry_request_with_args_and_env(
-            "skills",
-            "detail",
-            serde_json::json!({"name": "raw-install-probe"}),
-            home.path(),
-            Some(project.path()),
-            &[],
-            &env,
-        );
-        assert_eq!(detail["success"], false);
+            .find(|skill| skill["name"] == "raw-install-probe")
+            .unwrap_or_else(|| panic!("raw skill missing for XDG_DATA_HOME={data_home:?}"));
+        assert_eq!(skill["level"], "user");
     }
 }
 


### PR DESCRIPTION
## Why

ANOLISA raw installations place OS skills outside Cosh's previous default roots. Enabling raw user discovery alone also bypasses the Cosh Skill Ledger hook, because its covered directories omit that root.

## What changed

Discover raw system and user skills through one ordered directory list shared by scanning and watching, with list/load collision winners kept consistent. Reuse Extensions' executable-relative data-root resolver for custom system prefixes. Add raw user directory coverage to the standalone Ledger hook and CLI in a separate sec-core commit, using the same XDG fallback rules and normalizing repeated leading slashes for generated default entries. Synchronize the capability environment view, regression tests, and bilingual guides.

## Related issue

Closes #3145

#3153 is consolidated into this PR: raw user discovery and Ledger coverage are delivered together.

## User / Agent impact

Raw OS skills are discovered without custom paths. Traditional user skills retain precedence over raw user skills, and raw system skills precede RPM system skills; project > custom > user > extension > system priority is unchanged. Raw user invocations now reach the existing Ledger policy through both exact Host file context and name lookup.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

Installer paths, CLI flags, and configuration keys remain unchanged. Missing roots remain optional; watching starts only for existing directories. The standalone hook stays independent of CLI imports, and Ledger preserves existing policy, managed/unmanaged handling, infrastructure-error behavior, and default-directory opt-out. The capability view reads only the current environment. Generated raw user roots normalize leading slashes without weakening explicitly configured canonical-path validation. Custom-prefix system skills remain outside the existing Ledger hook scope. No migration is required.

## Validation

Linux aarch64; Rust commands from `src/cosh-ng`, Python 3.11.6 checks using an isolated task environment:

- `cargo fmt --all -- --check` — passed.
- `cargo test --locked -p cosh-core --bin cosh-core 'skill::'` — 19 passed, including priority, list/load consistency, missing directories, watching, and invocation lookup.
- `cargo test --locked -p cosh-core --test registry_protocol registry_skills_` — 4 passed, covering raw user XDG rules and raw/RPM executable layouts under custom prefixes.
- `cargo clippy --locked -p cosh-core --all-targets -- -D warnings` — passed.
- Targeted pytest on `tests/unit-test/cosh_hooks/test_skill_ledger_hook.py`, `tests/unit-test/skill_ledger/test_config.py`, and `tests/unit-test/capabilities/test_view.py` — 296 passed, 1 skipped, 3 subtests passed. Coverage includes exact context/name lookup in block mode, XDG fallback, default opt-out, capability parity, and double/triple-leading-slash roots.
- Real `agent-sec-cli skill-ledger status` reproduction with a double-leading-slash XDG root — exit 0 and valid JSON for an absent root and for one installed skill.
- Component-root Black/Isort — passed. Incremental Ruff — no changed-line diagnostics; one unchanged import-order diagnostic remains in the existing capability test imports.
- `git diff --check` and bilingual guide links — passed.

Tests use isolated directories and child environments. No host installation, external provider call, or macOS runtime validation was performed.

## Documentation and rollback

Update the English and Chinese Cosh/Skill Ledger guides and the Ledger design contract with directory scope, prefix behavior, collision precedence, and XDG rules. The first commit fixes system discovery; the second enables raw user discovery together with Ledger coverage. Revert the second commit to withdraw that integration, or both commits to restore previous discovery. Installed skill files are not moved or modified.
