### PR TITLE
fix(anolisa): preflight RPM install conflicts

### DIFF
--- a/docs/user-guide/en/user-entrypoint/anolisa-cli.md
+++ b/docs/user-guide/en/user-entrypoint/anolisa-cli.md
@@ -60,6 +60,20 @@ An installation in the other scope does not make the selected scope
 "already installed." Reinstalling or changing an existing record is handled
 by lifecycle planning rather than silently overwriting it.
 
+RPM installs, including `--dry-run` and merged `--all` plans, ask DNF to
+resolve dependencies and package conflicts before creating recovery journals.
+The check uses the same repositories and version pins as the install. It may
+refresh repository metadata but does not download packages or change rpmdb.
+DNF 4 requires root for this check:
+
+```bash
+sudo anolisa --install-mode system --dry-run install cosh --backend rpm
+```
+
+A conflict fails the command without leaving a pending operation. Resolve the
+reported conflict before retrying. A successful check does not guarantee that
+a later download, scriptlet, or transaction will succeed.
+
 ### uninstall
 
 Remove one installation from the selected scope:
@@ -104,6 +118,13 @@ anolisa status <component>
 In a user view with records in both scopes, the user record is active and the
 system record remains visible as shadowed state. A system-mode view reads only
 the system root; it does not enumerate other users' state.
+
+Untracked RPM observations use the same package resolver as installation.
+An index mapping takes precedence over historical package aliases and
+capabilities: an old cosh-ng RPM providing `anolisa-component(cosh)` is shown
+under cosh-ng, while cosh still resolves to copilot-shell. `action=install`
+identifies a lifecycle action; it is not a native dependency check. Use the
+RPM install dry-run to check whether the packages can coexist.
 
 ### doctor
 
@@ -165,6 +186,11 @@ native removal authority. `repair` reconciles a scoped record with rpmdb or an
 interrupted journal. `forget` removes only the record in the selected scope and
 never performs package or owned-file removal; a user-scoped forget cannot
 delete a visible system record.
+
+If an operation is pending, `forget` directs you to `repair`, even when an
+install failed before creating an installation record. Repair reconciles the
+journal with rpmdb; forgetting must not discard evidence of a transaction
+that may already have changed the system.
 
 ### adapter
 

--- a/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
+++ b/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
@@ -55,6 +55,17 @@ anolisa install --all
 另一个 scope 中已有安装，不会让当前 scope 变成“already installed”。已有
 记录的重装或变更由 lifecycle planner 处理，不会被静默覆盖。
 
+RPM 安装（包括 `--dry-run` 和合并的 `--all` 计划）会在创建 recovery
+journal 前，让 DNF 求解依赖和包冲突。预检使用与安装相同的仓库和版本约束，
+可能刷新仓库 metadata，但不会下载包或修改 rpmdb。DNF 4 的预检也要求 root：
+
+```bash
+sudo anolisa --install-mode system --dry-run install cosh --backend rpm
+```
+
+存在冲突时命令失败，不留下 pending operation；解决报告的冲突后再重试。
+预检成功不保证后续下载、scriptlet 或 transaction 一定成功。
+
 ### uninstall
 
 从所选 scope 移除一个安装：
@@ -97,6 +108,11 @@ anolisa status <component>
 user view 中两个 scope 都有同名组件时，user record 为 active，system record
 仍作为 shadowed state 可见。system-mode view 只读取 system root，不枚举其他
 用户的 state。
+
+未跟踪的 RPM 观察使用与安装相同的包解析器。index 映射优先于历史包 alias
+和 capability：提供 `anolisa-component(cosh)` 的旧 cosh-ng RPM 显示在
+cosh-ng 下，cosh 仍解析到 copilot-shell。`action=install` 表示生命周期操作，
+并不代表已检查 native 依赖；请通过 RPM install dry-run 检查这些包能否共存。
 
 ### doctor
 
@@ -155,6 +171,10 @@ sudo anolisa --install-mode system forget <component>
 authority。`repair` 协调指定 scope 的 record 与 rpmdb 或中断 journal。
 `forget` 只删除所选 scope 的记录，绝不执行 package 或 owned-file 删除；
 user scope 的 forget 不能删除只是在视图中可见的 system 记录。
+
+有 pending operation 时，即使安装尚未创建安装记录就失败，`forget` 也会
+引导先运行 `repair`。repair 会将 journal 与 rpmdb 协调；forget 不能丢弃
+可能已经改变系统的 transaction 证据。
 
 ### adapter
 

--- a/src/anolisa/README.md
+++ b/src/anolisa/README.md
@@ -84,6 +84,9 @@ installation even when the same component is already installed system-wide.
 See the [full CLI guide](../../docs/user-guide/en/user-entrypoint/anolisa-cli.md)
 for command forms, scope behavior, and recovery workflows.
 
+RPM install plans run DNF conflict checks before creating a recovery journal.
+DNF 4 requires root even for this check; use `sudo` with RPM `--dry-run`.
+
 ## Architecture
 
 Five-crate Cargo workspace:

--- a/src/anolisa/README_zh.md
+++ b/src/anolisa/README_zh.md
@@ -83,6 +83,9 @@ scope。因此，即使 system scope 已安装同名组件，
 完整的命令形式、scope 行为与恢复流程见
 [CLI 用户指南](../../docs/user-guide/zh/user-entrypoint/anolisa-cli.md)。
 
+RPM 安装计划会先通过 DNF 检查冲突，再创建 recovery journal。
+DNF 4 的预检也要求 root，因此 RPM `--dry-run` 需要使用 `sudo`。
+
 ## 架构
 
 五 crate Cargo workspace：

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt/application.rs
@@ -97,6 +97,10 @@ impl NoNativeTransaction {
 }
 
 impl PackageTransaction for NoNativeTransaction {
+    fn check_install(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
+        Err(Self::refused("install preflight", packages))
+    }
+
     fn install(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
         Err(Self::refused("install", packages))
     }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -899,6 +899,37 @@ mod tests {
         );
     }
 
