### PR TITLE
fix(tokenless): gate unsafe-install flag

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/en/token-saving/tokenless/framework-integration.md
@@ -212,7 +212,11 @@ must repeat every profile that should remain registered.
 Running OpenClaw adapter enable or the tokenless OpenClaw `install.sh` accepts
 the plugin's declared capabilities. Both entry points pass
 `--accept-capabilities` only when `plugins install --help` advertises that
-exact option, so older hosts keep working.
+exact option, so older hosts keep working. The standalone `install.sh` also
+passes `--dangerously-force-unsafe-install` only while the installer advertises
+the option as effective; hosts that list it as a deprecated no-op (OpenClaw
+2026.9.2+) no longer receive it, and the safety scan there follows
+`security.installPolicy`.
 
 For OpenClaw, anolisa first attempts a normal install and does not add an unsafe-install bypass by default. If OpenClaw rejects the plugin on its safety scan, read the reported findings. Only after accepting them, retry explicitly:
 
@@ -278,7 +282,7 @@ bash ~/.local/share/anolisa/adapters/tokenless/<framework>/scripts/uninstall.sh
 
 The scripts call the framework's own plugin or extension mechanism. Follow their restart instructions. If a script is missing, fails, or reports an incompatible framework version, prefer an anolisa-managed installation.
 
-The OpenClaw install script invokes `plugins install` with `--dangerously-force-unsafe-install` because the plugin launches the `tokenless` and `rtk` binaries through Node.js child-process APIs. Review the installed adapter source and your OpenClaw policy before running it. If that policy does not permit the override, do not install the plugin.
+On hosts whose installer still enforces the safety scan, the OpenClaw install script invokes `plugins install` with `--dangerously-force-unsafe-install` because the plugin launches the `tokenless` and `rtk` binaries through Node.js child-process APIs. Hosts that advertise the option as a deprecated no-op no longer receive it; there the scan follows `security.installPolicy`. Review the installed adapter source and your OpenClaw policy before running it. If that policy does not permit the override, do not install the plugin.
 
 ### npm with cosh
 
@@ -302,7 +306,7 @@ Extensions are discovered at startup. Restart cosh, run a shell-tool task, and i
 
 ### OpenClaw
 
-The install script uses OpenClaw's unsafe-install override as described above. Restart the gateway after accepting and installing the plugin. Response compression and RTK rewriting default to enabled in the plugin code; TOON defaults to disabled. The plugin's Tool Ready option currently has no effect because the underlying check is hard-disabled.
+The install script uses OpenClaw's unsafe-install override on legacy hosts, as described above. Restart the gateway after accepting and installing the plugin. Response compression and RTK rewriting default to enabled in the plugin code; TOON defaults to disabled. The plugin's Tool Ready option currently has no effect because the underlying check is hard-disabled.
 
 ### Hermes
 

