### PR TITLE
refactor(anolisa): inject telemetry status deps

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -1169,6 +1169,11 @@ mod tests {
                 command: system::SystemCommands::Status { json: false },
             },
         )));
+        assert_read_only(Commands::Management(ManagementCommands::Telemetry(
+            telemetry::TelemetryArgs {
+                command: telemetry::TelemetryCommands::Status { json: false },
+            },
+        )));
         assert_read_only(Commands::Management(ManagementCommands::Osbase(
             osbase::OsbaseArgs {
                 command: osbase::OsbaseCommands::Sandbox(osbase::SandboxArgs {

--- a/src/anolisa/crates/anolisa-cli/src/commands/telemetry.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/telemetry.rs
@@ -223,16 +223,44 @@ fn applied_output(result: &TelemetryApplied, warnings: &[String]) -> Vec<Telemet
 
 // ── status ──────────────────────────────────────────────────────────
 
+struct TelemetryStatusObservation {
+    collection_enabled: bool,
+    link_id: Option<String>,
+}
+
 fn handle_status(json: bool) -> Result<(), CliError> {
-    let enabled = TelemetryChannel::new().is_enabled();
-    let link_id = RegistrationManager::new().read_link_id();
+    let observation = collect_status_with(
+        || TelemetryChannel::new().is_enabled(),
+        || RegistrationManager::new().read_link_id(),
+    );
+    render_status(json, observation)
+}
+
+fn collect_status_with<F, L>(collection_enabled: F, read_link_id: L) -> TelemetryStatusObservation
+where
+    F: FnOnce() -> bool,
+    L: FnOnce() -> Option<String>,
+{
+    let collection_enabled = collection_enabled();
+    let link_id = read_link_id();
+    TelemetryStatusObservation {
+        collection_enabled,
+        link_id,
+    }
+}
+
+fn render_status(json: bool, observation: TelemetryStatusObservation) -> Result<(), CliError> {
+    let TelemetryStatusObservation {
+        collection_enabled,
+        link_id,
+    } = observation;
     let linked = link_id.is_some();
 
     if json {
         return render_json(
             "telemetry status",
             serde_json::json!({
-                "collection_enabled": enabled,
+                "collection_enabled": collection_enabled,
                 "linked": linked,
                 "link_id": link_id,
             }),
@@ -241,7 +269,11 @@ fn handle_status(json: bool) -> Result<(), CliError> {
 
     println!(
         "Telemetry collection: {}",
-        if enabled { "enabled" } else { "disabled" }
+        if collection_enabled {
+            "enabled"
+        } else {
+            "disabled"
+        }
     );
     match &link_id {
         Some(id) => println!("Named reporting:      linked ({id})"),
@@ -254,8 +286,434 @@ fn handle_status(json: bool) -> Result<(), CliError> {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+
     use super::*;
+    use anolisa_core::telemetry::TelemetryConfig;
     use clap::Parser;
+
+    const STATUS_RECORDS: &[&str] = &[
+        "missing",
+        "init-linked",
+        "registered-linked",
+        "unregistered-linked",
+        "unlinked",
+        "empty-link",
+        "v1",
+        "corrupt",
+        "future-schema",
+        "legacy-mode",
+        #[cfg(target_os = "linux")]
+        "unexpected-mode",
+        "read-error",
+    ];
+
+    const STATUS_OUTPUT_MODES: &[(&str, &[&str], bool)] = &[
+        ("human", &["anolisa", "telemetry", "status"], false),
+        (
+            "local-json",
+            &["anolisa", "telemetry", "status", "--json"],
+            true,
+        ),
+        (
+            "global-json",
+            &["anolisa", "--json", "telemetry", "status"],
+            true,
+        ),
+        (
+            "middle-json",
+            &["anolisa", "telemetry", "--json", "status"],
+            true,
+        ),
+        (
+            "quiet",
+            &["anolisa", "--quiet", "telemetry", "status"],
+            false,
+        ),
+        (
+            "quiet-json",
+            &["anolisa", "--quiet", "--json", "telemetry", "status"],
+            true,
+        ),
+        (
+            "dry-run",
+            &["anolisa", "--dry-run", "telemetry", "status"],
+            false,
+        ),
+        (
+            "dry-run-json",
+            &["anolisa", "--dry-run", "telemetry", "status", "--json"],
+            true,
+        ),
+    ];
+
+    struct StatusFixture {
+        tmp: tempfile::TempDir,
+        channel: TelemetryChannel,
+        registration: RegistrationManager,
+        expected_link: Option<&'static str>,
+    }
+
+    impl StatusFixture {
+        fn new(enabled: bool, record: &str) -> Self {
+            let tmp = tempfile::tempdir().unwrap();
+            let root = tmp.path();
+            let marker = root.join(".telemetry_disabled");
+            if !enabled {
+                fs::write(&marker, "disabled fixture\n").unwrap();
+            }
+            let config = TelemetryConfig {
+                metadata_url: "http://127.0.0.1:9/unused".to_string(),
+                ops_dir: root.join("ops"),
+                logrotate_config_path: root.join("logrotate"),
+                instance_id_cache_path: root.join("instance-id.cache"),
+                identity_cache_path: root.join("identity.json"),
+                machine_id_path: root.join("machine-id"),
+                release_path: root.join("release"),
+                os_release_path: root.join("os-release"),
+                cpu_present_path: root.join("cpu-present"),
+                image_id_path: root.join("image-id"),
+                telemetry_id_path: root.join("telemetry-id"),
+                legacy_accounts_path: root.join("legacy-accounts.json"),
+            };
+            let registration = RegistrationManager::with_paths(
+                root.join("register.json"),
+                config.release_path.clone(),
+            );
+            let expected_link = match record {
+                "init-linked" | "registered-linked" | "unregistered-linked" | "legacy-mode" => {
+                    Some("fixture-link")
+                }
+                "empty-link" => Some(""),
+                _ => None,
+            };
+            match record {
+                "missing" => {}
+                "read-error" => fs::create_dir(&registration.register_path).unwrap(),
+                "corrupt" => fs::write(&registration.register_path, "not valid json {{").unwrap(),
+                "v1" => fs::write(
+                    &registration.register_path,
+                    r#"{"version":1,"state":"registered","registration_time":"2026-01-01T00:00:00Z"}"#,
+                ).unwrap(),
+                "init-linked" | "registered-linked" | "unregistered-linked" | "unlinked"
+                | "empty-link" | "future-schema" | "legacy-mode" | "unexpected-mode" => {
+                    let state = match record {
+                        "init-linked" => "init",
+                        "unregistered-linked" => "unregistered",
+                        _ => "registered",
+                    };
+                    let mut contents = serde_json::json!({
+                        "schema_version": if record == "future-schema" { "3" } else { "2" },
+                        "state": state,
+                        "history": [],
+                    });
+                    if record != "unlinked" {
+                        contents["link_id"] = serde_json::json!(
+                            if record == "empty-link" { "" } else { "fixture-link" }
+                        );
+                    }
+                    fs::write(&registration.register_path, contents.to_string()).unwrap();
+                }
+                _ => panic!("unknown status fixture: {record}"),
+            }
+            if record != "missing" {
+                let mode = match record {
+                    "legacy-mode" => 0o600,
+                    "unexpected-mode" => 0o640,
+                    _ => 0o644,
+                };
+                // A directory with an accepted mode reaches the read-error path even as root.
+                fs::set_permissions(
+                    &registration.register_path,
+                    fs::Permissions::from_mode(mode),
+                )
+                .unwrap();
+            }
+            Self {
+                channel: TelemetryChannel::with_paths(config, marker),
+                registration,
+                tmp,
+                expected_link,
+            }
+        }
+
+        fn collect(&self) -> TelemetryStatusObservation {
+            let calls = RefCell::new(Vec::new());
+            let observation = collect_status_with(
+                || {
+                    assert!(calls.borrow().is_empty());
+                    calls.borrow_mut().push("collection");
+                    self.channel.is_enabled()
+                },
+                || {
+                    assert_eq!(*calls.borrow(), ["collection"]);
+                    calls.borrow_mut().push("link");
+                    self.registration.read_link_id()
+                },
+            );
+            assert_eq!(*calls.borrow(), ["collection", "link"]);
+            assert_eq!(observation.link_id.as_deref(), self.expected_link);
+            observation
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct StatusFileEvidence {
+        path: PathBuf,
+        mode: u32,
+        contents: Option<Vec<u8>>,
+    }
+
+    fn status_files(root: &Path) -> Vec<StatusFileEvidence> {
+        let mut paths = fs::read_dir(root)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect::<Vec<_>>();
+        paths.sort();
+        paths
+            .into_iter()
+            .map(|path| {
+                let metadata = fs::metadata(&path).unwrap();
+                let contents = if metadata.is_file() {
+                    Some(fs::read(&path).unwrap())
+                } else {
+                    // Only the dedicated read-error directory is part of these flat fixtures.
+                    assert!(fs::read_dir(&path).unwrap().next().is_none());
+                    None
+                };
+                StatusFileEvidence {
+                    path,
+                    mode: metadata.permissions().mode(),
+                    contents,
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn status_collects_real_readers_in_order_without_writes() {
+        for enabled in [false, true] {
+            for &record in STATUS_RECORDS {
+                let fixture = StatusFixture::new(enabled, record);
+                let before = status_files(fixture.tmp.path());
+                let observation = fixture.collect();
+                assert_eq!(observation.collection_enabled, enabled, "{record}");
+                assert_eq!(status_files(fixture.tmp.path()), before, "{record}");
+            }
+        }
+    }
+
+    #[test]
+    fn status_cli_flags_preserve_json_selection() {
+        for &(mode, args, expected_json) in STATUS_OUTPUT_MODES {
+            let cli = crate::commands::Cli::parse_from(args);
+            assert_eq!(cli.json, expected_json, "{mode}");
+            assert_eq!(cli.quiet, args.contains(&"--quiet"), "{mode}");
+            assert_eq!(cli.dry_run, args.contains(&"--dry-run"), "{mode}");
+            let crate::commands::Commands::Management(
+                crate::commands::ManagementCommands::Telemetry(TelemetryArgs {
+                    command: TelemetryCommands::Status { json },
+                }),
+            ) = cli.command
+            else {
+                panic!("expected telemetry status")
+            };
+            assert_eq!(json, expected_json, "{mode}");
+        }
+    }
+
+    #[test]
+    fn status_preserves_output_and_read_warnings() {
+        let (_, module) = module_path!().split_once("::").unwrap();
+        for enabled in [false, true] {
+            for &record in STATUS_RECORDS {
+                // Exercise flag combinations once; degradation needs only human and JSON forms.
+                let modes = if record == "registered-linked" {
+                    STATUS_OUTPUT_MODES
+                } else {
+                    &STATUS_OUTPUT_MODES[..2]
+                };
+                for &(mode, _, json) in modes {
+                    let output = std::process::Command::new(std::env::current_exe().unwrap())
+                        .args([
+                            format!("{module}::status_output_child"),
+                            "--exact".to_string(),
+                            "--nocapture".to_string(),
+                        ])
+                        .env("ANOLISA_TEST_TELEMETRY_STATUS_RECORD", record)
+                        .env("ANOLISA_TEST_TELEMETRY_STATUS_ENABLED", enabled.to_string())
+                        .env("ANOLISA_TEST_TELEMETRY_STATUS_OUTPUT", mode)
+                        .output()
+                        .unwrap();
+                    assert_eq!(
+                        output.status.code(),
+                        Some(0),
+                        "{record}/{enabled}/{mode}: {output:?}"
+                    );
+                    let stdout = String::from_utf8(output.stdout).unwrap();
+                    let path = stdout
+                        .lines()
+                        .find_map(|line| line.strip_prefix("STATUS_REGISTER_PATH="))
+                        .unwrap();
+                    let (_, rendered) = stdout.split_once("STATUS_OUTPUT_BEGIN\n").unwrap();
+                    let (rendered, _) = rendered.split_once("STATUS_OUTPUT_END\n").unwrap();
+                    let link = match record {
+                        "init-linked"
+                        | "registered-linked"
+                        | "unregistered-linked"
+                        | "legacy-mode" => Some("fixture-link"),
+                        "empty-link" => Some(""),
+                        _ => None,
+                    };
+                    if json {
+                        assert_eq!(
+                            serde_json::from_str::<serde_json::Value>(rendered).unwrap(),
+                            serde_json::json!({
+                                "ok": true,
+                                "schema_version": crate::response::SCHEMA_VERSION,
+                                "command": "telemetry status",
+                                "data": {
+                                    "collection_enabled": enabled,
+                                    "linked": link.is_some(),
+                                    "link_id": link,
+                                },
+                                "warnings": [],
+                            })
+                        );
+                    } else {
+                        let collection = if enabled { "enabled" } else { "disabled" };
+                        let linked = match link {
+                            Some(id) => format!("linked ({id})"),
+                            None => "not linked".to_string(),
+                        };
+                        assert_eq!(
+                            rendered,
+                            format!(
+                                "Telemetry collection: {collection}\nNamed reporting:      {linked}\n"
+                            )
+                        );
+                    }
+                    let stderr = String::from_utf8(output.stderr).unwrap();
+                    let expected_warning = match record {
+                        "corrupt" => {
+                            format!("[anolisa] warn: failed to parse {path}; treating as INIT\n")
+                        }
+                        "future-schema" => format!(
+                            "[anolisa] warn: {path} has schema_version 3 (expected <= 2); treating as INIT\n"
+                        ),
+                        "unexpected-mode" => format!(
+                            "[anolisa] warn: {path} has unexpected permissions 640; treating as INIT\n"
+                        ),
+                        "read-error" => {
+                            let reason = stdout
+                                .lines()
+                                .find_map(|line| line.strip_prefix("STATUS_READ_ERROR="))
+                                .unwrap();
+                            format!("[anolisa] warn: cannot read {path}: {reason}\n")
+                        }
+                        _ => String::new(),
+                    };
+                    assert_eq!(stderr, expected_warning, "{record}/{enabled}/{mode}");
+                    assert!(stdout.contains("test result: ok."));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn status_output_child() {
+        let (_, module) = module_path!().split_once("::").unwrap();
+        if std::env::args().skip(1).collect::<Vec<_>>()
+            != [
+                format!("{module}::status_output_child"),
+                "--exact".to_string(),
+                "--nocapture".to_string(),
+            ]
+        {
+            return;
+        }
+        let record = std::env::var("ANOLISA_TEST_TELEMETRY_STATUS_RECORD").unwrap();
+        let enabled = std::env::var("ANOLISA_TEST_TELEMETRY_STATUS_ENABLED")
+            .unwrap()
+            .parse::<bool>()
+            .unwrap();
+        let mode = std::env::var("ANOLISA_TEST_TELEMETRY_STATUS_OUTPUT").unwrap();
+        let (_, args, expected_json) = STATUS_OUTPUT_MODES
+            .iter()
+            .find(|(name, _, _)| *name == mode)
+            .unwrap();
+        let cli = crate::commands::Cli::parse_from(*args);
+        let crate::commands::Commands::Management(crate::commands::ManagementCommands::Telemetry(
+            TelemetryArgs {
+                command: TelemetryCommands::Status { json },
+            },
+        )) = cli.command
+        else {
+            panic!("expected telemetry status")
+        };
+        assert_eq!(json, *expected_json);
+        let fixture = StatusFixture::new(enabled, &record);
+        let before = status_files(fixture.tmp.path());
+        println!(
+            "STATUS_REGISTER_PATH={}",
+            fixture.registration.register_path.display()
+        );
+        if record == "read-error" {
+            println!(
+                "STATUS_READ_ERROR={}",
+                fs::read_to_string(&fixture.registration.register_path).unwrap_err()
+            );
+        }
+        println!("STATUS_OUTPUT_BEGIN");
+        let observation = fixture.collect();
+        assert_eq!(observation.collection_enabled, enabled);
+        render_status(json, observation).unwrap();
+        println!("STATUS_OUTPUT_END");
+        assert_eq!(status_files(fixture.tmp.path()), before);
+    }
+
+    #[test]
+    fn status_capture_environment_does_not_redirect_normal_suite() {
+        let (_, module) = module_path!().split_once("::").unwrap();
+        for (record, enabled, mode) in [
+            ("registered-linked", "true", "human"),
+            ("invalid", "invalid", "invalid"),
+        ] {
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    format!("{module}::status_"),
+                    "--skip".to_string(),
+                    format!("{module}::status_capture_environment_does_not_redirect_normal_suite"),
+                    "--skip".to_string(),
+                    format!("{module}::status_preserves_output_and_read_warnings"),
+                ])
+                .env("ANOLISA_TEST_TELEMETRY_STATUS_RECORD", record)
+                .env("ANOLISA_TEST_TELEMETRY_STATUS_ENABLED", enabled)
+                .env("ANOLISA_TEST_TELEMETRY_STATUS_OUTPUT", mode)
+                .output()
+                .unwrap();
+            assert!(output.status.success(), "{output:?}");
+            let stdout = String::from_utf8(output.stdout).unwrap();
+            assert!(stdout.contains("status_output_child ... ok"), "{stdout}");
+            assert!(
+                stdout.contains("status_collects_real_readers_in_order_without_writes ... ok"),
+                "{stdout}"
+            );
+            assert!(
+                stdout.contains("status_cli_flags_preserve_json_selection ... ok"),
+                "{stdout}"
+            );
+            assert!(
+                !stdout.contains("status_preserves_output_and_read_warnings ..."),
+                "{stdout}"
+            );
+            assert!(!stdout.contains("STATUS_OUTPUT_BEGIN"), "{stdout}");
+            assert!(stdout.contains("test result: ok."), "{stdout}");
+        }
+    }
 
     #[derive(Parser)]
     struct TestCli {


### PR DESCRIPTION
## Why

The telemetry status handler directly constructs readers for fixed host paths, preventing isolated tests of its full observation and output path. This R4 slice introduces private one-shot callbacks and a renderer in the existing module, keeping real core parsing and fallback behavior unchanged.

## What changed

- Collect collection-enabled state before reading the link ID, once each, then derive `linked` only while rendering.
- Keep production readers and paths unchanged; test real `with_paths` readers using temporary marker and registration fixtures.
- Cover 24 observation combinations and 60 human/JSON output combinations, including CLI flag propagation, quiet/dry-run, read warnings, and file immutability.
- Add telemetry status to the existing read-only command policy regression; guard output-capture subprocesses against inherited environment values without repeating the output matrix.

## Related issue

Closes #3148

Part of #2628. The R4 tracker remains open.

## User / Agent impact

None. Preserve CLI arguments, the response envelope and three data fields, null link IDs, stderr warnings, human/quiet output, permissions, and success exit codes. Collection state and registration/link state remain independent.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: production changes are private extraction only. No core reader, mutation, upload, service, clock/UID, or component snapshot behavior changes. Tests cover v1/v2 records, missing and empty link IDs, corrupt/future schemas, accepted/unexpected Linux permissions, and directory-based read errors independent of root privileges.

## Validation

Passed on the implementation baseline (upstream/main `80301fb9e`):

```text
cargo fmt --all
cargo fmt --all -- --check
cargo test -p anolisa-cli telemetry --locked
cargo test -p anolisa-cli read_only --locked
cargo test -p anolisa-core register --locked
cargo test -p anolisa-core telemetry::channel --locked
cargo check --workspace --locked
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo test -p anolisa-cli --locked
cargo test --workspace --locked
cargo doc --workspace --no-deps --locked
git diff --check
```

The full CLI unit suite passed 1,058 tests with one pre-existing ignored child test. Telemetry (38), read-only policy (10), registration (23 unit and 2 integration), and telemetry channel (7) targeted tests also passed in `anolisa/alinux4-rust-selftest:20260824` (ALinux 4.0.3, Rust 1.93.1).

Container validation used UID 1000, no network, a read-only root filesystem, read-only source and temporary vendored dependencies, and an independent temporary target directory. Tests never ran production telemetry status against host files, modified host services, or launched a real uploader. Formatting and CLI telemetry/read-only targeted tests were rechecked before committing.

## Documentation and rollback

The local Chinese refactoring roadmap was updated for tracking but remains untracked and is intentionally excluded from this PR. No public documentation or migration is required. Revert this single commit to restore the previous private handler structure; no persistent data or protocol changes need rollback.
