### PR TITLE
fix(sight): assemble fragmented HTTP responses

### DIFF
--- a/docs/user-guide/en/agent-observability/agentsight/integrations.md
+++ b/docs/user-guide/en/agent-observability/agentsight/integrations.md
@@ -47,6 +47,15 @@ The page reads Tokenless's own statistics database, so numbers appear only after
 optimized something. A savings figure of 0 usually means Tokenless is installed but not active for
 the Agent that produced those sessions.
 
+Savings association also requires AgentSight to capture and parse the corresponding output tool-call
+ID. Non-SSE HTTP/1.1 responses split across TLS reads are assembled using Content-Length or chunked
+framing before usage and tool calls are extracted. Oversized responses are discarded with a collector
+warning. Incomplete responses, including close-delimited responses without Content-Length or chunked
+framing, cannot supply complete usage or tool-call IDs; Tokenless stats can therefore remain
+unassociated. When SQLite storage is enabled, idle calls retain their request as pending evidence
+for interruption detection and can still complete if the response resumes. Response buffering remains
+bounded by the connection capacity and per-connection body limit.
+
 ## agent-sec-core: security observability and audit
 
 When [agent-sec-core](../../agent-security/agent-sec-core/QUICKSTART.md) is installed, two more

--- a/docs/user-guide/zh/agent-observability/agentsight/integrations.md
+++ b/docs/user-guide/zh/agent-observability/agentsight/integrations.md
@@ -44,6 +44,13 @@ Token，两侧都不需要额外配置：
 该页面读取的是 Tokenless 自己的统计数据库，因此只有 Tokenless 真正优化过之后才会有数字。节省量为 0
 通常意味着 Tokenless 装了但没有对产生这些会话的 Agent 生效。
 
+节省统计的关联还要求 AgentSight 完整采集并解析对应的输出 tool-call ID。非 SSE HTTP/1.1 响应跨多次
+TLS 读取时，会依据 Content-Length 或 chunked 消息边界完成组装，再提取 usage 和工具调用。超限响应
+会被丢弃并在采集器日志中告警。不完整响应（包括没有 Content-Length 或 chunked 定界、仅靠关闭连接
+确定结束的响应）无法提供完整的 usage 或 tool-call ID，Tokenless 已记录的 stats 因此仍可能无法关联。
+启用 SQLite 存储时，空闲调用会保留请求作为 pending 证据供中断检测使用，响应恢复后仍可继续完成；
+响应缓冲仍受连接数量和单连接响应体大小上限约束。
+
 ## agent-sec-core：安全可观测与审计
 
 装了 [agent-sec-core](../../agent-security/agent-sec-core/QUICKSTART.md) 后，Dashboard 会多出两页：

--- a/src/agentsight/src/aggregator/http/aggregator.rs
+++ b/src/agentsight/src/aggregator/http/aggregator.rs
@@ -5,13 +5,16 @@
 
 use super::super::result::AggregatedResult;
 use super::pair::HttpPair;
+#[path = "pending_response.rs"]
+mod pending_response;
 use super::response::AggregatedResponse;
 use crate::config::DEFAULT_CONNECTION_CAPACITY;
-use crate::parser::http::{ParsedRequest, ParsedResponse};
+use crate::parser::http::{HttpParser, ParsedHttpMessage, ParsedRequest, ParsedResponse};
 use crate::parser::sse::{ParsedSseEvent, SseParser};
 use crate::probes::sslsniff::SslEvent;
 use crate::utils::decompress::ZstdStreamDecoder;
 use lru::LruCache;
+use pending_response::PendingResponse;
 use std::cell::RefCell;
 use std::num::NonZeroUsize;
 use std::rc::Rc;