--- a/docs/user-guide/en/token-saving/tokenless/troubleshooting.md
+++ b/docs/user-guide/en/token-saving/tokenless/troubleshooting.md
@@ -194,7 +194,7 @@ anolisa adapter enable tokenless openclaw \
   --allow-unsafe-plugin-install
 ```
 
-The npm/manual install script behaves differently: it always passes OpenClaw's `--dangerously-force-unsafe-install` because the plugin launches fixed `tokenless` and `rtk` child processes. Review the adapter and policy; do not enable it where that override is prohibited.
+The npm/manual install script differs in *how* it consents, not *whether*: it adds `--dangerously-force-unsafe-install` automatically whenever the installer still advertises that option as effective, because the plugin launches fixed `tokenless` and `rtk` child processes. Hosts that mark the option a deprecated no-op (OpenClaw 2026.9.2+) never receive it — there the safety scan is decided by `security.installPolicy`, so a rejection must be resolved by the operator relaxing that policy, not by re-running the script. Review the adapter and policy; do not enable it where that override is prohibited.
 
 ## A command is not rewritten
 

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -192,7 +192,10 @@ DeepSeek Harness 按 profile 管理，因此必须至少提供一个 `--profile`
 
 执行 OpenClaw adapter enable 或 tokenless 的 OpenClaw `install.sh` 即同意
 插件声明的能力。两个入口仅在 `plugins install --help` 列出完整的
-`--accept-capabilities` 参数时传递它，以兼容旧版宿主。
+`--accept-capabilities` 参数时传递它，以兼容旧版宿主。独立的 `install.sh`
+也只在安装器仍声明该参数有效时传递 `--dangerously-force-unsafe-install`；
+将其列为 deprecated no-op 的宿主（OpenClaw 2026.9.2+）不再收到该参数，
+安全扫描改由 `security.installPolicy` 决定。
 
 对于 OpenClaw，anolisa 会先尝试普通安装，默认不会加入 unsafe-install 覆盖参数。如果 OpenClaw 的安全扫描拒绝此 Plugin，应先阅读其报告；确认接受风险后，才显式重试：
 
@@ -257,7 +260,7 @@ bash ~/.local/share/anolisa/adapters/tokenless/<framework>/scripts/uninstall.sh
 
 脚本会调用框架自身的 Plugin/Extension 机制；按照脚本输出完成重启。安装脚本缺失、失败或框架版本不兼容时，优先改用 anolisa 管理的安装方式。
 
-OpenClaw 安装脚本会带 `--dangerously-force-unsafe-install` 调用 `plugins install`，因为 Plugin 通过 Node.js 子进程 API 启动 `tokenless` 和 `rtk` 二进制。运行前应审查已安装的 Adapter 源码和 OpenClaw 安全策略。如果策略不允许该覆盖参数，就不要安装此 Plugin。
+在安装器仍执行安全扫描的宿主上，OpenClaw 安装脚本会带 `--dangerously-force-unsafe-install` 调用 `plugins install`，因为 Plugin 通过 Node.js 子进程 API 启动 `tokenless` 和 `rtk` 二进制；将该参数列为 deprecated no-op 的宿主不再收到该参数，安全扫描由 `security.installPolicy` 决定。运行前应审查已安装的 Adapter 源码和 OpenClaw 安全策略。如果策略不允许该覆盖参数，就不要安装此 Plugin。
 
 ### npm + cosh
 
@@ -281,7 +284,7 @@ Extension 在启动时发现。启用后重启 cosh，并运行一个 Shell 工�
 
 ### OpenClaw
 
-安装脚本会使用上文说明的 OpenClaw unsafe-install 覆盖参数。确认风险并安装后，重启 Gateway。Plugin 代码默认启用响应压缩和 RTK 重写，默认关闭 TOON。由于底层检查已硬关闭，Plugin 的 Tool Ready 选项当前不会生效。
+安装脚本会在旧版宿主上使用上文说明的 OpenClaw unsafe-install 覆盖参数。确认风险并安装后，重启 Gateway。Plugin 代码默认启用响应压缩和 RTK 重写，默认关闭 TOON。由于底层检查已硬关闭，Plugin 的 Tool Ready 选项当前不会生效。
 
 ### Hermes
 

--- a/docs/user-guide/zh/token-saving/tokenless/troubleshooting.md
+++ b/docs/user-guide/zh/token-saving/tokenless/troubleshooting.md
@@ -189,7 +189,7 @@ anolisa adapter enable tokenless openclaw \
   --allow-unsafe-plugin-install
 ```
 
-npm/手动安装脚本的行为不同：它总是传入 OpenClaw 的 `--dangerously-force-unsafe-install`，因为 Plugin 会启动固定的 `tokenless` 和 `rtk` 子进程。应先审查 Adapter 和安全策略；策略禁止该覆盖参数时不要启用。
+npm/手动安装脚本的区别在于“如何同意”而非“是否同意”：在安装器仍声明该参数有效时（旧版宿主），脚本会自动附加 `--dangerously-force-unsafe-install`，因为 Plugin 会启动固定的 `tokenless` 和 `rtk` 子进程。将该参数标记为 deprecated no-op 的宿主（OpenClaw 2026.9.2+）不会收到该参数——此时安全扫描由 `security.installPolicy` 决定，安装被拒时应由运维放宽该策略解决，而不是重跑脚本。应先审查 Adapter 和安全策略；策略禁止该覆盖参数时不要启用。
 
 ## 命令没有被重写
 

--- a/src/tokenless/adapters/tokenless/openclaw/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/openclaw/scripts/install.sh
@@ -45,7 +45,8 @@ if [ ! -f "$PLUGIN_SRC/dist/index.js" ]; then
 fi
 
 if [ "$DRY_RUN" = "1" ]; then
-    echo "DRY-RUN: env -u OPENCLAW_HOME OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR $OPENCLAW_BIN plugins install $PLUGIN_SRC --force --dangerously-force-unsafe-install"
+    echo "DRY-RUN: env -u OPENCLAW_HOME OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR $OPENCLAW_BIN plugins install $PLUGIN_SRC --force"
+    echo "DRY-RUN: add --dangerously-force-unsafe-install only while the advertised option still has effect (legacy hosts)"
     echo "DRY-RUN: add --accept-capabilities only if advertised by plugins install --help"
     exit 0
 fi
