### PR TITLE
fix(memory): accept openclaw capability consent

### DIFF
--- a/docs/user-guide/en/token-saving/agent-memory.md
+++ b/docs/user-guide/en/token-saving/agent-memory.md
@@ -115,6 +115,8 @@ anolisa adapter status agent-memory
 
 **Prerequisite**: `openclaw` CLI on `$PATH`. The script logs clearly and exits 0 if missing — rerun after installing OpenClaw. `yum remove agent-memory` triggers `%preun` to call the uninstall script, leaving no orphaned config.
 
+Running `anolisa adapter enable agent-memory openclaw` or the agent-memory OpenClaw `install.sh` accepts the plugin's declared capabilities. Both entry points pass `--accept-capabilities` only when `plugins install --help` advertises that exact option, so older hosts keep working.
+
 Plugin contract ↔ agent-memory MCP tool mapping:
 
 | OpenClaw contract | agent-memory MCP tool |
@@ -590,6 +592,7 @@ RUST_LOG=agent_memory=debug agent-memory
 | search misses just-written content | inside the 200 ms debounce window | retry, or use `mem_grep` (regex on the filesystem, no index) |
 | `mem_promote` reports `session not found` | `MEMORY_SESSION_ID`/`MEMORY_SESSION_DIR` unset or scratch missing | see Promote workflow |
 | OpenClaw plugin not loaded | `openclaw` CLI not on PATH | rerun `install.sh` after installing OpenClaw |
+| install.sh reports `Plugin "memory-anolisa" requires capability consent` | OpenClaw >= 2026.8.1 consent gate; installer-options probe failed, or script predates the fix | check install output for the probe WARNING line; update agent-memory, or run `openclaw plugins install <plugin-dir> --force --accept-capabilities` manually |
 | system state out of sync after manual dnf | — | `sudo anolisa --install-mode system repair agent-memory`; use system-scoped `forget` / `adopt` only when intentionally rebuilding the record for a present RPM |
 
 For deeper investigation: start with `RUST_LOG=agent_memory=debug` and inspect both stderr and `<mount>/.anolisa/audit.log`.

--- a/docs/user-guide/zh/token-saving/agent-memory.md
+++ b/docs/user-guide/zh/token-saving/agent-memory.md
@@ -114,6 +114,8 @@ anolisa adapter status agent-memory
 
 **前置条件**：`openclaw` CLI 在 `$PATH` 上。脚本缺失时输出明确日志并以 0 退出，安装 OpenClaw 后重跑即可。`yum remove agent-memory` 时 spec 的 `%preun` 自动调用 uninstall 脚本，配置不残留孤立项。
 
+执行 `anolisa adapter enable agent-memory openclaw` 或 agent-memory 的 OpenClaw `install.sh` 即同意插件声明的能力。两个入口仅在 `plugins install --help` 列出完整的 `--accept-capabilities` 参数时传递它，以兼容旧版宿主。
+
 插件 contract 名 ↔ agent-memory MCP 工具映射：
 
 | OpenClaw contract | agent-memory MCP 工具 |
@@ -589,6 +591,7 @@ RUST_LOG=agent_memory=debug agent-memory
 | 索引检索对刚写入的内容查不到 | 还在 200 ms debounce 窗口内 | 重试，或用 `mem_grep`（直接走文件系统正则，不依赖索引） |
 | `mem_promote` 报 `session not found` | `MEMORY_SESSION_ID`/`MEMORY_SESSION_DIR` 未设或 scratch 不存在 | 见 Promote 工作流 |
 | OpenClaw 插件未加载 | `openclaw` CLI 不在 PATH | 安装 OpenClaw 后重跑 `install.sh` |
+| install.sh 报 `Plugin "memory-anolisa" requires capability consent` | OpenClaw >= 2026.8.1 的能力同意门禁；安装参数探测失败或脚本早于修复版本 | 查看安装输出中的探测 WARNING 行；升级 agent-memory，或手动执行 `openclaw plugins install <插件目录> --force --accept-capabilities` |
 | 手动 dnf 操作后 system 状态不同步 | — | `sudo anolisa --install-mode system repair agent-memory`；仅在为仍存在的 RPM 重建记录时使用 system-scoped `forget` / `adopt` |
 
 深入排查：`RUST_LOG=agent_memory=debug` 启动，检查服务端 stderr 与 `<mount>/.anolisa/audit.log`。

