### PR TITLE
feat(cosh-ng): export LLM plaintext tap

### DIFF
--- a/src/cosh-ng/crates/cosh-core/build.rs
+++ b/src/cosh-ng/crates/cosh-core/build.rs
@@ -1,0 +1,23 @@
+//! Exports the observability tap symbol so it survives `strip`.
+//!
+//! `provider::observe::cosh_llm_plaintext_tap` is resolved by name from outside
+//! the process, but the release profile sets `strip = true`, which erases
+//! `.symtab` and would take the symbol with it. `--export-dynamic` promotes it to
+//! `.dynsym`, which strip leaves alone.
+//!
+//! This lives in a build script rather than `.cargo/config.toml` on purpose: a
+//! `RUSTFLAGS` environment variable overrides `target.*.rustflags` from config
+//! files entirely, and packaging environments commonly set one, which would drop
+//! the flag and silently stop capture. Link args emitted here are appended to the
+//! link command instead of competing with `RUSTFLAGS`, and they travel with the
+//! crate source into any release tarball.
+
+fn main() {
+    // GNU spelling, and therefore Linux-only: Apple's ld64 documents the
+    // single-dash `-export_dynamic` and rejects the double-dash form, which
+    // would fail every `cosh-core` link on the supported macOS target. Binaries
+    // only: the flag is meaningless for the library target.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux") {
+        println!("cargo::rustc-link-arg-bins=-Wl,--export-dynamic");
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/provider/mod.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/mod.rs
@@ -1,4 +1,5 @@
 pub mod mock;
+pub mod observe;
 pub mod openai_compat;
 pub mod profile;
 pub mod sysom;
@@ -299,6 +300,27 @@ pub type GenerateStream = Pin<Box<dyn Stream<Item = GenerateEvent> + Send>>;
 
 #[async_trait]
 pub trait ContentGenerator: Send + Sync {
+    /// Produce a stream of events for one LLM turn.
+    ///
+    /// # Observability contract
+    ///
+    /// An implementation that talks to a real network endpoint **must** report
+    /// its traffic through [`observe`], at three points:
+    ///
+    /// 1. [`observe::tap_request`] before sending the request body.
+    /// 2. [`observe::tap_response_head`] once the response status is known.
+    /// 3. [`observe::tap_response_chunk`] for every chunk received.
+    ///
+    /// This is not optional bookkeeping. cosh-ng terminates TLS in-process via
+    /// rustls, so an external observer can read nothing off the wire and these
+    /// calls are the only way LLM traffic becomes visible; a provider that skips
+    /// them silently contributes no token accounting, and nothing fails loudly to
+    /// say so. See `provider::observe` for why the taps exist and
+    /// `openai_compat`/`sysom` for the two existing call patterns.
+    ///
+    /// Implementations backed by fixtures rather than a network (such as
+    /// `MockProvider`) must **not** tap: doing so would report test data as real
+    /// traffic.
     async fn generate(
         &self,
         messages: &[Message],

--- a/src/cosh-ng/crates/cosh-core/src/provider/observe.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/observe.rs
@@ -1,0 +1,255 @@
+//! Stable attach point for out-of-process LLM observability.
+//!
+//! An eBPF observer cannot see cosh-ng's LLM traffic on the wire: rustls
+//! terminates TLS inside the process and exports no `SSL_read`/`SSL_write`, so
+//! there is nothing to hook at the library boundary. Locating rustls' own
+//! plaintext functions by byte pattern was tried and does not survive: the
+//! patterns encode rustc's register allocation, and the release RPM is built
+//! with whatever system Rust the build host happens to have (see
+//! `scripts/rpm-build.sh`, which deliberately drops `rust-toolchain.toml`), so a
+//! compiler bump silently breaks capture.
+//!
+//! This module replaces that guesswork with an explicit contract: one exported
+//! symbol whose name and signature are the whole interface. An observer attaches
+//! a uprobe by name and reads the buffer out of the argument registers.
+//!
+//! # Adding a provider
+//!
+//! The taps are wired per call site, because each provider builds and sends its
+//! own request — there is no shared HTTP chokepoint to hook once. A new provider
+//! that reaches a real endpoint therefore has to call all three:
+//! [`tap_request`], [`tap_response_head`], and [`tap_response_chunk`]. Omitting
+//! them is silent: the provider keeps working, no error is logged, and its LLM
+//! calls simply never appear in token accounting. `ContentGenerator::generate`
+//! states this as a requirement; `openai_compat` and `sysom` are the reference
+//! call patterns.
+//!
+//! Place the calls at the network boundary, not inside a reusable stream adapter
+//! — adapters are commonly driven by in-memory fixtures in tests, which would
+//! then be reported as real traffic.
+
+/// Direction marker for [`cosh_llm_plaintext_tap`]: an outbound request body.
+pub const TAP_DIR_REQUEST: u32 = 1;
+/// Direction marker for [`cosh_llm_plaintext_tap`]: an inbound response chunk.
+pub const TAP_DIR_RESPONSE: u32 = 0;
+
+/// Observability attach point; does nothing on its own.
+///
+/// The body is intentionally empty — the *symbol* is the contract, not the
+/// behaviour. Callers hand over a borrowed buffer that must stay valid for the
+/// duration of the call, which is trivially true for the synchronous call sites
+/// in the providers.
+///
+/// Three attributes are load-bearing and none may be dropped:
+///
+/// - `#[no_mangle]` keeps the name stable for a by-name uprobe.
+/// - `#[inline(never)]` keeps a real call site to attach to; `lto = true` would
+///   otherwise inline an empty function away entirely.
+/// - `black_box` keeps the arguments live, so the optimiser cannot decide the
+///   call computes nothing and delete it along with the argument setup.
+///
+/// The release profile additionally needs `-C link-args=-Wl,--export-dynamic`,
+/// emitted by `build.rs` (Linux targets only): `strip = true` erases `.symtab`,
+/// and only `.dynsym` survives it.
+///
+/// # Safety
+///
+/// `buf` must point to at least `len` readable bytes. Passing a dangling
+/// pointer is unsound even though this function never dereferences it, because
+/// an attached observer will.
+#[no_mangle]
+#[inline(never)]
+pub extern "C" fn cosh_llm_plaintext_tap(dir: u32, buf: *const u8, len: usize) {
+    std::hint::black_box((dir, buf, len));
+}
+
+/// Report an outbound request to any attached observer, framed as HTTP/1.1.
+///
+/// The framing is what makes the payload useful. An observer identifies the
+/// provider and the API being called from the request line and headers, so a
+/// bare JSON body is unrecognisable to it — it arrives as opaque bytes and no
+/// token usage is ever extracted. Synthesising the framing here rather than in
+/// the observer keeps the wire format knowledge (paths, content type) on the
+/// side that already owns it.
+///
+/// `url` is the absolute request URL; its path and authority are split out to
+/// build the request line and `Host` header.
+pub fn tap_request(method: &str, url: &str, body: &[u8]) {
+    let (authority, path) = split_url(url);
+    let head = format!(
+        "{method} {path} HTTP/1.1\r\n\
+         Host: {authority}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\r\n",
+        body.len()
+    );
+    // One allocation per LLM call, not per chunk: the observer needs the head and
+    // body contiguous, because it reads a single buffer per tap invocation.
+    let mut framed = Vec::with_capacity(head.len() + body.len());
+    framed.extend_from_slice(head.as_bytes());
+    framed.extend_from_slice(body);
+    cosh_llm_plaintext_tap(TAP_DIR_REQUEST, framed.as_ptr(), framed.len());
+}
+
+/// Report the start of a response, framed as an HTTP/1.1 status line.
+///
+/// Emitted once per call, before any chunk, so the observer sees a response
+/// begin on this connection and can pair it with the request. The chunks that
+/// follow are reported raw by [`tap_response_chunk`].
+pub fn tap_response_head(status: u16, content_type: &str) {
+    let head = format!(
+        "HTTP/1.1 {status} OK\r\n\
+         Content-Type: {content_type}\r\n\r\n"
+    );
+    cosh_llm_plaintext_tap(TAP_DIR_RESPONSE, head.as_ptr(), head.len());
+}
+
+/// Report one inbound response chunk to any attached observer.
+///
+/// Chunks are passed through untouched: they are already the SSE body an
+/// observer expects to follow the status line.
+pub fn tap_response_chunk(chunk: &[u8]) {
+    cosh_llm_plaintext_tap(TAP_DIR_RESPONSE, chunk.as_ptr(), chunk.len());
+}
+
+/// Split an absolute URL into `(authority, path_with_query)`.
+///
+/// Falls back to the whole input as the path when the URL has no scheme
+/// separator, which keeps the framing well-formed rather than silently empty.
+fn split_url(url: &str) -> (&str, &str) {
+    let after_scheme = url.split_once("://").map_or(url, |(_, rest)| rest);
+    match after_scheme.find('/') {
+        Some(i) => (&after_scheme[..i], &after_scheme[i..]),
+        None => (after_scheme, "/"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_url_separates_authority_from_path() {
+        assert_eq!(
+            split_url("https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"),
+            (
+                "dashscope.aliyuncs.com",
+                "/compatible-mode/v1/chat/completions"
+            )
+        );
+    }
+
+    #[test]
+    fn split_url_defaults_a_missing_path_to_root() {
+        assert_eq!(split_url("https://example.com"), ("example.com", "/"));
+    }
+
+    #[test]
+    fn split_url_tolerates_a_schemeless_input() {
+        // Rather than yield an empty path, which would produce a malformed
+        // request line that no observer could parse.
+        assert_eq!(split_url("/v1/chat"), ("", "/v1/chat"));
+    }
+}
+
+/// Guards the build configuration the tap depends on.
+///
+/// These assertions cannot run against the release binary from a unit test, so
+/// they pin the two things a reader might otherwise "clean up": the symbol name
+/// and the fact that a build script must export it. The end-to-end guarantee —
+/// that the symbol reaches `.dynsym` — is asserted by CI against the built
+/// binary, because only the linker can prove that.
+#[cfg(test)]
+mod build_contract {
+    /// The build script must emit the export flag; without it `strip = true`
+    /// removes the symbol and capture silently stops.
+    #[test]
+    fn build_script_exports_the_tap() {
+        let build_rs = include_str!("../../build.rs");
+        assert!(
+            build_rs.contains("rustc-link-arg-bins=-Wl,--export-dynamic"),
+            "build.rs must export binary symbols or the tap disappears after strip"
+        );
+    }
+
+    /// Deliberately not `.cargo/config.toml`: a `RUSTFLAGS` environment variable
+    /// overrides config-file rustflags outright, and packaging environments set
+    /// one, which silently dropped the flag when this was tried.
+    #[test]
+    fn export_flag_is_not_placed_where_rustflags_can_override_it() {
+        let cargo_config = include_str!("../../../../.cargo/config.toml");
+        assert!(
+            !cargo_config.contains("export-dynamic"),
+            "keep the export flag in build.rs; RUSTFLAGS overrides config.toml rustflags"
+        );
+    }
+
+    /// The GNU flag would fail every cosh-core link on macOS, whose ld64
+    /// documents the single-dash `-export_dynamic` instead, so the emission must
+    /// stay gated on the target OS.
+    #[test]
+    fn export_flag_is_gated_to_linux_targets() {
+        let build_rs = include_str!("../../build.rs");
+        assert!(
+            build_rs.contains("CARGO_CFG_TARGET_OS"),
+            "build.rs must gate --export-dynamic on the target OS: the GNU spelling \
+             is rejected by Apple's ld64 and would break the macOS build"
+        );
+    }
+
+    /// The response head must be announced before the success check. Reporting
+    /// only 2xx responses leaves the observer with a request that never
+    /// completes whenever the endpoint answers 401/429/5xx.
+    #[test]
+    fn response_head_is_tapped_before_the_success_check() {
+        for (provider, source) in [
+            ("openai_compat", include_str!("openai_compat.rs")),
+            ("sysom", include_str!("sysom.rs")),
+        ] {
+            let head = source
+                .find("tap_response_head(")
+                .unwrap_or_else(|| panic!("{provider} never taps the response head"));
+            let check = source
+                .find("is_success()")
+                .unwrap_or_else(|| panic!("{provider} has no status check"));
+            assert!(
+                head < check,
+                "{provider} taps the response head after the success check, so \
+                 error responses are never reported"
+            );
+        }
+    }
+
+    /// Every network-backed provider must tap, and forgetting is silent, so the
+    /// wiring is asserted here rather than left to review.
+    ///
+    /// Deliberately source-level: the taps are `extern "C"` no-ops with no
+    /// observable effect in-process, so there is nothing a runtime assertion
+    /// could check. Add new network providers to this list.
+    #[test]
+    fn every_network_provider_taps_all_three_points() {
+        for (provider, source) in [
+            ("openai_compat", include_str!("openai_compat.rs")),
+            ("sysom", include_str!("sysom.rs")),
+        ] {
+            for tap in ["tap_request(", "tap_response_head(", "tap_response_chunk("] {
+                assert!(
+                    source.contains(tap),
+                    "provider `{provider}` never calls `{tap}`; its LLM traffic \
+                     would be invisible to observers (see provider::observe)"
+                );
+            }
+        }
+    }
+
+    /// The mock provider is fixture-driven; tapping it would publish test data as
+    /// if it were real traffic.
+    #[test]
+    fn the_mock_provider_does_not_tap() {
+        let source = include_str!("mock.rs");
+        assert!(
+            !source.contains("observe::tap"),
+            "MockProvider must not tap: its bytes never came from a network"
+        );
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/provider/openai_compat.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/openai_compat.rs
@@ -190,11 +190,32 @@ impl ContentGenerator for OpenAICompatProvider {
             request = request.header("X-DashScope-CacheControl", "enable");
         }
 
+        // Report the request before it is encrypted: rustls leaves nothing on the
+        // wire an out-of-process observer can read (see `provider::observe`).
+        // Serialising twice is acceptable here — this runs once per LLM call, not
+        // per chunk — and reusing reqwest's own body would mean building the
+        // request in two steps just to peek at it.
+        if let Ok(serialised) = serde_json::to_vec(&body) {
+            super::observe::tap_request("POST", &url, &serialised);
+        }
+
         let response = request
             .json(&body)
             .send()
             .await
             .map_err(|e| format!("HTTP request failed: {e}"))?;
+
+        // Announce the response before the status check: an error response
+        // (401/429/5xx) must still be reported, otherwise the observer is left
+        // with a pending request that never completes. The body below is
+        // reported through the same chunk tap as a success stream.
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("text/event-stream")
+            .to_string();
+        super::observe::tap_response_head(response.status().as_u16(), &content_type);
 
         if !response.status().is_success() {
             let status = response.status();
@@ -202,6 +223,7 @@ impl ContentGenerator for OpenAICompatProvider {
                 .text()
                 .await
                 .unwrap_or_else(|_| "unknown".to_string());
+            super::observe::tap_response_chunk(text.as_bytes());
             return Err(format!("API error {status}: {text}"));
         }
 
@@ -403,6 +425,8 @@ impl ContentGenerator for OpenAICompatProvider {
 
                     match stream.next().await {
                         Some(Ok(bytes)) => {
+                            // Report the decrypted chunk before it is consumed.
+                            super::observe::tap_response_chunk(&bytes);
                             buf.extend(&bytes);
                             // A line is only extracted once its terminator
                             // arrives, so an endless line must be bounded

--- a/src/cosh-ng/crates/cosh-core/src/provider/sysom.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/sysom.rs
@@ -314,11 +314,20 @@ impl SysomProvider {
                 .header("x-acs-security-token", token);
         }
 
+        // Report the request before it is encrypted; see `provider::observe` for
+        // why an out-of-process observer cannot read it off the wire.
+        super::observe::tap_request("POST", &url, body_bytes);
+
         let response = req
             .body(body_bytes.to_vec())
             .send()
             .await
             .map_err(|e| format!("HTTP request failed: {e}"))?;
+
+        // Announce the response before the status check, mirroring
+        // `openai_compat`: an error response must still be reported or the
+        // observer is left with a pending request that never completes.
+        super::observe::tap_response_head(response.status().as_u16(), "text/event-stream");
 
         if !response.status().is_success() {
             let status = response.status();
@@ -326,15 +335,25 @@ impl SysomProvider {
                 .text()
                 .await
                 .unwrap_or_else(|_| "unknown".to_string());
+            super::observe::tap_response_chunk(text.as_bytes());
             return Err(format!("SysOM API error {status}: {text}"));
         }
 
         let cancelled = Arc::clone(&self.cancelled);
         // Normalizing to owned bytes keeps the SSE state machine testable with a
         // plain in-memory stream instead of a live HTTP response.
-        let byte_stream = response
-            .bytes_stream()
-            .map(|chunk| chunk.map(|bytes| bytes.to_vec()).map_err(|e| e.to_string()));
+        //
+        // The tap sits here rather than inside `sysom_event_stream` because that
+        // function is also driven by in-memory streams in its tests, which would
+        // report fixture bytes as if they came off the network.
+        let byte_stream = response.bytes_stream().map(|chunk| {
+            chunk
+                .map(|bytes| {
+                    super::observe::tap_response_chunk(&bytes);
+                    bytes.to_vec()
+                })
+                .map_err(|e| e.to_string())
+        });
 
         Ok(sysom_event_stream(Box::pin(byte_stream), cancelled))
     }


### PR DESCRIPTION
## Description

cosh-core links rustls, which terminates TLS in-process and exports no `SSL_read`/`SSL_write`. An out-of-process eBPF observer (agentsight) therefore sees nothing on the wire and cannot record cosh-ng's LLM token usage (#3042). A first fix located rustls' internal plaintext functions by hard-coded byte pattern (#3092); it broke in production (#3115) because the release RPM builds with whatever system Rust the host provides, and the patterns encode rustc's register allocation — a compiler bump silently reduced capture to zero.

This PR replaces that guesswork with an explicit contract: cosh-core exports one stable symbol, `cosh_llm_plaintext_tap`, and each network-backed provider frames its request and response through it as HTTP/1.1. An observer attaches a uprobe by name; libbpf resolves the address at attach time, so the same name keeps working across toolchains even though the address moves. The agentsight side that consumes this symbol lands in a companion PR.

## Key implementation decisions

- **Exported symbol, not byte pattern.** Immune to rustc version drift — verified by building with rustc 1.89 and 1.96-nightly: the address changes (`0x50bb20` → `0x7060d0`) but the symbol name resolves in both.
- **`--export-dynamic` via `build.rs`, not `.cargo/config.toml`.** The release profile sets `strip = true`, which erases `.symtab`; only `.dynsym` survives, so the symbol must be promoted there. A `RUSTFLAGS` set in the packaging environment overrides config-file `rustflags` outright and would silently drop the flag — `build.rs` link args are appended instead and travel with the crate source into the release tarball.
- **Linux-only emission.** The GNU spelling `--export-dynamic` is rejected by Apple's ld64, so `build.rs` emits it only when `CARGO_CFG_TARGET_OS == "linux"`.
- **Framing done here, not in the observer.** The provider owns the wire-format knowledge (URL, content type). Emitting a synthetic HTTP/1.1 head keeps the observer generic — it recognises the traffic the same way it recognises any other agent's.
- **Per-provider wiring, guarded by tests.** Each provider builds its own request, so there is no single chokepoint to hook. `ContentGenerator::generate` documents the requirement, and unit tests assert every network provider (`openai_compat`, `sysom`) taps all three points while `MockProvider` does not — forgetting is otherwise silent.

## Risk and compatibility

- **Behaviourally inert.** The tap is an empty `extern "C"` function; when no observer is attached it is a no-op. No change to request/response handling, no new runtime dependency.
- **Binary size: +4,104 bytes (+0.028%) on cosh-core**, measured by same-tree A/B with the RPM build scope (`cargo build --workspace --release`); cosh-shell / cosh-cli / cosh-gateway are byte-identical. ~600 bytes of that are the export table, the rest is the tap and HTTP framing code.
- **Overhead** is one `format!` + one `Vec` allocation per LLM call (not per chunk) on the request path; response chunks are passed by reference.
- **Error responses are reported.** The response head is announced before the status check and the error body is tapped as a chunk, so a 401/429/5xx reaches the observer as a complete HTTP response rather than a dangling request.
- No public API change. `cosh_llm_plaintext_tap` is an internal ABI contract with agentsight, not a user-facing interface.

## Validation

- `cargo fmt --all --check`, `cargo clippy -p cosh-core --all-targets -- -D warnings`: clean.
- `cargo test -p cosh-core --lib`: 132 passed / 0 failed; `provider::observe`: 9 passed (includes guard tests for the build wiring, the macOS gate, and the tap ordering).
- Symbol presence confirmed in the stripped release binary via `nm -D` (survives strip; survives a second manual `strip`).
- End-to-end on a live host (ALinux4, kernel 6.6, rustls 0.23.40): agentsight attaches the uprobe by name, and real DashScope conversations produce `token_records`/`genai_events` rows with correct model, tokens, prompt, and response.

## Related Issue

Relates to #3042 and #3115. Companion agentsight PR switches capture to this symbol.

## Notes for reviewer

- `sysom.rs` is wired identically to `openai_compat.rs` but was not exercised end-to-end (the test host uses the DashScope compatible-mode path); the guard test covers the wiring.
- The `Rustls` naming on the agentsight side now means "binary carrying an explicit tap" rather than anything rustls-specific; that rename lands with the companion PR.
- macOS: repo CI has no Darwin job, so the ld64 incompatibility is covered by the target-OS gate and its guard test rather than a real Darwin link.