@@ -56,7 +57,7 @@ if ! command -v "$OPENCLAW_BIN" &>/dev/null; then
     exit 0
 fi
 
-INSTALL_ARGS=(plugins install "$PLUGIN_SRC" --force --dangerously-force-unsafe-install)
+INSTALL_ARGS=(plugins install "$PLUGIN_SRC" --force)
 if ! INSTALL_HELP="$(env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install --help 2>&1)"; then
     printf '[%s] Cannot inspect OpenClaw installer options: %s\n' "$COMPONENT" "$INSTALL_HELP" >&2
     exit 1
@@ -67,18 +68,44 @@ if [[ "$INSTALL_HELP" =~ (^|[^[:alnum:]_.-])--accept-capabilities([^[:alnum:]_.-
     INSTALL_ARGS+=(--accept-capabilities)
 fi
 
+# Legacy hosts gate installs on a safety scan of child_process usage whose only
+# non-interactive bypass is --dangerously-force-unsafe-install. OpenClaw 2026.9.2
+# keeps the token as a deprecated no-op: passing it there accomplishes nothing
+# and breaks again once the token is removed outright, so keep it only while the
+# advertised option still has effect (the scanner moved to
+# security.installPolicy on no-op hosts). The npm package ships this script to
+# macOS, where /bin/bash stays at 3.2 — no ${var,,} here.
+UNSAFE_SUPPORT=absent
+while IFS= read -r help_line; do
+    if [[ "$help_line" =~ (^|[^[:alnum:]_.-])--dangerously-force-unsafe-install([^[:alnum:]_.-]|$) ]]; then
+        help_line_lc="$(printf '%s' "$help_line" | tr '[:upper:]' '[:lower:]')"
+        case "$help_line_lc" in
+            *"no op"*|*"no-op"*) UNSAFE_SUPPORT=noop ;;
+            *) UNSAFE_SUPPORT=effective; INSTALL_ARGS+=(--dangerously-force-unsafe-install) ;;
+        esac
+        break
+    fi
+done <<< "$INSTALL_HELP"
+
 # OpenClaw's built-in security scanner flags child_process imports as "dangerous
 # code patterns" and requires --dangerously-force-unsafe-install to proceed.
 # This is expected for the tokenless plugin: it delegates to tokenless and rtk
 # system binaries via execFileSync/spawnSync with fixed paths and timeouts.
 # No shell injection vector exists — all subprocess arguments are hardcoded or
 # come from resolveBinaryPath(), never from user input.
-echo "[${COMPONENT}] Note: --dangerously-force-unsafe-install is required because"
-echo "[${COMPONENT}]       this plugin wraps tokenless/rtk system binaries via child_process."
-echo "[${COMPONENT}]       See https://github.com/alibaba/anolisa for source."
+if [ "$UNSAFE_SUPPORT" = "effective" ]; then
+    echo "[${COMPONENT}] Note: --dangerously-force-unsafe-install is required because"
+    echo "[${COMPONENT}]       this plugin wraps tokenless/rtk system binaries via child_process."
+    echo "[${COMPONENT}]       See https://github.com/alibaba/anolisa for source."
+fi
 
 env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" "${INSTALL_ARGS[@]}" || {
     echo "[${COMPONENT}] openclaw CLI install failed — check OpenClaw version >= 5.0.0" >&2
+    if [ "$UNSAFE_SUPPORT" = "noop" ]; then
+        echo "[${COMPONENT}]       this OpenClaw advertises --dangerously-force-unsafe-install as a" >&2
+        echo "[${COMPONENT}]       deprecated no-op; the safety scan follows the operator-owned" >&2
+        echo "[${COMPONENT}]       security.installPolicy instead." >&2
+    fi
     exit 1
 }
 

--- a/src/tokenless/tests/test-openclaw-adapter-install.sh
+++ b/src/tokenless/tests/test-openclaw-adapter-install.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Check capability-consent negotiation without installing a real plugin.
+# Check installer flag negotiation (capability consent and the legacy
+# unsafe-install bypass) without installing a real plugin.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -18,23 +19,46 @@ printf '%s\n' "$*" >> "$TEST_ARGV_LOG"
 if [ "$*" = "plugins install --help" ]; then
     echo "--force"
     case "$TEST_SUPPORT" in
-        modern) echo "--accept-capabilities" ;;
+        modern|modern_unsafe) echo "--accept-capabilities" ;;
         near_match) echo "--accept-capabilities-only" ;;
         failed) echo "cannot inspect --accept-capabilities" >&2; exit 3 ;;