@@ -63,6 +66,11 @@ pub(crate) enum ConnectionState {
         request: ParsedRequest,
         expected_body_len: Option<usize>,
         body_buffer: Vec<u8>,
+    },
+    /// HTTP response headers or body awaiting further SSL reads.
+    ResponsePending {
+        request: Option<ParsedRequest>,
+        assembly: PendingResponse,
     },
     /// SSE active - response headers received, body streaming
     SseActive {
@@ -187,6 +195,7 @@ impl HttpConnectionAggregator {
                     match evicted_state {
                         ConnectionState::Idle => "Idle",
                         ConnectionState::RequestPending { .. } => "RequestPending",
+                        ConnectionState::ResponsePending { .. } => "ResponsePending",
                         ConnectionState::RequestBodyPending { .. } => "RequestBodyPending",
                         ConnectionState::SseActive { .. } => "SseActive",
                     },
@@ -199,8 +208,8 @@ impl HttpConnectionAggregator {
     /// Evict discardable connections that have been idle for longer than
     /// `self.idle_timeout` or whose buffered body exceeds `self.max_body_bytes`.
     ///
-    /// In-flight request/response states are preserved here so callers can
-    /// drain and persist them instead of losing a manually interrupted stream.
+    /// In-flight calls retain request evidence for interruption snapshots and
+    /// can still complete if more response bytes arrive after the idle timeout.
     pub fn evict_idle_and_oversized(&mut self) {
         let now = Instant::now();
         let timeout = self.idle_timeout;
@@ -221,7 +230,20 @@ impl HttpConnectionAggregator {
 
         let mut evicted_idle = 0usize;
         for key in &to_evict {
-            if matches!(self.connections.peek(key), Some(ConnectionState::Idle)) {
+            if matches!(
+                self.connections.peek(key),
+                Some(
+                    ConnectionState::Idle | ConnectionState::ResponsePending { request: None, .. }
+                )
+            ) {
+                if matches!(
+                    self.connections.peek(key),
+                    Some(ConnectionState::ResponsePending { .. })
+                ) {
+                    log::warn!(
+                        "[HttpAggregator] discarded incomplete idle response | conn={key:?}"
+                    );
+                }
                 self.connections.pop(key);
                 self.sse_continuation_buffers.pop(key);
                 self.last_appended_src_ptr.pop(key);
@@ -520,6 +542,15 @@ impl HttpConnectionAggregator {
         let connection_id = ConnectionId::from_ssl_event(&request.source_event);
         self.idle_snapshotted.pop(&connection_id);
 
+        if matches!(
+            self.connections.peek(&connection_id),
+            Some(ConnectionState::ResponsePending { .. })
+        ) {
+            log::warn!(
+                "[HttpAggregator] new request replaced incomplete response | conn={connection_id:?}"
+            );
+        }
+
         // Check if body is complete by comparing with Content-Length
         let content_length: Option<usize> = request
             .headers
@@ -576,9 +607,21 @@ impl HttpConnectionAggregator {
 
     /// Process HTTP Response (from HTTP Parser)
     /// Returns completed HttpPair or SSE started signal
-    pub fn process_response(&mut self, response: ParsedResponse) -> Option<AggregatedResult> {
+    pub fn process_response(&mut self, mut response: ParsedResponse) -> Option<AggregatedResult> {
         let connection_id = ConnectionId::from_ssl_event(&response.source_event);
 
+        while (100..200).contains(&response.status_code) && response.status_code != 101 {
+            if response.body().is_empty() {
+                return None;
+            }
+            let mut event = (*response.source_event).clone();
+            event.buf = response.body().to_vec();
+            event.len = event.buf.len() as u32;
+            match HttpParser::new().parse(Rc::new(event.clone())) {
+                Ok(ParsedHttpMessage::Response(next)) => response = next,
+                _ => return self.process_response_bytes(&event),
+            }
+        }
         let state = self.connections.pop(&connection_id)?;
 
         match state {
@@ -629,8 +672,7 @@ impl HttpConnectionAggregator {
                     );
                     None
                 } else {
-                    let pair = HttpPair::from_parsed(connection_id, completed_request, response);
-                    Some(AggregatedResult::HttpComplete(pair))
+                    self.start_response(connection_id, Some(completed_request), response)
                 }
             }
             ConnectionState::RequestPending { request } => {
@@ -677,8 +719,7 @@ impl HttpConnectionAggregator {
                         connection_id,
                         response.status_code,
                     );
-                    let pair = HttpPair::from_parsed(connection_id, request, response);
-                    Some(AggregatedResult::HttpComplete(pair))
+                    self.start_response(connection_id, Some(request), response)
                 }
             }
             ConnectionState::Idle => {
@@ -723,14 +764,10 @@ impl HttpConnectionAggregator {
                         connection_id,
                         response.status_code
                     );
-                    let aggregated_response = AggregatedResponse::from_parsed(response);
-                    Some(AggregatedResult::ResponseOnly {
-                        connection_id,
-                        response: aggregated_response,
-                    })
+                    self.start_response(connection_id, None, response)
                 }
             }
-            ConnectionState::SseActive { .. } => {
+            ConnectionState::SseActive { .. } | ConnectionState::ResponsePending { .. } => {
                 log::trace!(
                     "[HttpAggregator] State transition: SseActive (unexpected response) | conn={connection_id:?}"
                 );
@@ -745,6 +782,9 @@ impl HttpConnectionAggregator {
     /// Process raw body data (continuation bytes for an in-progress request)
     pub fn process_raw_body_data(&mut self, ssl_event: &SslEvent) -> Option<AggregatedResult> {
         let connection_id = ConnectionId::from_ssl_event(ssl_event);
+        if self.accepts_response_bytes(ssl_event) || self.starts_response(ssl_event) {
+            return self.process_response_bytes(ssl_event);
+        }
         let state = self.connections.pop(&connection_id)?;
 
         match state {
@@ -1262,7 +1302,7 @@ mod tests {
             version: 11,
             status_code: 200,
             reason: "OK".to_string(),
-            headers: HashMap::new(),
+            headers: HashMap::from([("content-length".into(), "0".into())]),
             body_offset: 0,
             body_len: 0,
             source_event: event,
@@ -1433,8 +1473,8 @@ mod tests {
             version: 1,
             status_code: 200,
             reason: "OK".to_string(),
-            headers: HashMap::new(),
-            body_offset: 0,
+            headers: HashMap::from([("content-length".into(), "2".into())]),
+            body_offset: 38,
             body_len: 2,
             source_event: resp_event,
         };
@@ -1501,14 +1541,18 @@ mod tests {
         aggregator.process_raw_body_data(&cont);
 
         // Response arrives before Content-Length is satisfied → force-complete
-        let resp_event =
-            create_mock_ssl_event_with_buf(5678, 0x3000, b"HTTP/1.1 200 OK\r\n\r\n{}".to_vec(), 0);
+        let resp_event = create_mock_ssl_event_with_buf(
+            5678,
+            0x3000,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}".to_vec(),
+            0,
+        );
         let response = ParsedResponse {
             version: 1,
             status_code: 200,
             reason: "OK".to_string(),
-            headers: HashMap::new(),
-            body_offset: 0,
+            headers: HashMap::from([("content-length".into(), "2".into())]),
+            body_offset: 38,
             body_len: 2,
             source_event: resp_event,
         };

--- a/src/agentsight/src/aggregator/http/pending_response.rs
+++ b/src/agentsight/src/aggregator/http/pending_response.rs
@@ -1,0 +1,359 @@
+//! Bounded HTTP/1 response assembly. Only message framing can establish completion.
+
+use super::{
+    AggregatedResponse, AggregatedResult, ConnectionId, ConnectionState, HttpConnectionAggregator,
+    HttpPair,
+};
+use crate::parser::http::{HttpParser, ParsedHttpMessage, ParsedRequest, ParsedResponse};
+use crate::probes::sslsniff::SslEvent;
+use anyhow::{Result, bail};
+use std::rc::Rc;
+
+const MAX_RESPONSE_HEADERS: usize = 64 * 1024;
+
+impl ConnectionState {
+    /// Request evidence shared by idle, process-exit and dead-PID persistence.
+    pub(crate) fn pending_request(&self) -> Option<&ParsedRequest> {
+        match self {
+            Self::RequestPending { request } => Some(request),
+            Self::ResponsePending { request, .. } | Self::SseActive { request, .. } => {
+                request.as_ref()
+            }
+            Self::Idle | Self::RequestBodyPending { .. } => None,
+        }
+    }
+}
+
+/// In-flight response bytes, retained only within the connection limits.
+#[derive(Debug, Clone)]
+pub(crate) enum PendingResponse {
+    /// Header prefix awaiting the terminating blank line.
+    Headers(Rc<SslEvent>),
+    /// Parsed headers with undecoded body bytes and a framing cursor.
+    Body {
+        response: ParsedResponse,
+        framing: Framing,
+        end_timestamp_ns: u64,
+    },
+}
+
+/// HTTP message-length rules, applied before content decoding.
+#[derive(Debug, Clone)]
+pub(crate) enum Framing {
+    /// Content-Length or a response that cannot carry a body.
+    Length(usize),
+    /// Cursor at the next chunk-size or trailer line.
+    Chunked { offset: usize, trailers: bool },
+    /// No close notification is available; idle timeout cannot imply completion.
+    CloseDelimited,
+}
+
+impl Framing {
+    fn new(response: &ParsedResponse, method: Option<&str>) -> Result<Self> {
+        if method == Some("HEAD")
+            || (100..200).contains(&response.status_code)
+            || matches!(response.status_code, 204 | 304)
+            || (method == Some("CONNECT") && (200..300).contains(&response.status_code))
+        {
+            return Ok(Self::Length(0));
+        }
+        if let Some(encoding) = response.headers.get("transfer-encoding") {
+            let chunked = encoding
+                .rsplit(',')
+                .next()
+                .is_some_and(|v| v.trim().eq_ignore_ascii_case("chunked"));
+            return Ok(if chunked {
+                Self::Chunked {
+                    offset: 0,
+                    trailers: false,
+                }
+            } else {
+                Self::CloseDelimited
+            });
+        }
+        match response.headers.get("content-length") {
+            Some(length) => Ok(Self::Length(length.trim().parse()?)),
+            None => Ok(Self::CloseDelimited),
+        }
+    }
+
+    fn complete_len(&mut self, body: &[u8]) -> Result<Option<usize>> {
+        match self {
+            Self::Length(len) => Ok((body.len() >= *len).then_some(*len)),
+            Self::CloseDelimited => Ok(None),
+            Self::Chunked { offset, trailers } => loop {
+                let Some(line_len) = body[*offset..].windows(2).position(|w| w == b"\r\n") else {
+                    return Ok(None);
+                };
+                let line_end = *offset + line_len;
+                if *trailers {
+                    *offset = line_end + 2;
+                    if line_len == 0 {
+                        return Ok(Some(*offset));
+                    }
+                    continue;
+                }
+                let line = std::str::from_utf8(&body[*offset..line_end])?;
+                let size = usize::from_str_radix(line.split(';').next().unwrap_or("").trim(), 16)?;
+                if size == 0 {
+                    *offset = line_end + 2;
+                    *trailers = true;
+                    continue;
+                }
+                let Some(end) = (line_end + 2)
+                    .checked_add(size)
+                    .and_then(|n| n.checked_add(2))
+                else {
+                    bail!("chunk size overflows response length");
+                };
+                if end > body.len() {
+                    return Ok(None);
+                }
+                if &body[end - 2..end] != b"\r\n" {
+                    bail!("missing CRLF after response chunk");
+                }
+                *offset = end;
+            },
+        }
+    }
+}
+
+impl PendingResponse {
+    /// Select message framing without decoding the response body.
+    pub(super) fn body(response: ParsedResponse, method: Option<&str>) -> Result<Self> {
+        let framing = Framing::new(&response, method)?;
+        let end_timestamp_ns = response.source_event.timestamp_ns;
+        Ok(Self::Body {
+            response,
+            framing,
+            end_timestamp_ns,
+        })
+    }
+
+    /// SSL direction that owns the response.
+    pub(super) fn direction(&self) -> i32 {
+        match self {
+            Self::Headers(event) => event.rw,
+            Self::Body { response, .. } => response.source_event.rw,
+        }
+    }
+
+    /// Append captured bytes after enforcing the connection budget.
+    pub(super) fn append(&mut self, event: &SslEvent, limit: usize) -> Result<()> {
+        let data = &event.buf[..event.buf_size() as usize];
+        let (source, used, cap) = match self {
+            Self::Headers(source) => {
+                let len = source.buf.len();
+                (source, len, limit.saturating_add(MAX_RESPONSE_HEADERS))
+            }
+            Self::Body {
+                response,
+                end_timestamp_ns,
+                ..
+            } => {
+                *end_timestamp_ns = event.timestamp_ns;
+                let used = response.body_len;
+                response.body_len = used.saturating_add(data.len());
+                (&mut response.source_event, used, limit)
+            }
+        };
+        if data.len() > cap.saturating_sub(used) {
+            bail!("response buffer exceeds {cap} bytes");
+        }
+        let source = Rc::make_mut(source);
+        source.buf.extend_from_slice(data);
+        source.len = source.buf.len() as u32;
+        Ok(())
+    }
+
+    /// Parse a bounded complete header block, preserving its first timestamp.
+    pub(super) fn parsed_headers(&self) -> Result<Option<ParsedResponse>> {
+        let Self::Headers(event) = self else {
+            return Ok(None);
+        };
+        let Some(end) = event.buf.windows(4).position(|w| w == b"\r\n\r\n") else {
+            if event.buf.len() > MAX_RESPONSE_HEADERS {
+                bail!("response headers exceed {MAX_RESPONSE_HEADERS} bytes");
+            }
+            return Ok(None);
+        };
+        if end + 4 > MAX_RESPONSE_HEADERS {
+            bail!("response headers exceed {MAX_RESPONSE_HEADERS} bytes");
+        }
+        match HttpParser::new().parse(Rc::clone(event))? {
+            ParsedHttpMessage::Response(response) => Ok(Some(response)),
+            _ => bail!("invalid response headers"),
+        }
+    }
+
+    /// Trim to the framed message length once all bytes are present.
+    pub(super) fn complete(&mut self, limit: usize) -> Result<bool> {
+        let Self::Body {
+            response, framing, ..
+        } = self
+        else {
+            return Ok(false);
+        };
+        if response.body_len > limit || matches!(framing, Framing::Length(n) if *n > limit) {
+            bail!("response body exceeds {limit} bytes");
+        }
+        let Some(len) = framing.complete_len(response.body())? else {
+            return Ok(false);
+        };
+        response.body_len = len;
+        Ok(true)
+    }
+}
+
+impl HttpConnectionAggregator {
+    /// Whether connection state takes precedence over stateless protocol detection.
+    pub(crate) fn accepts_response_bytes(&self, event: &SslEvent) -> bool {
+        match self.connections.peek(&ConnectionId::from_ssl_event(event)) {
+            Some(ConnectionState::ResponsePending { assembly, .. }) => {
+                assembly.direction() == event.rw
+            }
+            _ => false,
+        }
+    }
+
+    /// Recognize a response prefix on a pending request connection.
+    pub(super) fn starts_response(&self, event: &SslEvent) -> bool {
+        let data = &event.buf[..event.buf_size() as usize];
+        match self.connections.peek(&ConnectionId::from_ssl_event(event)) {
+            Some(
+                ConnectionState::RequestPending { request }
+                | ConnectionState::RequestBodyPending { request, .. },
+            ) => {
+                request.source_event.rw != event.rw
+                    && !data.is_empty()
+                    && (data.starts_with(b"HTTP/1.") || b"HTTP/1.".starts_with(data))
+            }
+            _ => false,
+        }
+    }
+
+    /// Begin bounded assembly or emit an already complete response.
+    pub(super) fn start_response(
+        &mut self,
+        id: ConnectionId,
+        request: Option<ParsedRequest>,
+        response: ParsedResponse,
+    ) -> Option<AggregatedResult> {
+        match PendingResponse::body(response, request.as_ref().map(|r| r.method.as_str())) {
+            Ok(assembly) => self.advance_response(id, request, assembly),
+            Err(error) => {
+                log::warn!("[HttpAggregator] discarded invalid response | conn={id:?}: {error}");
+                None
+            }
+        }
+    }
+
+    fn advance_response(
+        &mut self,
+        id: ConnectionId,
+        request: Option<ParsedRequest>,
+        mut assembly: PendingResponse,
+    ) -> Option<AggregatedResult> {
+        match assembly.complete(self.max_body_bytes) {
+            Ok(true) => {
+                if let PendingResponse::Body {
+                    response,
+                    end_timestamp_ns,
+                    ..
+                } = assembly
+                {
+                    let mut response = AggregatedResponse::from_parsed(response);
+                    response.completion_timestamp_ns = Some(end_timestamp_ns);
+                    return Some(match request {
+                        Some(request) => AggregatedResult::HttpComplete(HttpPair {
+                            connection_id: id,
+                            request,
+                            response,
+                        }),
+                        None => AggregatedResult::ResponseOnly {
+                            connection_id: id,
+                            response,
+                        },
+                    });
+                }
+            }
+            Ok(false) => self.insert(id, ConnectionState::ResponsePending { request, assembly }),
+            Err(error) => {
+                log::warn!("[HttpAggregator] discarded incomplete response | conn={id:?}: {error}")
+            }
+        }
+        None
+    }
+
+    /// Continue response assembly using the original SSL bytes.
+    pub(super) fn process_response_bytes(&mut self, event: &SslEvent) -> Option<AggregatedResult> {
+        let id = ConnectionId::from_ssl_event(event);
+        let state = self.connections.pop(&id)?;
+        let (request, assembly) = match state {
+            ConnectionState::ResponsePending {
+                request,
+                mut assembly,
+            } => {
+                if let Err(error) = assembly.append(event, self.max_body_bytes) {
+                    log::warn!(
+                        "[HttpAggregator] discarded incomplete response | conn={id:?}: {error}"
+                    );
+                    return None;
+                }
+                (request, assembly)
+            }
+            ConnectionState::RequestPending { request } => (
+                Some(request),
+                PendingResponse::Headers(Rc::new(event.clone())),
+            ),
+            ConnectionState::RequestBodyPending {
+                mut request,
+                body_buffer,
+                ..
+            } => {
+                request.reassembled_body = Some(body_buffer);
+                (
+                    Some(request),
+                    PendingResponse::Headers(Rc::new(event.clone())),
+                )
+            }
+            other => {
+                self.insert(id, other);
+                return None;
+            }
+        };
+        match assembly.parsed_headers() {
+            Ok(Some(response)) => {
+                drop(assembly);
+                if let Some(request) = request {
+                    self.insert(id, ConnectionState::RequestPending { request });
+                } else {
+                    self.insert(id, ConnectionState::Idle);
+                }
+                let mut result = self.process_response(response);
+                if let Some(AggregatedResult::HttpComplete(pair)) = &mut result {
+                    pair.response.completion_timestamp_ns = Some(event.timestamp_ns);
+                }
+                if let Some(ConnectionState::ResponsePending {
+                    assembly:
+                        PendingResponse::Body {
+                            end_timestamp_ns, ..
+                        },
+                    ..
+                }) = self.connections.peek_mut(&id)
+                {
+                    *end_timestamp_ns = event.timestamp_ns;
+                }
+                return result;
+            }
+            Err(error) => {
+                log::warn!(
+                    "[HttpAggregator] discarded invalid response headers | conn={id:?}: {error}"
+                );
+                return None;
+            }
+            Ok(None) => {}
+        }
+        self.advance_response(id, request, assembly)
+    }
+}

--- a/src/agentsight/src/aggregator/http/response.rs
+++ b/src/agentsight/src/aggregator/http/response.rs
@@ -13,6 +13,8 @@ use serde_json::json;
 pub struct AggregatedResponse {
     /// Parsed response data
     pub parsed: ParsedResponse,
+    /// Last captured byte timestamp for a completed non-SSE response.
+    pub completion_timestamp_ns: Option<u64>,
     /// SSE events collected during streaming (if is_sse is true)
     pub sse_events: Vec<ParsedSseEvent>,
     /// Raw bytes that arrived as RawData while in SseActive state. These are
@@ -28,6 +30,7 @@ impl AggregatedResponse {
     pub fn from_parsed(parsed: ParsedResponse) -> Self {
         AggregatedResponse {
             parsed,
+            completion_timestamp_ns: None,
             sse_events: Vec::new(),
             sse_continuation_bytes: None,
         }
@@ -72,11 +75,12 @@ impl AggregatedResponse {
     }
 
     /// Get end timestamp (last packet) in nanoseconds
-    /// For SSE: last event's timestamp; for regular response: same as start
+    /// Uses the final body fragment for non-SSE responses.
     pub fn end_timestamp_ns(&self) -> u64 {
         self.sse_events
             .last()
             .map(|e| e.source_event().timestamp_ns)
+            .or(self.completion_timestamp_ns)
             .unwrap_or_else(|| self.start_timestamp_ns())
     }
 
@@ -335,6 +339,7 @@ mod latency_tests {
 
     fn response_with_sse_events(sse_events: Vec<ParsedSseEvent>) -> AggregatedResponse {
         AggregatedResponse {
+            completion_timestamp_ns: None,
             parsed: ParsedResponse {
                 version: 1,
                 status_code: 200,

--- a/src/agentsight/src/aggregator/unified.rs
+++ b/src/agentsight/src/aggregator/unified.rs
@@ -116,6 +116,32 @@ impl Aggregator {
             self.last_eviction = now;
         }
 
+        // One SSL read may yield several SSE messages (including a synthetic
+        // chunk terminator). Feed its original, longest source buffer only once
+        // when HTTP response framing owns the connection.
+        let response_event = result
+            .messages
+            .iter()
+            .filter_map(|message| match message {
+                ParsedMessage::Request(r) => Some(r.source_event.as_ref()),
+                ParsedMessage::Response(r) => Some(r.source_event.as_ref()),
+                ParsedMessage::RawData(event) => Some(event.as_ref()),
+                ParsedMessage::SseEvent(event) => Some(event.source_event()),
+                ParsedMessage::Http2Frames(frames) => {
+                    frames.first().map(|f| f.source_event.as_ref())
+                }
+                ParsedMessage::ProcEvent(_) => None,
+            })
+            .max_by_key(|event| event.buf_size());
+        if let Some(event) = response_event.filter(|event| self.http.accepts_response_bytes(event))
+        {
+            let results: Vec<_> = self.http.process_raw_body_data(event).into_iter().collect();
+            for result in &results {
+                export_trace_events(result);
+            }
+            return results;
+        }
+
         let results: Vec<AggregatedResult> = result
             .messages
             .into_iter()

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -1532,8 +1532,6 @@ impl AgentSight {
     /// [`record_agent_crash_interruptions`], passing the decoded raw
     /// `task_struct->exit_code` so clean exits are not misreported.
     fn handle_agent_crash_detection(&mut self, pid: u32, agent_name: &str, raw_exit_code: u32) {
-        use crate::aggregator::ConnectionState;
-
         // Flush this pid's deferred GenAI events first: the exited process can
         // never produce the awaited session_id mapping, and the pending-calls
         // query below must see those already-answered calls as 'complete' so
@@ -1567,12 +1565,8 @@ impl AgentSight {
 
         // 2. Persist drained connections as pending calls
         for (conn_id, state) in &drained {
-            let (_state_name, request) = match state {
-                ConnectionState::RequestPending { request } => ("RequestPending", request),
-                ConnectionState::SseActive {
-                    request: Some(req), ..
-                } => ("SseActive", req),
-                _ => continue,
+            let Some(request) = state.pending_request() else {
+                continue;
             };
 
             if let Some(pending) = self.genai_builder.build_pending_from_request(
@@ -1628,20 +1622,15 @@ impl AgentSight {
             return;
         }
 
-        use crate::aggregator::ConnectionState;
         use crate::storage::sqlite::PendingOrigin;
 
         for (conn_id, state) in snapshots {
-            let (_state_name, request) = match state {
-                ConnectionState::RequestPending { request } => ("RequestPending", request),
-                ConnectionState::SseActive {
-                    request: Some(req), ..
-                } => ("SseActive", req),
-                _ => continue,
+            let Some(request) = state.pending_request() else {
+                continue;
             };
 
             if let Some(mut pending) = self.genai_builder.build_pending_from_request(
-                &request,
+                request,
                 &conn_id,
                 &self.response_mapper,
                 &self.pid_agent_name_cache,
@@ -1698,19 +1687,21 @@ impl AgentSight {
         )> = Vec::new();
 
         for (conn_id, state) in drained {
-            // Destructure to capture both request AND sse_events.
+            let Some(request) = state.pending_request().cloned() else {
+                continue;
+            };
+            // Preserve SSE enrichment while sharing request selection with other drains.
             // For compressed SSE streams that were still in progress when the
             // process died (sse_events empty, compressed_buffer non-empty),
             // decode the buffer here so token-usage data is not lost (#973).
-            let (_state_name, request, sse_events) = match state {
-                ConnectionState::RequestPending { request } => ("RequestPending", request, vec![]),
+            let sse_events = match state {
                 ConnectionState::SseActive {
-                    request: Some(req),
                     sse_events,
                     compressed_buffer: Some(buf),
                     content_encoding,
                     response_headers,
                     zstd_decoder,
+                    ..
                 } if sse_events.is_empty() && !buf.is_empty() => {
                     // fix(#973): decode the unfinalized compressed buffer
                     // so drain-path token extraction can proceed.
@@ -1718,22 +1709,16 @@ impl AgentSight {
                         crate::aggregator::HttpConnectionAggregator::is_chunked_response(
                             &response_headers,
                         );
-                    let decoded =
-                        crate::aggregator::HttpConnectionAggregator::decode_compressed_sse(
-                            &buf,
-                            content_encoding.as_deref(),
-                            is_chunked,
-                            zstd_decoder.as_deref(),
-                            &response_headers.source_event,
-                        );
-                    ("SseActive", req, decoded)
+                    crate::aggregator::HttpConnectionAggregator::decode_compressed_sse(
+                        &buf,
+                        content_encoding.as_deref(),
+                        is_chunked,
+                        zstd_decoder.as_deref(),
+                        &response_headers.source_event,
+                    )
                 }
-                ConnectionState::SseActive {
-                    request: Some(req),
-                    sse_events,
-                    ..
-                } => ("SseActive", req, sse_events),
-                _ => continue,
+                ConnectionState::SseActive { sse_events, .. } => sse_events,
+                _ => vec![],
             };
 
             if let Some(pending) = self.genai_builder.build_pending_from_request(
@@ -2674,6 +2659,9 @@ fn watermark_report(marks: ChannelWatermarks, pending_genai: usize) -> (bool, St
 }
 
 #[cfg(test)]
+mod response_pending_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering};
@@ -2769,7 +2757,7 @@ mod tests {
     }
 
     /// Generate a unique temp directory for each test invocation.
-    fn unique_tmp_dir(tag: &str) -> PathBuf {
+    pub(super) fn unique_tmp_dir(tag: &str) -> PathBuf {
         static COUNTER: AtomicU32 = AtomicU32::new(0);
         let pid = std::process::id();
         let n = COUNTER.fetch_add(1, Ordering::SeqCst);

--- a/src/agentsight/src/unified/response_pending_tests.rs
+++ b/src/agentsight/src/unified/response_pending_tests.rs
@@ -1,0 +1,170 @@
+//! Parser-to-storage lifecycle regressions without loading or attaching probes.
+
+use super::*;
+use crate::aggregator::{AggregatedResult, ConnectionState};
+use crate::config::RuntimeLimits;
+use crate::probes::sslsniff::SslEvent;
+use crate::storage::sqlite::PendingOrigin;
+
+const PID: u32 = 3_999_989;
+
+fn feed(aggregator: &mut Aggregator, rw: i32, bytes: &[u8]) -> Vec<AggregatedResult> {
+    let event = SslEvent {
+        source: 0,
+        timestamp_ns: 1_000_000_000,
+        delta_ns: 0,
+        pid: PID,
+        tid: PID,
+        uid: 0,
+        len: bytes.len() as u32,
+        rw,
+        comm: "fixture".into(),
+        buf: bytes.to_vec(),
+        is_handshake: false,
+        ssl_ptr: 123,
+    };
+    aggregator.process_result(Parser::new().parse_event(Event::Ssl(event)))
+}
+
+fn fixture(prefix: &[u8]) -> Aggregator {
+    let mut aggregator = Aggregator::with_limits(
+        4,
+        &RuntimeLimits {
+            connection_idle_timeout_secs: 0,
+            ..Default::default()
+        },
+    );
+    let body = r#"{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}"#;
+    let request = format!(
+        "POST /v1/chat/completions HTTP/1.1\r\nHost: api.openai.com\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    );
+    assert!(feed(&mut aggregator, 1, request.as_bytes()).is_empty());
+    assert!(feed(&mut aggregator, 0, prefix).is_empty());
+    aggregator
+}
+
+fn prefixes() -> [&'static [u8]; 3] {
+    [
+        b"HTTP/1.1 200 OK\r\nContent-Typ",
+        b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{",
+        b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n2\r\n{",
+    ]
+}
+
+#[test]
+fn response_pending_exit_and_dead_pid_preserve_crash_evidence() {
+    for prefix in prefixes() {
+        for dead_pid in [false, true] {
+            for exit_status in [0, 9] {
+                let mut aggregator = fixture(prefix);
+                // Periodic eviction must not race either persistence path.
+                aggregator.http_mut().evict_idle_and_oversized();
+                let drained = if dead_pid {
+                    assert!(!crate::utils::procfs::proc_pid(PID).exists());
+                    aggregator.drain_dead_pid_connections()
+                } else {
+                    aggregator.drain_connections_for_pid(PID)
+                };
+                assert_eq!(drained.len(), 1);
+                let (id, state) = &drained[0];
+                assert!(matches!(state, ConnectionState::ResponsePending { .. }));
+                let pending = GenAIBuilder::new()
+                    .build_pending_from_request(
+                        state.pending_request().expect("retained request"),
+                        id,
+                        &ResponseSessionMapper::new(),
+                        &HashMap::new(),
+                    )
+                    .expect("pending LLM call");
+                let dir = super::tests::unique_tmp_dir("response-pending");
+                let store = GenAISqliteStore::new_with_path(&dir.join("genai.db")).unwrap();
+                let interruptions =
+                    InterruptionStore::new_with_path(&dir.join("interruptions.db")).unwrap();
+                store.insert_pending(&pending).unwrap();
+                let rows = store.list_pending_for_pids(&[PID as i32]).unwrap();
+                assert_eq!(rows.len(), 1);
+                record_agent_crash_interruptions(
+                    PID,
+                    "fixture",
+                    ProcessExitStatus::decode(exit_status),
+                    &rows,
+                    &interruptions,
+                    Some(&store),
+                );
+                let crashes = interruptions
+                    .list(0, i64::MAX, None, Some("agent_crash"), None, None, 100)
+                    .unwrap();
+                assert_eq!(crashes.len(), usize::from(exit_status == 9));
+                assert_eq!(
+                    store.list_pending_for_pids(&[PID as i32]).unwrap().len(),
+                    usize::from(exit_status == 0)
+                );
+                std::fs::remove_dir_all(&dir).unwrap();
+            }
+        }
+    }
+}
+
+#[test]
+fn response_pending_idle_snapshot_persists_once_and_can_resume() {
+    let body = r#"{"id":"fixture","model":"gpt-4","choices":[{"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3}}"#;
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    );
+    for split in [26, response.len() - 1] {
+        let mut aggregator = fixture(&response.as_bytes()[..split]);
+        aggregator.http_mut().evict_idle_and_oversized();
+        let snapshots = aggregator.snapshot_idle_connections();
+        assert_eq!(snapshots.len(), 1);
+        assert!(aggregator.snapshot_idle_connections().is_empty());
+        let (id, state) = &snapshots[0];
+        let mut pending = GenAIBuilder::new()
+            .build_pending_from_request(
+                state.pending_request().expect("retained request"),
+                id,
+                &ResponseSessionMapper::new(),
+                &HashMap::new(),
+            )
+            .unwrap();
+        pending.pending_origin = PendingOrigin::IdleDrain;
+        let dir = super::tests::unique_tmp_dir("response-pending");
+        let store = GenAISqliteStore::new_with_path(&dir.join("genai.db")).unwrap();
+        store.insert_pending(&pending).unwrap();
+        // Crash-candidate queries intentionally exclude idle snapshots; inspect
+        // the stored row to verify both persistence and in-place reconciliation.
+        let db = rusqlite::Connection::open(dir.join("genai.db")).unwrap();
+        let row_state = || {
+            db.query_row(
+                "SELECT COUNT(*), MIN(status), MIN(pending_origin) FROM genai_events",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                },
+            )
+            .unwrap()
+        };
+        assert_eq!(row_state(), (1, "pending".into(), "idle_drain".into()));
+        aggregator.http_mut().evict_idle_and_oversized();
+        let completed = feed(&mut aggregator, 0, &response.as_bytes()[split..]);
+        assert_eq!(completed.len(), 1);
+        let analyzed = Analyzer::new().analyze_aggregated(&completed[0]);
+        let (output, _) = GenAIBuilder::new().build_with_pending(
+            &analyzed,
+            &ResponseSessionMapper::new(),
+            &HashMap::new(),
+        );
+        assert!(!output.events.is_empty());
+        for event in &output.events {
+            store.complete_pending(event).unwrap();
+        }
+        assert_eq!(row_state(), (1, "complete".into(), "idle_drain".into()));
+        assert!(!aggregator.has_pending());
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/src/agentsight/tests/non_sse_response_fragments.rs
+++ b/src/agentsight/tests/non_sse_response_fragments.rs
@@ -1,0 +1,329 @@
+//! Response framing regressions through Parser → Aggregator → Analyzer → GenAI → SQLite.
+mod common;
+
+use agentsight::aggregator::{AggregatedResult, Aggregator};
+use agentsight::analyzer::Analyzer;
+use agentsight::config::RuntimeLimits;
+use agentsight::event::Event;
+use agentsight::genai::semantic::GenAISemanticEvent;
+use agentsight::genai::{GenAIBuilder, GenAIExporter};
+use agentsight::parser::Parser;
+use agentsight::response_map::ResponseSessionMapper;
+use agentsight::storage::sqlite::GenAISqliteStore;
+use std::collections::HashMap;
+
+fn body() -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "id": "fragment-fixture", "object": "chat.completion", "model": "test-model", "created": 0,
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": "hello",
+            "tool_calls": [{"id": "call_fragment_fixture", "type": "function",
+                "function": {"name": "read_file", "arguments": "{\"path\":\"fixture\"}"}}]},
+            "finish_reason": "tool_calls"}],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
+    }))
+    .unwrap()
+}
+
+fn response(body: &[u8], framing: &str) -> Vec<u8> {
+    let mut bytes =
+        format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n{framing}\r\n").into_bytes();
+    bytes.extend_from_slice(body);
+    bytes
+}
+
+fn full_response() -> Vec<u8> {
+    let body = body();
+    response(&body, &format!("Content-Length: {}\r\n", body.len()))
+}
+
+fn feed(aggregator: &mut Aggregator, rw: i32, bytes: &[u8], time: u64) -> Vec<AggregatedResult> {
+    let mut event = common::make_ssl_event(123, 0x123, rw, bytes.to_vec(), "fixture");
+    event.timestamp_ns = time;
+    aggregator.process_result(Parser::new().parse_event(Event::Ssl(event)))
+}
+
+fn request(aggregator: &mut Aggregator) {
+    assert!(
+        feed(
+            aggregator,
+            1,
+            &common::make_openai_request_bytes("test-model", "hello", false),
+            1
+        )
+        .is_empty()
+    );
+}
+
+fn check(chunks: &[&[u8]]) {
+    let mut aggregator = Aggregator::new();
+    // Reuse the same connection to detect stale framing and duplicated bytes.
+    for _ in 0..2 {
+        request(&mut aggregator);
+        for (index, chunk) in chunks.iter().enumerate() {
+            let time = 100 + index as u64;
+            let completed = feed(&mut aggregator, 0, chunk, time);
+            if index + 1 < chunks.len() {
+                assert!(
+                    completed.is_empty(),
+                    "response completed at fragment {index}"
+                );
+                continue;
+            }
+            assert_eq!(completed.len(), 1);
+            let AggregatedResult::HttpComplete(pair) = &completed[0] else {
+                panic!("expected HTTP pair")
+            };
+            assert_eq!(
+                pair.response.parsed.json_body(),
+                Some(serde_json::from_slice(&body()).unwrap())
+            );
+            assert_eq!(pair.response.start_timestamp_ns(), 100);
+            assert_eq!(pair.response.end_timestamp_ns(), time);
+            let analyzed = Analyzer::new().analyze_aggregated(&completed[0]);
+            let (output, _) = GenAIBuilder::new().build_with_pending(
+                &analyzed,
+                &ResponseSessionMapper::new(),
+                &HashMap::new(),
+            );
+            let mut events = output.events;
+            let call = events
+                .iter_mut()
+                .find_map(|event| match event {
+                    GenAISemanticEvent::LLMCall(call) => Some(call),
+                    _ => None,
+                })
+                .unwrap();
+            let usage = call.token_usage.as_ref().unwrap();
+            assert_eq!((usage.input_tokens, usage.output_tokens), (5, 3));
+            assert_eq!(call.end_timestamp_ns, time);
+            assert!(!call.response.messages.is_empty());
+            call.metadata
+                .insert("session_id".into(), "fragment-session".into());
+            let dir = common::temp_dir("response-fragments");
+            let store = GenAISqliteStore::new_with_path(&dir.join("genai.db")).unwrap();
+            store.export(&events);
+            store.flush();
+            // This is the output index used by the tokenless savings lookup.
+            assert!(
+                store
+                    .get_tool_call_turn_indices(&["fragment-session"])
+                    .unwrap()
+                    .contains_key("call_fragment_fixture")
+            );
+            drop(store);
+            std::fs::remove_dir_all(dir).unwrap();
+            assert!(!aggregator.has_pending());
+        }
+    }
+}
+
+#[test]
+fn complete_response_in_one_read() {
+    check(&[&full_response()]);
+}
+
+#[test]
+fn every_response_split_preserves_usage_and_tool_index() {
+    let bytes = full_response();
+    for split in 1..bytes.len() {
+        check(&[&bytes[..split], &bytes[split..]]);
+    }
+}
+
+#[test]
+fn response_one_byte_per_read() {
+    let bytes = full_response();
+    check(&bytes.chunks(1).collect::<Vec<_>>());
+}
+
+#[test]
+fn chunked_response_waits_for_trailers() {
+    let body = body();
+    let framed = format!(
+        "{:x};fixture=yes\r\n{}\r\n0\r\nX-Fixture: ok\r\n\r\n",
+        body.len(),
+        std::str::from_utf8(&body).unwrap()
+    );
+    let bytes = response(
+        framed.as_bytes(),
+        "Transfer-Encoding: Chunked\r\nContent-Length: 1\r\n",
+    );
+    check(&bytes.chunks(7).collect::<Vec<_>>());
+    // The parser synthesizes an SSE DONE event for this last read.
+    let bytes = response(
+        format!(
+            "{:x}\r\n{}\r\n0\r\n\r\n",
+            body.len(),
+            std::str::from_utf8(&body).unwrap()
+        )
+        .as_bytes(),
+        "Transfer-Encoding: chunked\r\n",
+    );
+    let split = bytes.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4;
+    check(&[&bytes[..split], &bytes[split..]]);
+}
+
+#[test]
+fn compressed_response_is_decoded_after_framing() {
+    use std::io::Write;
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(&body()).unwrap();
+    let compressed = encoder.finish().unwrap();
+    let bytes = response(
+        &compressed,
+        &format!(
+            "Content-Encoding: gzip\r\nContent-Length: {}\r\n",
+            compressed.len()
+        ),
+    );
+    check(&bytes.chunks(17).collect::<Vec<_>>());
+}
+
+#[test]
+fn body_bytes_that_look_like_protocol_are_not_reparsed() {
+    let mut aggregator = Aggregator::new();
+    for body in [
+        b"data: first\n\ndata: second\n\n".as_slice(),
+        b"HTTP/1.1 200 OK\r\n\r\n",
+        b"GET / HTTP/1.1\r\n\r\n",
+        b"5\r\nhello\r\n0\r\n\r\n",
+    ] {
+        request(&mut aggregator);
+        assert!(
+            feed(
+                &mut aggregator,
+                0,
+                &response(&[], &format!("Content-Length: {}\r\n", body.len())),
+                100
+            )
+            .is_empty()
+        );
+        let results = feed(&mut aggregator, 0, body, 200);
+        let [AggregatedResult::HttpComplete(pair)] = results.as_slice() else {
+            panic!("expected one HTTP pair")
+        };
+        assert_eq!(pair.response.body(), body);
+    }
+}
+
+#[test]
+fn bodyless_responses_ignore_advertised_length() {
+    for (method, status) in [("HEAD", 200), ("GET", 204), ("GET", 304), ("CONNECT", 200)] {
+        let mut aggregator = Aggregator::new();
+        // CONNECT is not detected by the unified parser's method heuristic;
+        // exercise its no-body framing with the explicit HTTP parser instead.
+        let event = common::make_ssl_event(
+            123,
+            0x123,
+            1,
+            format!("{method} / HTTP/1.1\r\n\r\n").into_bytes(),
+            "fixture",
+        );
+        let agentsight::parser::http::ParsedHttpMessage::Request(request) =
+            agentsight::parser::http::HttpParser::new()
+                .parse(std::rc::Rc::new(event))
+                .unwrap()
+        else {
+            panic!("expected request")
+        };
+        aggregator.http_mut().process_request(request);
+        let results = feed(
+            &mut aggregator,
+            0,
+            format!("HTTP/1.1 {status} OK\r\nContent-Length: 99999\r\n\r\n").as_bytes(),
+            2,
+        );
+        assert_eq!(results.len(), 1, "{method} {status}");
+        assert!(!aggregator.has_pending());
+    }
+}
+
+#[test]
+fn informational_response_keeps_request_for_final_response() {
+    for coalesced in [false, true] {
+        let mut aggregator = Aggregator::new();
+        request(&mut aggregator);
+        let mut first = b"HTTP/1.1 100 Continue\r\n\r\n".to_vec();
+        if coalesced {
+            first.extend(full_response());
+        }
+        let results = feed(&mut aggregator, 0, &first, 100);
+        if coalesced {
+            assert_eq!(results.len(), 1);
+        } else {
+            assert!(results.is_empty());
+            assert_eq!(feed(&mut aggregator, 0, &full_response(), 200).len(), 1);
+        }
+    }
+}
+
+#[test]
+fn incomplete_responses_are_bounded_and_never_complete_on_timeout() {
+    let limits = RuntimeLimits {
+        max_connection_body_bytes: 1024,
+        connection_idle_timeout_secs: 0,
+        ..Default::default()
+    };
+    for (bytes, completes) in [
+        (response(b"{}", "Connection: close\r\n"), false),
+        (response(b"{", "Content-Length: 2\r\n"), true),
+        (b"HTTP/1.1 200".to_vec(), false),
+    ] {
+        // Use the HTTP API for eviction so zero timeout doesn't evict between reads.
+        let mut aggregator = Aggregator::with_limits(4, &limits);
+        request(&mut aggregator);
+        assert!(feed(&mut aggregator, 0, &bytes, 100).is_empty());
+        aggregator.http_mut().evict_idle_and_oversized();
+        assert!(
+            aggregator.has_pending(),
+            "retain request evidence for idle persistence"
+        );
+        assert_eq!(
+            feed(&mut aggregator, 0, b"}", 200).len(),
+            usize::from(completes)
+        );
+        assert_eq!(aggregator.has_pending(), !completes);
+    }
+    let limits = RuntimeLimits {
+        connection_idle_timeout_secs: 60,
+        ..limits
+    };
+    for framing in [
+        "Content-Length: 1025\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "Connection: close\r\n",
+    ] {
+        let mut aggregator = Aggregator::with_limits(4, &limits);
+        request(&mut aggregator);
+        assert!(feed(&mut aggregator, 0, &response(&[], framing), 100).is_empty());
+        assert!(feed(&mut aggregator, 0, &[b'x'; 1025], 200).is_empty());
+        assert!(!aggregator.has_pending());
+        request(&mut aggregator);
+        assert_eq!(feed(&mut aggregator, 0, &full_response(), 300).len(), 1);
+    }
+}
+
+#[test]
+fn malformed_framing_does_not_emit_complete() {
+    for (framing, body) in [
+        ("Content-Length: nope\r\n", "{}"),
+        ("Transfer-Encoding: chunked\r\n", "z\r\n{}\r\n0\r\n\r\n"),
+        ("Transfer-Encoding: chunked\r\n", "2\r\n{}xx0\r\n\r\n"),
+    ] {
+        let mut aggregator = Aggregator::new();
+        request(&mut aggregator);
+        assert!(feed(&mut aggregator, 0, &response(body.as_bytes(), framing), 100).is_empty());
+        assert!(!aggregator.has_pending());
+    }
+}
+
+#[test]
+fn opposite_direction_bytes_do_not_extend_response() {
+    let mut aggregator = Aggregator::new();
+    request(&mut aggregator);
+    let bytes = full_response();
+    let split = bytes.len() - 20;
+    assert!(feed(&mut aggregator, 0, &bytes[..split], 100).is_empty());
+    assert!(feed(&mut aggregator, 1, b"unexpected write", 150).is_empty());
+    assert_eq!(feed(&mut aggregator, 0, &bytes[split..], 200).len(), 1);
+}


### PR DESCRIPTION
## Why

Non-SSE HTTP/1.1 responses split across SSL reads can be emitted as complete before the body arrives. Truncated JSON then loses usage and output tool-call IDs, leaving existing Tokenless savings records unassociated.

## What changed

Assemble response headers and bodies within connection limits, using Content-Length, complete chunked framing (including trailers), and bodyless-response rules to decide completion. Route continuation bytes through connection state before stateless protocol detection, then decode content and extract usage and tool calls once the response is complete. Preserve the final fragment timestamp and retain pending request evidence through idle snapshots, process exit, and dead-PID recovery, allowing resumed responses to reconcile their SQLite record.

## Related issue

Closes #3144

## User / Agent impact

Fragmented ordinary responses retain complete usage, output messages, and output tool-call IDs needed for Tokenless association. Interrupted calls remain visible as pending evidence; an idle snapshot can be updated to complete when the remaining response arrives. Historical truncated records cannot be reconstructed by this change.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The Rust `AggregatedResponse` struct gains an optional completion timestamp; external struct literals must initialize the new field. CLI options, configuration schema, database schema, BPF programs, and deployment privileges are unchanged by this PR.

Close-delimited responses without Content-Length or chunked framing cannot be confirmed complete from SSL data events alone. Responses with associated requests retain pending evidence across idle timeouts; connection capacity and per-connection body limits bound retained buffers. Malformed and oversized responses are rejected. This does not recover events lost before aggregation or repair historical data.

## Validation

Final commit `e3c20dbb9e0467310a5b24552d3cde7b49e5ab82`, rebased onto main `89c45da03c92fe89a5a003f62c877362add16c4b`, validated in an isolated Linux build container:

- `cargo fmt --all -- --check`: passed.
- `cargo clippy --offline --locked -p agentsight --all-targets -- -D warnings`: passed.
- `cargo test --offline --locked -p agentsight`: **1,928 passed, 0 failed, 38 ignored**, across 16 suites including doctests.
- `cargo doc --offline --locked --workspace --no-deps`: passed with existing rustdoc warnings.
- Local `git diff --check`, documentation lint/link checks, and English/Chinese website builds: passed.

Regression coverage includes every two-part split position, one-byte reads, chunked trailers, compression, informational and bodyless responses, direction isolation, connection reuse, body limits, malformed framing, and timeout behavior. Parser-to-GenAI-to-SQLite assertions verify usage and output tool-call indexing. Lifecycle tests cover 14 combinations of incomplete headers/bodies, process exit/dead-PID draining, clean exit/SIGKILL, idle snapshot deduplication, and in-place pending-to-complete reconciliation.

Before the rebase and lifecycle follow-up, a controlled loopback TLS/eBPF fixture captured three complete responses across 39 SSL reads and verified usage and SQLite output tool-call indexing. The final lifecycle changes are covered by synthetic pipeline tests; no deployment or end-to-end Tokenless stats injection is claimed for the final head.

Full-workspace test and Clippy gates are not claimed green: earlier checks failed in unchanged vendored `actplane-ifc-compiler` corpus tests (missing `test/policies`) and existing ActPlane lint findings. Those full-workspace commands were not rerun for this focused follow-up; component checks above were rerun on the final base.

## Documentation and rollback

Updated the English and Chinese AgentSight integration guides with framing, pending evidence, and Tokenless association limitations. No data migration is needed. Revert this commit to restore the previous behavior, including the original response truncation defect; deploy the fixed collector to affect future captures.
