### PR TITLE
fix(memory): report openclaw config validation errors before probing for the binary

### DIFF
--- a/src/agent-memory/Makefile
+++ b/src/agent-memory/Makefile
@@ -49,7 +49,7 @@ SPEC_FILE := $(NAME).spec
 
 .PHONY: all build build-openclaw-plugin sync-versions generate-component-contract test lint fmt clean install \
         install-adapter-resources uninstall dist spec rpm srpm \
-        smoke help
+        test-openclaw-plugin smoke help
 
 all: build
 
@@ -139,6 +139,16 @@ test-mcp: ## Run MCP integration tests only
 
 test-tools: ## Run Tier A file-tool integration tests only
 	cargo test --test file_tools_test
+
+# The openclaw adapter ships TS unit tests (tests/unit/*-test.ts) that `npm test`
+# runs through tsx. They are deliberately not a prerequisite of `test:` above —
+# that target is cargo-only and must stay runnable without a Node toolchain or
+# registry access. Use this target to exercise the adapter suite (see #3134 for
+# wiring it into the `Test agent-memory` CI job, which has no Node step today).
+test-openclaw-plugin: ## Run openclaw adapter TS unit tests (needs npm registry)
+	@echo "==> Running openclaw adapter unit tests..."
+	cd $(OPENCLAW_PLUGIN_SRC_DIR) && npm install --legacy-peer-deps --no-audit --no-fund
+	cd $(OPENCLAW_PLUGIN_SRC_DIR) && npm test
 
 # =============================================================================
 # REMOTE Linux build/test (for cross-platform development)

--- a/src/agent-memory/adapters/agent-memory/openclaw/src/config.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/src/config.ts
@@ -225,17 +225,36 @@ function resolveSessionDir(explicit?: string): string {
   return DEFAULT_SESSION_DIR;
 }
 
-/** Resolve the full plugin config with defaults. */
+/** Resolve the full plugin config with defaults.
+ *
+ *  Operator-supplied identifiers are resolved (and therefore validated)
+ *  before the environment is probed for the agent-memory binary. A
+ *  malformed `userId` / `sessionId` is a configuration error, and this
+ *  module's contract — see the header note about failures at plugin boot
+ *  being easier to diagnose than failures in the deep child — is that the
+ *  operator sees it as one. Resolving `binaryPath` first inverted that on
+ *  any host without the binary installed: the throw from
+ *  `resolveBinaryPath` ("agent-memory binary not found") masked the real
+ *  validation error, so `userId: "a/b"` reported a missing binary instead
+ *  of a path separator. Field order in the returned object is unchanged;
+ *  only evaluation order moves. */
 export function resolveConfig(api: OpenClawPluginApi): AgentMemoryConfig {
   const raw = (api.pluginConfig as Record<string, unknown>) ?? {};
 
+  const userId = resolveUserId(normalizeTrimmedString(raw.userId));
+  const sessionId = resolveSessionId(normalizeTrimmedString(raw.sessionId));
+  const sessionDir = resolveSessionDir(normalizeTrimmedString(raw.sessionDir));
+  const profile = normalizeProfile(raw.profile);
+  const maxReadBytes = normalizePositiveInt(raw.maxReadBytes, DEFAULT_MAX_READ_BYTES);
+  const maxWriteBytes = normalizePositiveInt(raw.maxWriteBytes, DEFAULT_MAX_WRITE_BYTES);
+
   return {
     binaryPath: resolveBinaryPath(normalizeTrimmedString(raw.binaryPath)),
-    userId: resolveUserId(normalizeTrimmedString(raw.userId)),
-    profile: normalizeProfile(raw.profile),
-    maxReadBytes: normalizePositiveInt(raw.maxReadBytes, DEFAULT_MAX_READ_BYTES),
-    maxWriteBytes: normalizePositiveInt(raw.maxWriteBytes, DEFAULT_MAX_WRITE_BYTES),
-    sessionId: resolveSessionId(normalizeTrimmedString(raw.sessionId)),
-    sessionDir: resolveSessionDir(normalizeTrimmedString(raw.sessionDir)),
+    userId,
+    profile,
+    maxReadBytes,
+    maxWriteBytes,
+    sessionId,
+    sessionDir,
   };
 }


### PR DESCRIPTION
## What

`resolveConfig()` in the OpenClaw adapter built its result object with `binaryPath` as the first property. Object-literal properties are evaluated in source order, so `resolveBinaryPath()` ran **before** `resolveUserId()` / `resolveSessionId()`.

On any host where the `agent-memory` binary is not on `PATH` (and not in `/usr/bin`, `/usr/local/bin`, `~/.local/bin`), the probe throws `agent-memory binary not found. Install it or set the binaryPath config option.` and identifier validation never runs.

