### PR TITLE
test(cosh-ng): [shell] route bare CJK after Insight

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/failed_command.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/failed_command.rs
@@ -264,6 +264,69 @@ fn raw_cli_build_failure_respects_analysis_mode_matrix() {
 }
 
 #[test]
+fn raw_cli_zsh_insight_keeps_bare_cjk_natural_language_routing_to_agent() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        eprintln!("zsh unavailable; mandatory coverage runs in the amd64 Anolis gate");
+        return;
+    }
+
+    let fixture = temp_shell_home("zsh-insight-cjk-routing");
+    let bin_dir = fixture.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    write_executable(
+        &bin_dir.join("make"),
+        "#!/bin/sh\necho 'make: *** [all] Error 2' >&2\nexit 2\n",
+    );
+    let path = format!(
+        "{}:{}",
+        bin_dir.to_string_lossy(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let insight = "Insight: The build or test command failed";
+    let first_prompt = "测试";
+    let second_prompt = "继续测试";
+    let first_request = format!("Received shell prompt request: {first_prompt}");
+    let second_request = format!("Received shell prompt request: {second_prompt}");
+    let first_line = format!("{first_prompt}\n");
+    let second_line = format!("{second_prompt}\n");
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
+        "fake",
+        &["--shell", "zsh"],
+        &[
+            ("COSH_SHELL_LANG", "en-US"),
+            ("COSH_SHELL_ANALYSIS_MODE", "smart"),
+            ("COSH_SHELL_STARTUP_BANNER", "0"),
+            ("LANG", "C.UTF-8"),
+            ("LC_ALL", "C.UTF-8"),
+            ("PATH", path.as_str()),
+        ],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$ ", b"make all\n"),
+            (insight, b""),
+            ("cosh-osc$ ", first_line.as_bytes()),
+            (first_request.as_str(), b""),
+            ("cosh-osc$ ", second_line.as_bytes()),
+            (second_request.as_str(), b""),
+            ("cosh-osc$ ", b"exit\n"),
+        ],
+    );
+    let _ = fs::remove_dir_all(&fixture);
+
+    let insight_pos = output.find(insight).expect("insight line missing");
+    let first_pos = output
+        .find(&first_request)
+        .expect("first CJK prompt request missing");
+    let second_pos = output
+        .find(&second_request)
+        .expect("second CJK prompt request missing");
+    assert!(insight_pos < first_pos, "{output}");
+    assert!(insight_pos < second_pos, "{output}");
+    assert!(first_pos < second_pos, "{output}");
+    assert!(!output.contains("command not found"), "{output}");
+}
+
+#[test]
 fn raw_cli_runtime_exception_requires_confirmation_outside_manual_mode() {
     for (mode, expects_insight) in [("smart", true), ("auto", true), ("manual", false)] {
         let fixture = temp_shell_home(&format!("runtime-exception-{mode}"));


### PR DESCRIPTION
## Why

GitHub issue #3055 reports intermittent loss of Agent routing for bare CJK natural-language prompts. The issue's observation matrix shows the sequence "failed command shows Insight, then `测试` and `继续测试`" currently passes on main, but no existing test covers the combined sequence (real Insight → two consecutive bare CJK prompts → both reach the Agent) in a default Zsh session. This PR is a **partial slice: regression test for the first acceptance item only** — it locks in known-good default behavior and does not attempt to fix the intermittent incident or implement the diagnostic proposal.

## What changed

- `src/cosh-ng/crates/cosh-shell/tests/raw_cli/failed_command.rs`: append one `#[test]`, `raw_cli_zsh_insight_keeps_bare_cjk_natural_language_routing_to_agent` (+63 lines, test-only).
- The test drives `cosh-shell raw fake --shell zsh` through the existing zero-sleep, marker-gated harness with an isolated HOME and a fake `make` that fails with exit code 2: wait for prompt → `make all` → wait for the real Insight line → submit `测试` → wait for `Received shell prompt request: 测试` → submit `继续测试` → wait for its request line → `exit`.
- Assertions: the Insight text appears before both distinct `Received shell prompt request:` lines (emitted by the fake adapter when the Agent receives the request — terminal echo cannot forge them), no `command not found` output, and clean child exit (harness status assertion).
- No production (`src/`) code, public API, or documentation changes.

## Related issue

Refs #3055 (partial slice — first acceptance item only; does not close the issue)

## User / Agent impact

None. Test-only addition; no runtime behavior change.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: pure test append in an existing integration test file.

## Validation

Environment: Linux x86_64, Rust 1.96.0, base `80301fb9e4a9fa047f95e8c943b1db1884c0b9af`.

- `cargo fmt --all -- --check` → exit 0.
- `cargo clippy --locked -p cosh-shell --test raw_cli -- -D warnings` → exit 0, no warnings.
- `cargo test --locked -p cosh-shell --test raw_cli failed_command::raw_cli_build_failure_respects_analysis_mode_matrix -- --exact` → 1 matched, 1 passed (real execution).
- `cargo test --locked -p cosh-shell --test raw_cli failed_command::raw_cli_natural_language_after_failure_does_not_bind_generic_failure -- --exact` → 1 matched, 1 passed (real execution).
- New test and the two zsh-adjacent tests (`agent_input::raw_cli_zsh_shell_arg_intercepts_fragmented_natural_language`, `failed_command::raw_cli_zsh_generic_failure_restores_prompt_without_insight`): compile and run, but the local runtime has no `zsh`, so each exits through the existing availability guard ("zsh unavailable; mandatory coverage runs in the amd64 Anolis gate") — recorded as env-blocked, **not** counted as passed. The authoritative zsh execution evidence is the CI amd64 Anolis gate.
- macOS: not tested.

## Documentation and rollback

No documentation changes. Rollback: revert the single commit (pure test addition, no production coupling).