+    #[test]
+    fn journal_without_installation_reports_repair_before_nothing_to_forget() {
+        for dry_run in [false, true] {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            let c = ctx(tmp.path().to_path_buf(), InstallMode::System, dry_run);
+            seed(&c, Vec::new(), Vec::new());
+            let layout = common::resolve_layout(&c);
+            let journal = Transaction::begin_with_subject(
+                "install",
+                Some("cosh"),
+                layout.state_dir.join("installed.toml"),
+                &rpm_install::journal_dir(&layout),
+            )
+            .expect("pending journal");
+            let err = handle(
+                ForgetArgs {
+                    component: "cosh".to_string(),
+                },
+                &c,
+            )
+            .expect_err("forget must preserve pending evidence");
+            assert!(err.reason().contains("anolisa repair cosh"), "{err}");
+            assert!(!err.reason().contains("nothing to forget"));
+            assert!(
+                Transaction::load_journal(&journal.journal_path)
+                    .unwrap()
+                    .is_pending()
+            );
+        }
+    }
+
     /// Dry-run leaves the state record in place.
     #[test]
     fn forget_dry_run_leaves_state_untouched() {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget/application.rs
@@ -62,6 +62,13 @@ pub(super) fn run(
     let store = view.writable.state;
     let target = resolved.as_str();
 
+    let journal_dir = rpm_install::journal_dir(&layout);
+    ensure_no_pending_journal(
+        JournalEvidence::new(&journal_dir, &store.operations),
+        target,
+        &command,
+    )?;
+
     // Forget also resolves quarantined records: it is the documented exit for
     // legacy state the migration refused to classify and repair cannot recover.
     let provenance = record_provenance(&store, target).ok_or_else(|| CliError::NotInstalled {
@@ -70,12 +77,6 @@ pub(super) fn run(
             "component '{target}' is not installed — nothing to forget (run `anolisa status` to see what is tracked)"
         ),
     })?;
-    let journal_dir = rpm_install::journal_dir(&layout);
-    ensure_no_pending_journal(
-        JournalEvidence::new(&journal_dir, &store.operations),
-        target,
-        &command,
-    )?;
 
     // A successful preview must prove the same adapter precondition that apply
     // re-checks under the lock; otherwise it would advertise work that cannot run.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
@@ -451,17 +451,17 @@ fn execute_merged_group_with_deps(
                 return all_failed(&group, &format!("failed to load installed state: {err}"));
             }
         };
+    let provider = DelegatedProvider::new(query, txn);
     let evidence = JournalEvidence::new(&journal_dir, &store.operations);
     let mut journal_gate = match LockedJournalGate::load(&_lock, evidence, BATCH_COMMAND) {
         Ok(gate) => gate,
         Err(err) => return all_failed(&group, &err.reason()),
     };
-    let provider = DelegatedProvider::new(query, txn);
 
-    // Re-validate each slot under the lock and open its journal, mirroring
-    // the single-component race check.
+    // Settle membership before solving: a stale slot must not prevent the
+    // remaining packages from installing or create a recovery journal.
     let mut items: Vec<BatchMemberOutcome> = Vec::with_capacity(group.len());
-    let mut active: Vec<(MergedItem, Transaction)> = Vec::with_capacity(group.len());
+    let mut eligible: Vec<MergedItem> = Vec::with_capacity(group.len());
     for item in group {
         let target = &item.planned.component;
         if store.find(ObjectKind::Component, target).is_some() || quarantined(&store, target) {
@@ -484,6 +484,23 @@ fn execute_merged_group_with_deps(
             items.push(failed_item(&item.name, err.reason().to_string()));
             continue;
         }
+        match journal_gate.ensure_clear(target, BATCH_COMMAND) {
+            Ok(()) => eligible.push(item),
+            Err(err) => items.push(failed_item(&item.name, err.reason().to_string())),
+        }
+    }
+    if eligible.is_empty() {
+        return BatchEffectOutcome { items };
+    }
+    let packages: Vec<&str> = eligible.iter().map(|item| item.package.as_str()).collect();
+    if let Err(err) = super::check_rpm_install(&provider, &packages, BATCH_COMMAND) {
+        items.extend(all_failed(&eligible, &err.reason()).items);
+        return BatchEffectOutcome { items };
+    }
+
+    let mut active: Vec<(MergedItem, Transaction)> = Vec::with_capacity(eligible.len());
+    for item in eligible {
+        let target = &item.planned.component;
         match journal_gate.begin(COMMAND, target, state_path.clone(), BATCH_COMMAND) {
             Ok(journal) => active.push((item, journal)),
             Err(err) => items.push(failed_item(&item.name, err.reason().to_string())),
@@ -837,6 +854,8 @@ mod tests {
     struct BatchTxn {
         calls: RefCell<Vec<(String, Vec<String>)>>,
         fail_install: bool,
+        fail_preflight: bool,
+        preflight_calls: RefCell<Vec<Vec<String>>>,
         attempted: Rc<Cell<bool>>,
     }
 
@@ -845,6 +864,8 @@ mod tests {
             Self {
                 calls: RefCell::new(Vec::new()),
                 fail_install,
+                fail_preflight: false,
+                preflight_calls: RefCell::new(Vec::new()),
                 attempted: Rc::new(Cell::new(false)),
             }
         }
@@ -883,6 +904,24 @@ mod tests {
     }
 
     impl PackageTransaction for BatchTxn {
+        fn check_install(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
+            self.preflight_calls.borrow_mut().push(
+                packages
+                    .iter()
+                    .map(|package| (*package).to_string())
+                    .collect(),
+            );
+            if self.fail_preflight && packages.contains(&"pkg-a") {
+                return Err(PackageTransactionError::TransactionFailed {
+                    command: "dnf".to_string(),
+                    operation: "install preflight".to_string(),
+                    code: Some(1),
+                    stderr: "pkg-a conflicts with pkg-b".to_string(),
+                });
+            }
+            Ok(())
+        }
+
         fn install(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
             self.attempted.set(true);
             self.calls.borrow_mut().push((
@@ -1053,6 +1092,33 @@ mod tests {
         let mut noop = i2_planned("a", "pkg-a");
         noop.route = PlannedRoute::AlreadyInstalled { version: None };
         assert!(merged_package(&noop).is_none());
+    }
+
+    #[test]
+    fn merged_solver_conflict_leaves_no_pending_members() {
+        let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+        let mut txn = BatchTxn::new(false);
+        txn.fail_preflight = true;
+        let effect = execute_merged_group_with_deps(
+            vec![i2_item("a", "pkg-a"), i2_item("b", "pkg-b")],
+            &batch_args(),
+            &ctx,
+            &FakeQuery::default(),
+            &txn,
+            true,
+            &mut |_| panic!("a solver refusal must not retry through apply"),
+            &mut |_| {},
+        );
+        assert_eq!(effect.items.len(), 2);
+        for item in effect.items {
+            assert_eq!(item.status, BatchMemberStatus::Failed);
+            assert!(item.reason.unwrap().contains("pkg-a conflicts with pkg-b"));
+        }
+        assert!(txn.calls.borrow().is_empty());
+        let layout = common::resolve_layout(&ctx);
+        let journals = rpm_install::journal_dir(&layout);
+        assert!(!journals.exists());
+        assert!(load_store(&ctx).find(ObjectKind::Component, "a").is_none());
     }
 
     #[test]
@@ -1416,7 +1482,8 @@ mod tests {
         // A second merged run over the same members must notice the records
         // that appeared since its (stale) planning and refuse each slot —
         // without running dnf again.
-        let txn = BatchTxn::new(false);
+        let mut txn = BatchTxn::new(false);
+        txn.fail_preflight = true;
         let effect = execute_merged_group_with_deps(
             vec![i2_item("a", "pkg-a"), i2_item("b", "pkg-b")],
             &batch_args(),
@@ -1429,6 +1496,7 @@ mod tests {
         );
         let items = effect.items;
         assert!(txn.calls.borrow().is_empty(), "dnf must not run twice");
+        assert!(txn.preflight_calls.borrow().is_empty());
         for component in ["a", "b"] {
             let item = item_status(&items, component);
             assert_eq!(item.status, BatchMemberStatus::Failed);
@@ -1437,6 +1505,84 @@ mod tests {
                     .as_deref()
                     .unwrap()
                     .contains("appeared while this install was resolving")
+            );
+        }
+    }
+
+    #[test]
+    fn merged_preflight_excludes_members_with_new_records_or_pending_journals() {
+        for pending in [false, true] {
+            let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+            let layout = common::resolve_layout(&ctx);
+            let state_path = layout.state_dir.join("installed.toml");
+            let journal_dir = rpm_install::journal_dir(&layout);
+            if pending {
+                Transaction::begin_with_subject(COMMAND, Some("a"), state_path, &journal_dir)
+                    .expect("inject a pending operation after planning");
+            } else {
+                let txn = BatchTxn::new(false);
+                let query = txn.query_after_attempt(vec![(
+                    "pkg-a".to_string(),
+                    pkg_info("pkg-a", "1.0.0", Some("1.al4"), "x86_64"),
+                )]);
+                let installed = execute_merged_group_with_deps(
+                    vec![i2_item("a", "pkg-a")],
+                    &batch_args(),
+                    &ctx,
+                    &query,
+                    &txn,
+                    true,
+                    &mut |_| panic!("initial install must succeed"),
+                    &mut |_| {},
+                );
+                assert_eq!(installed.items[0].status, BatchMemberStatus::Installed);
+            }
+            let mut txn = BatchTxn::new(false);
+            txn.fail_preflight = true;
+            let query = txn.query_after_attempt(vec![(
+                "pkg-b".to_string(),
+                pkg_info("pkg-b", "2.0.0", Some("1.al4"), "x86_64"),
+            )]);
+            let outcome = execute_merged_group_with_deps(
+                vec![i2_item("a", "pkg-a"), i2_item("b", "pkg-b")],
+                &batch_args(),
+                &ctx,
+                &query,
+                &txn,
+                true,
+                &mut |_| panic!("eligible member must not degrade"),
+                &mut |_| {},
+            );
+            let rejected = item_status(&outcome.items, "a");
+            assert_eq!(rejected.status, BatchMemberStatus::Failed);
+            assert!(rejected.reason.as_deref().unwrap().contains(if pending {
+                "anolisa repair a"
+            } else {
+                "appeared while this install was resolving"
+            }));
+            assert_eq!(
+                item_status(&outcome.items, "b").status,
+                BatchMemberStatus::Installed
+            );
+            assert_eq!(
+                *txn.preflight_calls.borrow(),
+                vec![vec!["pkg-b".to_string()]]
+            );
+            assert_eq!(
+                *txn.calls.borrow(),
+                vec![("install".to_string(), vec!["pkg-b".to_string()])]
+            );
+            assert!(load_store(&ctx).find(ObjectKind::Component, "b").is_some());
+            assert_eq!(
+                pending_journal_for(JournalEvidence::new(&journal_dir, &[]), "a")
+                    .expect("inspect a's journal")
+                    .is_some(),
+                pending
+            );
+            assert!(
+                pending_journal_for(JournalEvidence::new(&journal_dir, &[]), "b")
+                    .expect("inspect b's journal")
+                    .is_none()
             );
         }
     }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch/application.rs
@@ -212,7 +212,24 @@ pub(super) fn run(
             members: members.clone(),
         });
         if preview {
+            let per_args = per_component_args(&merged[0].name, request.args);
+            let packages: Vec<&str> = merged.iter().map(|item| item.package.as_str()).collect();
+            let preflight = host_backends(&merged[0].name, &per_args, &suppressed_ctx).and_then(
+                |(query, txn)| {
+                    super::super::check_rpm_install(
+                        &anolisa_core::providers::DelegatedProvider::new(&query, &txn),
+                        &packages,
+                        "install --all",
+                    )
+                },
+            );
             for item in &merged {
+                if let Err(err) = &preflight {
+                    results.insert(item.name.clone(), failed_item(&item.name, err.reason()));
+                    fail_fast_tripped = request.args.fail_fast;
+                    continue;
+                }
+
                 let steps = item.planned.route.steps().to_vec();
                 output(BatchOutputEvent::PreviewPlan {
                     component: item.name.clone(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -64,7 +64,8 @@ use super::owned_ops::{
 use super::raw::{load_dry_run_install_contract, resolve_raw};
 use super::render::repo_config_err;
 use super::rpm::{
-    PinError, RpmTarget, resolve_pinned_candidate, rpm_package_candidates_with_index,
+    PinError, RpmTarget, check_rpm_install, resolve_pinned_candidate,
+    rpm_package_candidates_with_index,
 };
 use super::types::{RawRepositoryOrigin, RawResolution, ResolveInputs};
 use super::{ANOLISA_RPM_REPO_ID, COMMAND, InstallArgs};
@@ -603,6 +604,18 @@ pub(crate) fn plan_component(
             PlannedRoute::AlreadyInstalled { version }
         }
     };
+
+    if let ProviderTarget::Delegated {
+        package, artifact, ..
+    } = &request.target
+        && matches!(route, PlannedRoute::Delegated { .. })
+    {
+        check_rpm_install(
+            &provider,
+            &[artifact.as_deref().unwrap_or(package)],
+            &command,
+        )?;
+    }
 
     Ok(PlannedComponent {
         command,
@@ -1299,6 +1312,13 @@ fn install_applied(
         degraded_rpmdb,
         command,
     )?;
+
+    if let ProviderTarget::Delegated {
+        package, artifact, ..
+    } = &request.target
+    {
+        check_rpm_install(provider, &[artifact.as_deref().unwrap_or(package)], command)?;
+    }
 
     let evidence = JournalEvidence::new(journal_dir, &store.operations);
     let mut journal_gate = LockedJournalGate::load(&lock, evidence, command)?;

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/rpm.rs
@@ -153,3 +153,18 @@ pub(crate) fn rpm_package_candidates_with_index(
         }
     })
 }
+
+/// Reject native solver failures before creating recovery evidence.
+pub(crate) fn check_rpm_install(
+    provider: &anolisa_core::providers::DelegatedProvider<'_>,
+    packages: &[&str],
+    command: &str,
+) -> Result<(), crate::response::CliError> {
+    provider.check_install(packages).map_err(|err| crate::response::CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "RPM install preflight for '{}' failed: {err}; no packages were changed and no recovery journal was created — resolve the reported package-manager error before retrying",
+            packages.join(", ")
+        ),
+    })
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
@@ -694,6 +694,10 @@ sha256 = "{sha}"
 pub struct NoTxn;
 
 impl PackageTransaction for NoTxn {
+    fn check_install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
+        Ok(())
+    }
+
     fn install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
         panic!("adopt-path test reached a delegated dnf install");
     }
@@ -760,6 +764,8 @@ pub struct FakeInstaller {
     pub available: Vec<PackageInfo>,
     /// `false` makes the dnf install transaction fail.
     pub install_succeeds: bool,
+    pub preflight_failure_on_call: Option<usize>,
+    pub preflight_calls: Cell<usize>,
     pub installed: RefCell<Option<PackageInfo>>,
     pub install_calls: Cell<usize>,
     /// Package spec(s) each `install` call received, joined per call, so tests
@@ -795,6 +801,8 @@ impl FakeInstaller {
             origin: None,
             available: Vec::new(),
             install_succeeds: true,
+            preflight_failure_on_call: None,
+            preflight_calls: Cell::new(0),
             installed: RefCell::new(None),
             install_calls: Cell::new(0),
             install_specs: RefCell::new(Vec::new()),
@@ -988,6 +996,23 @@ impl PackageQuery for FakeInstaller {
 }
 
 impl PackageTransaction for FakeInstaller {
+    fn check_install(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
+        self.preflight_calls.set(self.preflight_calls.get() + 1);
+        assert_eq!(
+            packages,
+            &[self.expected_install.as_deref().unwrap_or(&self.package)]
+        );
+        if self.preflight_failure_on_call == Some(self.preflight_calls.get()) {
+            return Err(PackageTransactionError::TransactionFailed {
+                command: "dnf".to_string(),
+                operation: "install preflight".to_string(),
+                code: Some(1),
+                stderr: "installed cosh-ng conflicts with copilot-shell".to_string(),
+            });
+        }
+        Ok(())
+    }
+
     fn install(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
         self.install_calls.set(self.install_calls.get() + 1);
         self.install_specs.borrow_mut().push(packages.join(","));

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
@@ -1522,6 +1522,7 @@ fn pinned_delegated_dry_run_shows_resolved_candidate_without_txn_or_state() {
         "copilot-shell",
         pkg_info("copilot-shell", "0.6.2", Some("1.al8"), &arch),
     )
+    .expecting_install(&format!("copilot-shell-0.6.2-1.al8.{arch}"))
     .with_available(vec![
         available_candidate(
             "copilot-shell",
@@ -1714,4 +1715,41 @@ fn pinned_install_refuses_state_when_dnf_installs_a_different_evr() {
             .is_none(),
         "the wrong version must not be recorded"
     );
+}
+
+#[test]
+fn rpm_solver_conflict_leaves_no_journal_or_install_record() {
+    for (dry_run, failed_call) in [(true, 1), (false, 1), (false, 2)] {
+        let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(dry_run);
+        let layout = common::resolve_layout(&ctx);
+        let mut fake = FakeInstaller::new(
+            "copilot-shell",
+            pkg_info("copilot-shell", "2.8.0", Some("1.alnx4"), "x86_64"),
+        );
+        fake.preflight_failure_on_call = Some(failed_call);
+        let mut a = args("copilot-shell");
+        a.backend = Some("rpm".to_string());
+        let err = install_component_with_deps("copilot-shell", &a, &ctx, &fake, &fake, true)
+            .expect_err("solver must refuse the conflicting package before execution");
+        assert!(
+            err.reason()
+                .contains("cosh-ng conflicts with copilot-shell")
+        );
+        assert!(err.reason().contains("no recovery journal was created"));
+        assert_eq!(fake.install_calls.get(), 0);
+        assert_eq!(fake.preflight_calls.get(), failed_call);
+        assert!(
+            load_store(&ctx)
+                .find(ObjectKind::Component, "copilot-shell")
+                .is_none()
+        );
+        let journal_dir = rpm_install::journal_dir(&layout);
+        assert!(!journal_dir.exists() || std::fs::read_dir(journal_dir).unwrap().next().is_none());
+        // Retrying can reach the solver again instead of entering pending recovery.
+        fake.preflight_failure_on_call = Some(failed_call + 1);
+        let retry = install_component_with_deps("copilot-shell", &a, &ctx, &fake, &fake, true)
+            .expect_err("retry should report the conflict again");
+        assert!(!retry.reason().contains("pending recovery"));
+        assert!(retry.reason().contains("cosh-ng conflicts"));
+    }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
@@ -146,7 +146,7 @@ fn build_rows_for_target(
         .components
         .iter()
         .filter_map(|entry| {
-            let projection = project_component(entry, state, rpm_query);
+            let projection = project_component(entry, index, state, rpm_query);
             if args.installed && !projection.local_state.matches_installed_filter() {
                 return None;
             }
@@ -188,7 +188,8 @@ fn build_rows_from_view(
                 return matching_records
                     .into_iter()
                     .filter_map(|record| {
-                        let projection = project_component(entry, &record.root.state, rpm_query);
+                        let projection =
+                            project_component(entry, index, &record.root.state, rpm_query);
                         if args.installed && !projection.local_state.matches_installed_filter() {
                             return None;
                         }
@@ -207,7 +208,7 @@ fn build_rows_from_view(
                     .collect::<Vec<_>>();
             }
 
-            let projection = project_component(entry, &view.writable.state, rpm_query);
+            let projection = project_component(entry, index, &view.writable.state, rpm_query);
             if args.installed && !projection.local_state.matches_installed_filter() {
                 return Vec::new();
             }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/state_view.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/state_view.rs
@@ -4,7 +4,10 @@ use anolisa_core::state_store::StateStore;
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
 
 use crate::commands::common;
-use crate::resolution::ComponentIndexEntry;
+use crate::resolution::{
+    BackendKind, ComponentIndex, ComponentIndexEntry, ComponentResolver, ResolutionSet,
+    ResolveOptions,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum LocalState {
@@ -97,20 +100,22 @@ impl LocalProjection {
 
 pub(super) fn project_component(
     entry: &ComponentIndexEntry,
+    index: &ComponentIndex,
     state: &StateStore,
     rpm_query: Option<&dyn PackageQuery>,
 ) -> LocalProjection {
     match state.find(ObjectKind::Component, &entry.name) {
         Some(installation) => project_tracked_object(installation, rpm_query),
-        None => project_untracked_entry(entry, rpm_query),
+        None => project_untracked_entry(entry, index, rpm_query),
     }
 }
 
 fn project_untracked_entry(
     entry: &ComponentIndexEntry,
+    index: &ComponentIndex,
     rpm_query: Option<&dyn PackageQuery>,
 ) -> LocalProjection {
-    match observed_rpm_info(entry, rpm_query) {
+    match observed_rpm_info(entry, index, rpm_query) {
         Some(info) => projection_from_observed_rpm(info),
         None => LocalProjection {
             backend: None,
@@ -227,37 +232,25 @@ fn rpm_drift_state(
 
 fn observed_rpm_info(
     entry: &ComponentIndexEntry,
+    index: &ComponentIndex,
     rpm_query: Option<&dyn PackageQuery>,
 ) -> Option<PackageInfo> {
     let query = rpm_query?;
-
-    // 1. Probe RPM backend package names.
-    for backend in entry.backends.iter().filter(|b| b.kind == "rpm") {
-        if let Some(info) = safe_query_installed(query, &backend.package) {
-            return Some(info);
-        }
+    // Without an RPM mapping, the resolver would query available providers;
+    // list only observes installed packages from the published RPM backends.
+    if !entry.backends.iter().any(|backend| backend.kind == "rpm") {
+        return None;
     }
-
-    // 2. Probe RPM package aliases (alternate historical names).
-    for alias in entry.aliases.iter().filter(|a| a.kind == "rpm-package") {
-        if let Some(info) = safe_query_installed(query, &alias.name) {
-            return Some(info);
-        }
-    }
-
-    // 3. Fallback: use `what_provides` for backends that declare a Provides
-    //    capability. This catches legacy RPMs whose package name differs from
-    //    the index entry but still declares `anolisa-component(<name>)`.
-    for backend in entry.backends.iter().filter(|b| b.kind == "rpm") {
-        let Some(capability) = backend.provides.as_deref().filter(|p| !p.is_empty()) else {
-            continue;
-        };
-        if let Some(info) = safe_what_provides(query, capability) {
-            return Some(info);
-        }
-    }
-
-    None
+    // Observation must use the same package authority as install. Aliases
+    // identify components; a stale capability cannot override the index.
+    let resolver = ComponentResolver::new(Some(index), None, Some(query));
+    let ResolutionSet::Unique(target) = resolver
+        .resolve(&entry.name, BackendKind::Rpm, ResolveOptions::default())
+        .ok()?
+    else {
+        return None;
+    };
+    safe_query_installed(query, &target.package)
 }
 
 /// Query an installed package, treating all errors as "not found" so the list
@@ -272,18 +265,6 @@ fn safe_query_installed(query: &dyn PackageQuery, package: &str) -> Option<Packa
         }
         Ok(None) => None,
         Err(_) => None,
-    }
-}
-
-/// Resolve a capability to a single installed package via `what_provides`,
-/// then fetch its full info. Returns `None` for zero or ambiguous (>1)
-/// providers so the list summary never picks an arbitrary package.
-fn safe_what_provides(query: &dyn PackageQuery, capability: &str) -> Option<PackageInfo> {
-    let names = query.what_provides_installed(capability).ok()?;
-    if names.len() == 1 {
-        safe_query_installed(query, &names[0])
-    } else {
-        None
     }
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/projection.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/projection.rs
@@ -168,7 +168,7 @@ fn rpm_query_command_missing_keeps_state_index_projection() {
 }
 
 #[test]
-fn observed_rpm_found_via_alias_when_backend_package_not_installed() {
+fn alias_does_not_override_the_install_package() {
     let index = sample_index_with_aliases();
     // Backend package "copilot-shell" is not installed; alias "cosh-old" is.
     let query = FakeRpmQuery {
@@ -182,14 +182,14 @@ fn observed_rpm_found_via_alias_when_backend_package_not_installed() {
 
     let projection = projection_for_index(&index, "cosh", &empty_state(), &query);
 
-    assert_eq!(projection.local_state_label(), "observed");
-    assert_eq!(projection.ownership_label(), "rpm");
+    assert_eq!(projection.local_state_label(), "not_installed");
+    assert_eq!(projection.ownership_label(), "none");
     assert_eq!(projection.action_label(), "install");
-    assert_eq!(projection.rpm_package.as_deref(), Some("cosh-old"));
+    assert_eq!(projection.rpm_package, None);
 }
 
 #[test]
-fn observed_rpm_found_via_provides_when_no_direct_match() {
+fn capability_does_not_override_the_install_package() {
     let index = sample_index_with_aliases();
     // Neither backend package nor alias is installed, but a package providing
     // `anolisa-component(cosh)` exists in rpmdb.
@@ -207,10 +207,10 @@ fn observed_rpm_found_via_provides_when_no_direct_match() {
 
     let projection = projection_for_index(&index, "cosh", &empty_state(), &query);
 
-    assert_eq!(projection.local_state_label(), "observed");
-    assert_eq!(projection.ownership_label(), "rpm");
+    assert_eq!(projection.local_state_label(), "not_installed");
+    assert_eq!(projection.ownership_label(), "none");
     assert_eq!(projection.action_label(), "install");
-    assert_eq!(projection.rpm_package.as_deref(), Some("cosh-legacy"));
+    assert_eq!(projection.rpm_package, None);
 }
 
 #[test]
@@ -239,4 +239,78 @@ fn observed_rpm_provides_with_ambiguous_providers_is_not_observed() {
 
     assert_eq!(projection.local_state_label(), "not_installed");
     assert_eq!(projection.ownership_label(), "none");
+}
+
+#[test]
+fn legacy_cosh_ng_capability_is_not_counted_as_cosh() {
+    let mut index = sample_index_with_aliases();
+    let mut ng = index.components[0].clone();
+    ng.name = "cosh-ng".to_string();
+    ng.aliases.clear();
+    ng.backends.retain(|backend| backend.kind == "rpm");
+    ng.backends[0].package = "cosh-ng".to_string();
+    ng.backends[0].provides = Some("anolisa-component(cosh-ng)".to_string());
+    index.components.push(ng);
+    let query = FakeRpmQuery {
+        installed: vec![(
+            "cosh-ng".to_string(),
+            pkg_info("cosh-ng", "0.23.0", Some("1.alnx4"), "x86_64"),
+        )],
+        what_provides: vec![(
+            "anolisa-component(cosh)".to_string(),
+            vec!["cosh-ng".to_string()],
+        )],
+        command_missing: false,
+    };
+    for state in [
+        empty_state(),
+        state_with_component_object(rpm_component_object(
+            "cosh-ng",
+            LifecycleStatus::Installed,
+            managed(),
+            "cosh-ng",
+            "0.23.0-1.alnx4",
+        )),
+    ] {
+        let cosh = projection_for_index(&index, "cosh", &state, &query);
+        assert_eq!(cosh.local_state_label(), "not_installed");
+        assert_eq!(cosh.rpm_package, None);
+        let ng = projection_for_index(&index, "cosh-ng", &state, &query);
+        assert_eq!(ng.rpm_package.as_deref(), Some("cosh-ng"));
+    }
+}
+
+#[test]
+fn ambiguous_install_packages_are_not_arbitrarily_observed() {
+    let mut index = sample_index_with_aliases();
+    let mut backend = index.components[0].backends[1].clone();
+    backend.package = "cosh-vendor".to_string();
+    index.components[0].backends.push(backend);
+    let query = FakeRpmQuery {
+        installed: vec![(
+            "copilot-shell".to_string(),
+            pkg_info("copilot-shell", "2.8.0", None, "x86_64"),
+        )],
+        ..Default::default()
+    };
+    let projection = projection_for_index(&index, "cosh", &empty_state(), &query);
+    assert_eq!(projection.rpm_package, None);
+}
+
+#[test]
+fn raw_only_list_entry_does_not_query_rpm_repositories() {
+    struct NoRpmQuery;
+    impl PackageQuery for NoRpmQuery {
+        fn query_installed(&self, _: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            panic!("raw-only entries have no RPM observation target");
+        }
+        fn query_available(&self, _: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+            panic!("list must not query available packages");
+        }
+        fn what_provides_installed(&self, _: &str) -> Result<Vec<String>, PackageQueryError> {
+            panic!("raw-only entries must not enter capability resolution");
+        }
+    }
+    let projection = projection_for("tokenless", &empty_state(), &NoRpmQuery);
+    assert_eq!(projection.local_state_label(), "not_installed");
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/support.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/support.rs
@@ -291,7 +291,7 @@ pub(super) fn projection_for_index(
         .iter()
         .find(|entry| entry.name == component)
         .unwrap();
-    state_view::project_component(entry, state, Some(query))
+    state_view::project_component(entry, index, state, Some(query))
 }
 
 /// A component whose RPM backend package name differs from the component name,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -2284,6 +2284,10 @@ mod tests {
     }
 
     impl PackageTransaction for FakeRpm {
+        fn check_install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
+            panic!("this path must not preflight an install")
+        }
+
         fn install(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
             let &[package] = packages else {
                 panic!("expected exactly one package, got {packages:?}");

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -1285,6 +1285,10 @@ mod tests {
     }
 
     impl PackageTransaction for FakeRpm {
+        fn check_install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
+            panic!("this path must not preflight an install")
+        }
+
         fn install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
             panic!("uninstall path must not delegate a dnf install");
         }
@@ -1360,6 +1364,10 @@ mod tests {
     }
 
     impl PackageTransaction for RacingRpm {
+        fn check_install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
+            panic!("this path must not preflight an install")
+        }
+
         fn install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
             panic!("uninstall path must not install")
         }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -2170,6 +2170,10 @@ pub(crate) mod tests {
     }
 
     impl PackageTransaction for FakeSelfTxn {
+        fn check_install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
+            panic!("this path must not preflight an install")
+        }
+
         fn install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
             panic!("self-update must not run dnf install");
         }
@@ -2750,6 +2754,10 @@ pub(crate) mod tests {
     }
 
     impl PackageTransaction for FakeRpm {
+        fn check_install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
+            panic!("this path must not preflight an install")
+        }
+
         fn install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
             // The update flow never installs; a call here is a routing bug.
             panic!("update path must not delegate a dnf install");

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all.rs
@@ -852,6 +852,10 @@ mod tests {
     }
 
     impl PackageTransaction for FakeHost {
+        fn check_install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
+            panic!("this path must not preflight an install")
+        }
+
         fn install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
             panic!("merged update must not run a dnf install");
         }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
@@ -118,6 +118,10 @@ impl PackageQuery for FakeHost {
 }
 
 impl PackageTransaction for FakeHost {
+    fn check_install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
+        panic!("this path must not preflight an install")
+    }
+
     fn install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
         self.txn_calls.set(self.txn_calls.get() + 1);
         Ok(())

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
@@ -134,6 +134,10 @@ impl PackageQuery for FakeHost {
 }
 
 impl PackageTransaction for FakeHost {
+    fn check_install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
+        panic!("this path must not preflight an install")
+    }
+
     // Calls record the full package set per invocation
     // (`verb:pkg-a,pkg-b`), so tests can pin that a merged transaction
     // really shared one dnf run. A transaction fails as a whole when any of

--- a/src/anolisa/crates/anolisa-core/src/providers.rs
+++ b/src/anolisa/crates/anolisa-core/src/providers.rs
@@ -71,6 +71,15 @@ impl<'a> DelegatedProvider<'a> {
         }
     }
 
+    /// Check an install without applying the native transaction.
+    ///
+    /// # Errors
+    /// Propagates the native solver or tooling failure.
+    pub fn check_install(&self, packages: &[&str]) -> Result<(), ProviderError> {
+        self.txn.check_install(packages)?;
+        Ok(())
+    }
+
     /// Run one native transaction verb over `packages`.
     ///
     /// The whole slice goes to the backend as a single native transaction:
@@ -201,6 +210,10 @@ pub(crate) mod test_fakes {
     }
 
     impl PackageTransaction for FakeTxn {
+        fn check_install(&self, _packages: &[&str]) -> Result<(), PackageTransactionError> {
+            panic!("this path must not preflight an install")
+        }
+
         fn install(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
             self.run("install", packages)
         }

--- a/src/anolisa/crates/anolisa-platform/src/pkg_transaction.rs
+++ b/src/anolisa/crates/anolisa-platform/src/pkg_transaction.rs
@@ -65,6 +65,14 @@ pub enum PackageTransactionError {
 /// single-package call is the one-element slice; callers must not pass an
 /// empty slice.
 pub trait PackageTransaction {
+    /// Resolve an install using the same repositories and solver as apply,
+    /// without downloading packages, running scriptlets, or changing rpmdb.
+    /// Metadata caches may be refreshed. Pass the exact pinned specs, if any.
+    ///
+    /// # Errors
+    /// Returns [`PackageTransactionError`] if solving fails or cannot run.
+    fn check_install(&self, packages: &[&str]) -> Result<(), PackageTransactionError>;
+
     /// Install `packages` from the configured repos in one transaction.
     ///
     /// Delegates the whole file transaction (dependency solving, download,

--- a/src/anolisa/crates/anolisa-platform/src/rpm_transaction.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_transaction.rs
@@ -136,6 +136,54 @@ impl<R: CommandRunner> RpmTransaction<R> {
 }
 
 impl<R: CommandRunner> PackageTransaction for RpmTransaction<R> {
+    fn check_install(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
+        let mut args = self.dnf_args("install", packages);
+        // Override both our non-interactive apply flag and host configuration.
+        args.retain(|arg| arg != "-y");
+        // A site may allow skipped targets or hide the messages we classify.
+        // Preflight must prove every requested package is installable.
+        args.splice(
+            0..0,
+            [
+                "--assumeno",
+                "--setopt=strict=1",
+                "--setopt=debuglevel=2",
+                "--setopt=errorlevel=2",
+            ]
+            .map(str::to_string),
+        );
+        let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        let out = self
+            .runner
+            .run(DNF, &refs)
+            .map_err(|err| map_spawn_error(err, DNF, "install preflight"))?;
+        // DNF 4 declines a solved transaction with exit 1. Logging and plugins
+        // may put the confirmation marker in either stream alongside warnings.
+        // Other pre-confirmation refusals reuse the same bare abort message.
+        let lines = || out.stdout.lines().chain(out.stderr.lines());
+        let resolved = lines().any(|line| line.trim() == "Dependencies resolved.");
+        let declined = lines().any(|line| {
+            matches!(
+                line.trim(),
+                "Operation aborted." | "Error: Operation aborted."
+            )
+        });
+        let refused = lines().any(|line| {
+            line.contains("usr_drift_protected_paths")
+                || line.contains("Persistent transactions aren't supported")
+                || line.contains("configured to be read-only")
+        });
+        if out.code == Some(0) || (out.code == Some(1) && resolved && declined && !refused) {
+            return Ok(());
+        }
+        Err(PackageTransactionError::TransactionFailed {
+            command: DNF.to_string(),
+            operation: "install preflight".to_string(),
+            code: out.code,
+            stderr: format!("{}{}", out.stdout, out.stderr),
+        })
+    }
+
     fn install(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
         self.run_dnf("install", packages)
     }
@@ -272,6 +320,132 @@ mod tests {
             stdout: stdout.to_string(),
             stderr: stderr.to_string(),
         })
+    }
+
+    #[test]
+    fn install_preflight_distinguishes_solver_success_from_failures() {
+        for (code, stdout, stderr, succeeds) in [
+            (Some(0), "Nothing to do.\n", "", true),
+            (
+                Some(1),
+                "Dependencies resolved.\nTransaction Summary\n",
+                "Operation aborted.\n",
+                true,
+            ),
+            (
+                Some(1),
+                "Dependencies resolved.\nOperation aborted.\n",
+                "",
+                true,
+            ),
+            (
+                Some(1),
+                "Dependencies resolved.\n",
+                "Error: Operation aborted.\n",
+                true,
+            ),
+            (
+                Some(1),
+                "Dependencies resolved.\n",
+                "Plugin warning: optional integration unavailable\nOperation aborted.\n",
+                true,
+            ),
+            (
+                Some(1),
+                "Operation aborted.\n",
+                "Dependencies resolved.\n",
+                true,
+            ),
+            (
+                Some(1),
+                "Dependencies resolved.\nThis bootc system is configured to be read-only.\n",
+                "Operation aborted.\n",
+                false,
+            ),
+            (
+                Some(1),
+                "Dependencies resolved.\nPersistent transactions aren't supported on bootc systems.\n",
+                "Error: Operation aborted.\n",
+                false,
+            ),
+            (
+                Some(1),
+                "Dependencies resolved.\n",
+                "Operation aborted. Pass --setopt=usr_drift_protected_paths= to disable this check.\n",
+                false,
+            ),
+            (
+                Some(1),
+                "",
+                "installed cosh-ng conflicts with copilot-shell",
+                false,
+            ),
+            (Some(1), "", "Operation aborted.\n", false),
+            (
+                Some(1),
+                "Dependencies resolved.\n",
+                "repository failed",
+                false,
+            ),
+            (
+                None,
+                "Dependencies resolved.\n",
+                "Operation aborted.\n",
+                false,
+            ),
+            (
+                Some(1),
+                "",
+                "This command has to be run with superuser privileges",
+                false,
+            ),
+        ] {
+            let t = RpmTransaction::with_runner(FakeCommandRunner {
+                dnf: Some(ok_out(code, stdout, stderr)),
+                expected_verb: String::new(),
+                expected_package: String::new(),
+                expected_args: Some(vec![
+                    "--assumeno".into(),
+                    "--setopt=strict=1".into(),
+                    "--setopt=debuglevel=2".into(),
+                    "--setopt=errorlevel=2".into(),
+                    "install".into(),
+                    "copilot-shell".into(),
+                ]),
+            });
+            let result = t.check_install(&["copilot-shell"]);
+            assert_eq!(result.is_ok(), succeeds, "{code:?}: {stdout} {stderr}");
+            if let Err(err) = result {
+                assert!(err.to_string().contains(stderr.trim()));
+            }
+        }
+    }
+
+    #[test]
+    fn install_preflight_keeps_repo_pins_and_joint_solver_targets() {
+        let t = txn_with_repo(
+            "install",
+            "cosh-ng-0.23.0-1.alnx4.x86_64",
+            &[
+                "--assumeno",
+                "--setopt=strict=1",
+                "--setopt=debuglevel=2",
+                "--setopt=errorlevel=2",
+                "--repofrompath=anolisa-configured,http://repo.example/alinux/4/agentic-os/x86_64/os",
+                "--enablerepo=anolisa-configured",
+                "--setopt=anolisa-configured.gpgcheck=1",
+                "repository-packages",
+                "anolisa-configured",
+                "install",
+                "cosh-ng-0.23.0-1.alnx4.x86_64",
+                "copilot-shell",
+            ],
+            ok_out(Some(1), "", "cosh-ng conflicts with copilot-shell"),
+        );
+        let err = t
+            .check_install(&["cosh-ng-0.23.0-1.alnx4.x86_64", "copilot-shell"])
+            .expect_err("joint solver conflict");
+        assert!(err.to_string().contains("cosh-ng conflicts"));
     }
 
     #[test]


### PR DESCRIPTION
## Why

On images with an older cosh-ng RPM, `list` could associate its legacy `anolisa-component(cosh)` capability with cosh even though `install cosh` selected copilot-shell. The resulting native conflict was invisible to dry-run and repeatedly left pending recovery journals.

## What changed

- Use the install package resolver for untracked RPM observations, with index mappings taking precedence over legacy aliases and capabilities.
- Run DNF install preflight with the same repositories and pinned package specs before opening journals, including joint solving for merged `install --all` plans after revalidating their members under the install lock.
- Report pending recovery before `forget` reports an absent installation; existing journals remain recoverable through `repair`.

DNF owns dependency and conflict resolution, avoiding a separate implementation of RPM conflict rules in ANOLISA.

## Related issue

Closes #3139

## User / Agent impact

Legacy cosh-ng RPMs are no longer observed twice as cosh and cosh-ng. Native conflicts fail single and batch install previews/apply before creating recovery journals, so retrying does not enter the reported recovery loop. DNF 4 requires root for RPM install preflight, including `--dry-run`.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

`PackageTransaction` implementors now explicitly provide `check_install`; all workspace implementations are updated. RPM dry-run invokes `dnf --assumeno` and may refresh repository metadata, but does not download package payloads, run scriptlets, or change rpmdb. Preflight pins `strict=1`, `debuglevel=2`, and `errorlevel=2`. DNF 4 success classification accepts solver/abort markers from either C-locale output stream alongside plugin warnings, while rejecting known pre-confirmation refusals; native validation covered DNF 4.14.0, not DNF 5. A successful preflight cannot guarantee subsequent downloads, scriptlets, or a transaction racing with external package-manager activity will succeed.

Pending journals are deliberately preserved because a failed native transaction may already have changed the system. `repair` continues to reconcile that evidence before `forget` can drop state.

## Validation

From `src/anolisa` on Linux:

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 2495 passed, 1 existing ignored test.
- `cargo doc --workspace --no-deps --locked`
- Targeted adopt tests after updating its explicit preflight refusal.
- `git diff --check`
- Repository Commitlint configuration against the complete PR commit range; body lines are wrapped at 72 characters.

Native integration used an isolated Rocky Linux 9 container with RPM 4.16.1.3, DNF 4.14.0, a local repository, and fixture RPMs declaring the legacy cosh capability and mutual conflicts. Verified list identity, conflicting dry-run/apply/retry without new journals, successful preview and installation after removing the blocker, and joint conflicts for both `--all` preview and apply. Also verified that non-root RPM dry-run reports the native privilege error. The temporary container was removed after testing.

Additional native checks with `strict=False` verified conflict refusal for the plain `RpmTransaction::system()` preflight and the configured-repository CLI path, including single and merged previews/apply with no new journals. A DNF plugin reproduced the original failure on a benign stderr warning; the revised preflight succeeded with that warning and with host `debuglevel=0` / `errorlevel=0`, including a pinned version and a successful real install after removing the conflict.

Regression tests cover pinned specs, ambiguous package mappings, raw-only list entries without RPM repository queries, conflicts appearing at the locked recheck, pending journals without installation records, supported abort output variants, and filtering newly tracked or recovery-blocked batch members before solving. The output-variant and stale-batch regression tests were confirmed to fail before their fixes.

## Documentation and rollback

Updated the component README and CLI user guide in English and Chinese for the RPM preflight/root requirement, observation semantics, and recovery guidance. No state migration is required. Revert this commit to roll back; existing pending operations still require `anolisa repair <component>` before retrying or forgetting their state.