--- a/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
+++ b/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
@@ -48,6 +48,34 @@ if [ "${AGENT_MEMORY_SAFE_INSTALL:-0}" = "1" ]; then
     INSTALL_ARGS=("--force")
 fi
 
+# OpenClaw gates capability-declaring plugins behind install-time consent:
+# a noninteractive `plugins install` is rejected unless --accept-capabilities
+# is passed. Version boundaries here are unreliable — the flag shipped in
+# 2026.8.1 but the CLI reference documents it only since 2026.9.1, and older
+# releases abort on the unknown option outright — so probe the host's
+# installer help instead of version-gating. Whole-token match (near-miss
+# options such as --no-accept-capabilities stay out), mirroring tokenless's
+# installer and anolisa-core's help_lists_flag().
+PROBE_RC=0
+INSTALL_HELP="$(env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" \
+    "$OPENCLAW_BIN" plugins install --help 2>&1)" || PROBE_RC=$?
+if [ "$PROBE_RC" -ne 0 ]; then
+    # Degrade to the base flags instead of failing closed: the script must
+    # keep installing on every host the manifest claims to support. Clearing
+    # INSTALL_HELP keeps probe error text from being mistaken for an
+    # advertised option.
+    printf '[%s] WARNING: cannot inspect OpenClaw installer options (rc=%s): %s\n' \
+        "$COMPONENT" "$PROBE_RC" "$INSTALL_HELP" >&2
+    printf '[%s]          Installing with the base flags only.\n' "$COMPONENT" >&2
+    INSTALL_HELP=""
+fi
+if [[ "$INSTALL_HELP" =~ (^|[^[:alnum:]_.-])--accept-capabilities([^[:alnum:]_.-]|$) ]]; then
+    INSTALL_ARGS+=("--accept-capabilities")
+    echo "[${COMPONENT}] Passing --accept-capabilities: granting install-time consent to memory-anolisa's declared capabilities."
+elif [ -n "$INSTALL_HELP" ]; then
+    echo "[${COMPONENT}] OpenClaw did not advertise --accept-capabilities (pre-2026.8.1 host); installing with the base flags."
+fi
+
 env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install "$PLUGIN_DIR" \
     "${INSTALL_ARGS[@]}" || {
     echo "[${COMPONENT}] openclaw CLI install failed — check OpenClaw version >= 5.0.0" >&2


### PR DESCRIPTION
## Why

OpenClaw gates capability-declaring plugins behind install-time consent: `openclaw plugins install` rejects them (rc=1) unless `--accept-capabilities` is passed. The gate shipped in OpenClaw **2026.8.1** — verified in the published 2026.8.1 npm tarball (the installer registers the flag and `docs/plugins/manage-plugins.md` documents the consent section; the CLI reference mentions the flag only since 2026.9.1, which is why the boundary is easy to miscount — the nightly host in #3099 happened to run 2026.9.2). `agent-memory`'s install.sh only passes `--force --dangerously-force-unsafe-install`, so `memory-anolisa` can never be installed on 2026.8.1+ hosts, violating install.sh's declared OpenClaw >= 5.0.0 compatibility contract and breaking the 9 OpenClaw E2E cases at their `ensure_memory_plugin_installed()` fixture.

## What changed

`src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh` probes `openclaw plugins install --help` and appends `--accept-capabilities` (both the default and `AGENT_MEMORY_SAFE_INSTALL=1` paths) only when the host advertises it:

- Help output is captured into a variable and matched with a whole-token regex — the same form as tokenless's installer and anolisa-core's `help_lists_flag()`. A `cmd | grep -q` pipeline can silently drop the match under `set -o pipefail` (grep exits on match → writer gets SIGPIPE), and prefix-matching would confuse near-miss options (`--no-accept-capabilities`, `--accept-capabilities-only`).
- Probe outcomes are logged distinctly: consent granted, flag not advertised (pre-2026.8.1 host, base flags), or probe failure (stderr WARNING with rc and captured output; degrades to base flags rather than failing closed so every host the manifest claims to support keeps installing).
- User guides (en/zh) document that both install entry points grant the declared-capability consent, with a troubleshooting row for the consent error, per specs/documentation-standard.md §5.

This deliberately differs from the unconditional append suggested in the issue: pre-2026.8.1 releases abort on the unknown option (`OpenClaw does not recognize option`, verified on 2026.5.27 with rc=1), so an unconditional flag would trade the new failure for an old one.

## Related issue

fixes #3099

## User / Agent impact

`memory-anolisa` installs successfully on OpenClaw 2026.8.1+ and continues to install on older releases. Consent grants and probe degradation are now visible in install output. No configuration or plugin behavior changes.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

`--accept-capabilities` grants install-time consent to the plugin's declared capabilities. The consent is granted by an operator-run install script that already passes `--force --dangerously-force-unsafe-install`, so this does not widen the trust boundary beyond what invoking the script implies; the grant is now explicitly logged (one stdout line) for audit visibility. The flag is only passed on hosts that advertise it. Deliberate deviation from tokenless's installer: a failed probe degrades to base flags with a WARNING instead of `exit 1` — this script predates the flag and must keep installing on every host the manifest claims to support.

## Validation

- `shellcheck` passes on the modified script.
- Stub-CLI matrix (10 cases + 2 safe-install cases): old host (help without flag → base flags + "did not advertise" log), new host (commander-style help → flag + consent log), `AGENT_MEMORY_SAFE_INSTALL=1` on both hosts (`--force [--accept-capabilities]`, no unsafe flag), probe rc=3 whose error text contains the flag name (WARNING printed, error text NOT mistaken for an advertised option), near-miss-only help (`--accept-capabilities-only`, `--no-accept-capabilities` → no flag), alternate help styles (`--accept-capabilities: desc`, `Options (--accept-capabilities):` → flag), and a 200k-line help output (flag still detected — the pre-fix `grep -q` pipeline form loses this match to SIGPIPE under pipefail, reproduced locally with rc=141).
- Real OpenClaw 2026.5.27: probe succeeds, flag not advertised, base flags.
- Version boundary verified against published npm tarballs: 2026.8.1 registers `--accept-capabilities` and documents the consent section; 2026.8.1's CLI reference has zero mentions while 2026.9.1's documents it. (2026.7.2's tarball is no longer available from any reachable registry, so the 2026.8.1 floor rests on the 2026.8.1 artifact, its own changelog, and #3149 review's independent check.)
- Not validated: a real OpenClaw 2026.8.1+/2026.9.2 host (unavailable locally); new-host gating behavior is modeled from the issue logs and the 2026.8.1 documentation.

## Documentation and rollback

Docs: `docs/user-guide/en/token-saving/agent-memory.md` and `docs/user-guide/zh/token-saving/agent-memory.md` gained the consent paragraph (mirroring tokenless's wording) plus a troubleshooting row. CHANGELOG is intentionally not touched — per specs/documentation-standard.md §5, CHANGELOG entries are written only in release version-bump PRs.

### Deliberate de-scope from #3100

#3100 (closed unmerged) had converged toward a broader change set; this P1 hotfix intentionally keeps only the probe. Dropped, with rationale:

- `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` opt-out — not carried over; operator policies that disallow non-interactive capability-consent grants need it, so it belongs in a follow-up issue rather than blocking the hotfix.
- `tests/unit/install-script-test.ts` + Makefile wiring — dropped; #3134 (wire install-script-test.ts into CI) now has no target file and should be re-scoped or closed. The behaviors it would pin (SIGPIPE-safe probe, whole-token match, probe-failure visibility) are covered by the manual stub matrix above; landing a committed test modeled on `src/tokenless/tests/test-openclaw-adapter-install.sh` is the follow-up.
- Richer per-case failure diagnostics from #3100 — the three distinct probe-outcome log lines cover the diagnosis path; anything beyond belongs in the test/diagnostics follow-up.

Also noted as out of scope: the `--dangerously-force-unsafe-install` / `AGENT_MEMORY_SAFE_INSTALL` comment block (install.sh:37-44) describes pre-2026.8.1 scanner behavior and is stale on current hosts; per review guidance this should be a separate issue converging the script with anolisa-core's `UnsafeInstallSupport::DeprecatedNoOp` modeling, not part of this hotfix.

Revert this single commit to restore previous behavior.