This inverts the contract the module states in its own header comment — validation is deliberately kept in lock-step with the Rust `validate_user_id` *"so that a value accepted here is also accepted by the subprocess — failures in the deep child are harder to diagnose than failures at plugin boot"*. In practice an operator who typo'd `userId: "a/b"` was told to install the binary instead of being told their config contains a path separator.

The fix resolves the operator-supplied identifiers (and the other non-throwing normalizations) first and probes the environment last. The `AgentMemoryConfig` type and the returned object's field order are unchanged — only evaluation order moves, so there is no consumer-visible shape change.

Second, smaller change: `src/agent-memory/Makefile` gains a `test-openclaw-plugin` target so the adapter's TS unit tests have a runnable entry point (`test-mcp` / `test-tools` already follow this shape). It is intentionally **not** a prerequisite of `test:`, which stays cargo-only and runnable without a Node toolchain or registry access.

## Why now / how this was found

Nothing executes the adapter's TS tests today:

- `.github/workflows/ci.yaml` → `test-agent-memory` (lines 1027-1062) is `cargo fmt --all --check`, `cargo clippy`, `cargo test --locked`. There is no `actions/setup-node` and no Node step anywhere in that job.
- `src/agent-memory/Makefile` → `test:` is `cargo test --locked`; no target reached `npm test` (= `npx tsx --test tests/unit/*-test.ts`).
- `.github/workflows/openclaw-plugin-e2e.yml` is a different plugin: every `paths:` filter and `working-directory:` in it is `src/agent-sec-core/openclaw-plugin`, not `src/agent-memory/adapters/agent-memory/openclaw`.

So `tests/unit/*-test.ts` (4 files) and `tests/smoke-test.ts` are dead weight in CI. **5 of the 88 tests fail on a clean `main` checkout** (`c075ed84`) — all five are the `config-test.ts` cases that assert validation errors propagate:

```
not ok - propagates validateUserId rejection of '..'
not ok - propagates validateUserId rejection of '/'
not ok - propagates validateUserId rejection of '\\'
not ok - propagates validateUserId rejection of NUL
not ok - sessionId still validated by validateUserId rules
  error: 'agent-memory binary not found. Install it or set the binaryPath config option.'
  operator: 'throws'
```

The rest of that file is written defensively around the same hazard (`it("accepts a valid userId (may fail later on missing binary)")`, `catch → assert(err.message.includes("binary"))`), i.e. the binary probe firing early was known — but the five assertions above encode the intended precedence and have been red since they were written.

## Testing

Node v22.21.1, npm 10.9.4, clean worktree at `main` (`c075ed84`), no pre-existing `node_modules`:

| Step | Result |
|---|---|
| `make test-openclaw-plugin` **without** the `config.ts` change (Makefile target only) | `make` exit **2** — 88 tests, **83 pass / 5 fail** (the five above) |
| `make test-openclaw-plugin` **with** the change | `make` exit **0** — 88 tests, **88 pass / 0 fail**, ~330 ms |
| `npm run build:check` (`tsc --noEmit`) before vs. after | **Identical 4 pre-existing errors**, none added by this change |
| `make help` | new target renders in the help table |

The 4 pre-existing `tsc` errors are left alone deliberately to keep this diff to the defect — they are unrelated to evaluation order:

- `src/index.ts(515,13)` TS2322 — `memory_corpus_get` handler returns `{corpus, path, title, content}` but the SDK's `MemoryCorpusGetResult` also requires `fromLine` / `lineCount`.
- `tests/smoke-test.ts(51,37)`, `tests/unit/mcp-client-test.ts(98,39)`, `(103,39)` TS2345 — config fixtures missing `sessionId` / `sessionDir`.

They are reported here rather than fixed because `index.ts:515` needs a product decision (pass `fromLine`/`lineCount` through from the binary, or widen the handler), which is out of scope for an error-precedence fix. Happy to split them into a follow-up.

No Rust code is touched, so `cargo fmt` / `clippy` / `test` are unaffected.

## Related

- Related to #3134 — this PR supplies the Makefile entry point that issue asks to wire into CI, plus concrete evidence for why the missing Node step matters (5 red tests on `main`). **The `ci.yaml` half of #3134 is not included here**: the credential this agent runs under has scopes `gist, read:org, repo` and GitHub rejects workflow-file writes from an OAuth app without `workflow`, so the job edit has to come from a maintainer or a `workflow`-scoped token. Note that wiring it up as-is would need `actions/setup-node` + `npm ci` in the adapter dir, because the tests import `../../src/*.js` specifiers that resolve to `.ts` — plain `node --test` fails with `ERR_MODULE_NOT_FOUND` (verified), so `tsx` is not optional.
- Related to AGE-6745 (Multica) — this work was picked up by the Developer agent's todo scan, which found no claimable development issue this round.