+    esac
+    case "$TEST_SUPPORT" in
+        unsafe_effective|modern_unsafe)
+            echo "--dangerously-force-unsafe-install  Bypass the install safety scan" ;;
+        unsafe_noop|noop_rejected)
+            echo "--dangerously-force-unsafe-install  Deprecated no-op; governed by security.installPolicy" ;;
+        unsafe_noop_upper)
+            echo "--dangerously-force-unsafe-install  Deprecated NO-OP; governed by security.installPolicy" ;;
+        unsafe_near) echo "--dangerously-force-unsafe-install-only" ;;
     esac
     exit 0
 fi
 [ "$1" = plugins ] && [ "$2" = install ]
 [ "$3" = "$ANOLISA_ADAPTER_DIR/openclaw" ]
 accepted=0
+unsafe=0
 for arg in "$@"; do
     [ "$arg" != --accept-capabilities ] || accepted=1
+    [ "$arg" != --dangerously-force-unsafe-install ] || unsafe=1
 done
-if [ "$TEST_SUPPORT" = modern ]; then
-    [ "$accepted" = 1 ] || { echo 'Plugin requires capability consent' >&2; exit 1; }
-else
-    [ "$accepted" = 0 ] || { echo 'unknown option --accept-capabilities' >&2; exit 2; }
-fi
+case "$TEST_SUPPORT" in
+    modern|modern_unsafe)
+        [ "$accepted" = 1 ] || { echo 'Plugin requires capability consent' >&2; exit 1; }
+        ;;
+    *)
+        [ "$accepted" = 0 ] || { echo 'unknown option --accept-capabilities' >&2; exit 2; }
+        ;;
+esac
+case "$TEST_SUPPORT" in
+    unsafe_effective|modern_unsafe)
+        [ "$unsafe" = 1 ] || { echo 'install safety scan blocks child_process plugins' >&2; exit 4; }
+        ;;
+    *)
+        [ "$unsafe" = 0 ] || { echo 'unknown option --dangerously-force-unsafe-install' >&2; exit 5; }
+        ;;
+esac
+[ "$TEST_SUPPORT" != noop_rejected ] || { echo 'install blocked by security.installPolicy' >&2; exit 6; }
 : > "$TEST_INSTALLED"
 STUB
 chmod +x "$SANDBOX/openclaw"
@@ -48,15 +72,31 @@ export TEST_ARGV_LOG="$SANDBOX/argv"
 export TEST_INSTALLED="$SANDBOX/installed"
 export ANOLISA_DRY_RUN=0
 
-for TEST_SUPPORT in modern legacy near_match; do
+for TEST_SUPPORT in modern legacy near_match unsafe_effective unsafe_noop unsafe_noop_upper unsafe_near modern_unsafe; do
     export TEST_SUPPORT
     : > "$TEST_ARGV_LOG"
     bash "$INSTALL_SH" > "$SANDBOX/output" 2>&1 || { cat "$SANDBOX/output" >&2; exit 1; }
     [ -f "$TEST_INSTALLED" ]
     [ "$(grep -c '^plugins install --help$' "$TEST_ARGV_LOG")" = 1 ]
+    case "$TEST_SUPPORT" in
+        unsafe_effective|modern_unsafe)
+            grep -q -- '--dangerously-force-unsafe-install is required' "$SANDBOX/output" ;;
+        *)
+            ! grep -q -- '--dangerously-force-unsafe-install is required' "$SANDBOX/output" ;;
+    esac
     rm "$TEST_INSTALLED"
     echo "PASS: $TEST_SUPPORT installer"
 done
+
+export TEST_SUPPORT=noop_rejected
+if bash "$INSTALL_SH" > "$SANDBOX/output" 2>&1; then
+    echo 'FAIL: policy-rejected install reported success' >&2
+    exit 1
+fi
+[ ! -f "$TEST_INSTALLED" ]
+grep -q 'security.installPolicy' "$SANDBOX/output"
+grep -q 'deprecated no-op' "$SANDBOX/output"
+echo 'PASS: noop host failure points at security.installPolicy'
 
 export TEST_SUPPORT=failed
 if bash "$INSTALL_SH" > "$SANDBOX/output" 2>&1; then
@@ -71,7 +111,8 @@ ANOLISA_DRY_RUN=1 bash "$INSTALL_SH" > "$SANDBOX/output" 2>&1
 [ ! -s "$TEST_ARGV_LOG" ]
 [ ! -f "$TEST_INSTALLED" ]
 grep -q -- '--accept-capabilities' "$SANDBOX/output"
-echo 'PASS: dry-run describes consent without invoking OpenClaw'
+grep -q -- '--dangerously-force-unsafe-install' "$SANDBOX/output"
+echo 'PASS: dry-run describes consent and bypass gating without invoking OpenClaw'
 
 OPENCLAW_BIN="$SANDBOX/missing-openclaw" bash "$INSTALL_SH" > "$SANDBOX/output" 2>&1
 grep -q 'skipping plugin installation' "$SANDBOX/output"


### PR DESCRIPTION
## Why

OpenClaw 2026.9.2 advertises `--dangerously-force-unsafe-install` as a deprecated no-op governed by `security.installPolicy`, but the tokenless OpenClaw `install.sh` still passes it unconditionally — a no-op today and a hard `unknown option` failure once OpenClaw removes the token. This is the follow-up cleanup flagged in the #3113 discussion; the main capability-consent fix already landed in #3126 (`eab1555a`).

## What changed

- `install.sh` now negotiates the flag from the `plugins install --help` probe introduced by `eab1555a`: it is appended only when the option appears as a standalone token and its description is not marked "no-op". The explanatory install note prints only on those legacy hosts, and the DRY-RUN output is updated to match. This mirrors anolisa-core's `UnsafeInstallSupport` classification and sec-core `deploy.sh` gating.
- The option line is lowercased with `tr` instead of `${var,,}` — the npm package ships this script to macOS, where `/bin/bash` stays at 3.2.
- Install failures on no-op hosts now add a pointer to the operator-owned `security.installPolicy`, matching anolisa-core's `DeprecatedNoOp` advice.
- Regression test `src/tokenless/tests/test-openclaw-adapter-install.sh` extended with unsafe-effective, no-op, uppercase no-op (exercises the case normalization), near-match (`--dangerously-force-unsafe-install-only`), combined-with-`--accept-capabilities`, and policy-rejected cases, plus assertions that the help probe still runs exactly once and the note is conditional.
- en/zh user-guide updated: `framework-integration.md` and `troubleshooting.md` both describe the gating and the `security.installPolicy` escape hatch.

## Related issue

closes #3113 (the reported regression itself was fixed by #3126; this addresses the remaining deprecated-flag cleanup item from that issue's discussion)

## User / Agent impact

OpenClaw 2026.9.2+ hosts no longer receive the deprecated flag — behavior-equivalent, since the flag is a no-op there and installs remain governed by `security.installPolicy`. Legacy hosts are unaffected. The three-line install note no longer prints on no-op hosts, and a failed install on such hosts now explains the `security.installPolicy` remedy instead of only suggesting an OpenClaw version check.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed — the user-guide's description of the install script's flags changed (updated in this PR); the argv change only affects hosts where the flag is a no-op.
- [x] Privileged or security-sensitive behavior changed — touches the safety-scan bypass flag, but the effective security posture is unchanged: on no-op hosts the bypass never did anything, and restrictive `security.installPolicy` outcomes are identical before and after.
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

## Validation

- `bash src/tokenless/tests/test-openclaw-adapter-install.sh` — 12/12 PASS (modern, legacy, near_match, unsafe_effective, unsafe_noop, unsafe_noop_upper, unsafe_near, modern_unsafe, noop_rejected, failed help probe, dry-run, missing CLI)
- `shellcheck` 0.11.0 clean on both scripts; `bash -n` clean; no Bash 4-only constructs remain under `src/tokenless/adapters/` (macOS `/bin/bash` 3.2 compatibility)
- Verified with a stub OpenClaw CLI only; not end-to-end against a real OpenClaw 2026.9.2 host. The strict-xfail sentinel from #3113 will re-verify once a fixed RPM lands.

## Documentation and rollback

- `docs/user-guide/{en,zh}/token-saving/tokenless/framework-integration.md` and `troubleshooting.md` updated in the same PR per `specs/documentation-standard.md` (bilingual semantics equivalent).
- Rollback: revert the single commit; `install.sh` returns to unconditional flag passing.