### PR TITLE
feat(sec-core): add v2 rpm e2e gate

### DIFF
--- a/.github/workflows/sec-core-rpmbuild.yaml
+++ b/.github/workflows/sec-core-rpmbuild.yaml
@@ -245,3 +245,147 @@ jobs:
           name: agent-sec-core-rpms-${{ github.run_number }}-${{ github.sha }}
           path: scripts/rpmbuild/RPMS/**/*.rpm
           retention-days: 7
+
+  # Runs in parallel with build-rpm (no `needs`): the V2 Rust CLI/daemon RPM
+  # plus its dedicated e2e suite. Either job failing fails the PR.
+  build-rpm-v2:
+    name: Build agent-sec-core V2 RPM
+    # workflow_dispatch (manual/fork) -> GitHub-hosted; pull_request -> ARC runner.
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-22.04' || 'anolisa-k8s-general-ci-x64' }}
+    container:
+      image: alibaba-cloud-linux-4-registry.cn-hangzhou.cr.aliyuncs.com/alinux4/alinux4:latest
+    steps:
+      - name: Configure mirrors and install dependencies
+        run: |
+          sed -i -e "s/cloud.aliyuncs/aliyun/g" /etc/yum.repos.d/*.repo
+          dnf install -y tar git rpm-build systemd-rpm-macros gcc make clang llvm \
+                         openssl-devel libseccomp-devel bubblewrap \
+                         python3-pip
+
+      - uses: actions/checkout@v4
+
+      # V2 daemon/CLI are pinned to 1.93.1; linux-sandbox also builds on it.
+      # The V1 job stays on 1.93.0.
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.93.1'
+
+      - uses: astral-sh/setup-uv@v8.0.0
+        with:
+          python-version: '3.11.6'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build V2 RPM
+        run: ./scripts/rpm-build.sh agent-sec-core-v2
+
+      - name: List RPM contents
+        run: |
+          echo "=== RPM files built ==="
+          find scripts/rpmbuild/RPMS -name '*.rpm' | sort
+          echo ""
+          for rpm in scripts/rpmbuild/RPMS/**/*.rpm; do
+            echo "========================================"
+            echo ">>> $rpm"
+            echo "========================================"
+            rpm -qlvp "$rpm"
+            echo ""
+          done
+
+      - name: Test RPM installation
+        run: |
+          dnf makecache
+          dnf install -y scripts/rpmbuild/RPMS/**/*.rpm
+          echo "=== Verify CLI (Rust) ==="
+          agent-sec-cli --help
+          echo "=== Verify daemon (Rust) ==="
+          agent-sec-daemon --help
+          echo "=== Verify sandbox ==="
+          linux-sandbox --help
+          echo "=== Verify cosh extension ==="
+          test -f /usr/share/anolisa/extensions/agent-sec-core/cosh-extension.json
+          ls /usr/share/anolisa/extensions/agent-sec-core/hooks/
+          echo "=== Verify openclaw plugin ==="
+          ls /opt/agent-sec/openclaw-plugin/dist/
+          echo "=== Verify hermes plugin ==="
+          ls /opt/agent-sec/hermes-plugin/src/plugin.yaml
+          echo "=== Verify codex plugin ==="
+          ls /opt/agent-sec/codex-plugin/hooks-plugin/hooks/code_scanner_hook.py
+          echo "=== Verify daemon systemd unit ==="
+          ls /usr/lib/systemd/user/agent-sec-core.service
+          echo "=== Verify component manifest ==="
+          test -f /usr/share/anolisa/components/sec-core/component.toml || { echo "ERROR: component.toml not found after RPM install"; exit 1; }
+          echo "=== Assert no V1 Python site-packages ==="
+          if [ -e /opt/agent-sec/lib/python3.11/site-packages ]; then
+            echo "ERROR: V1 site-packages present in V2 RPM"; exit 1;
+          fi
+
+      - name: Verify cosh hook Python imports
+        run: |
+          python3 << 'PYEOF'
+          import importlib.util, pathlib, sys
+
+          hooks_dir = pathlib.Path('/usr/share/anolisa/extensions/agent-sec-core/hooks')
+          print(f'Hooks directory: {hooks_dir.resolve()}')
+          sys.path.insert(0, str(hooks_dir))
+
+          py_files = sorted(hooks_dir.glob('*.py'))
+          if not py_files:
+              print('ERROR: no hook .py files found', file=sys.stderr)
+              sys.exit(1)
+
+          failed = []
+          for pyfile in py_files:
+              mod_name = pyfile.stem.replace('-', '_')
+              spec = importlib.util.spec_from_file_location(mod_name, pyfile)
+              if spec is None:
+                  print(f'  {pyfile.name} ... FAILED: cannot create module spec')
+                  failed.append((pyfile.name, 'cannot create module spec'))
+                  continue
+              try:
+                  mod = importlib.util.module_from_spec(spec)
+                  spec.loader.exec_module(mod)
+                  print(f'  {pyfile.name} ... OK')
+              except Exception as e:
+                  print(f'  {pyfile.name} ... FAILED: {e}')
+                  failed.append((pyfile.name, str(e)))
+
+          print(f'\nTotal: {len(py_files)} hooks, {len(failed)} failed')
+          if failed:
+              print('\nFailed hooks:', file=sys.stderr)
+              for name, err in failed:
+                  print(f'  - {name}: {err}', file=sys.stderr)
+              sys.exit(1)
+          print('All hook scripts imported successfully')
+          PYEOF
+
+      - name: Uninstall skills package before E2E tests
+        run: rpm -e agent-sec-skills --nodeps
+
+      - name: Run V2 E2E tests on installed RPM
+        run: |
+          source_dir=src/agent-sec-core/agent-sec-cli
+          hidden_root="$(mktemp -d)"
+          mv "$source_dir" "$hidden_root/agent-sec-cli"
+          restore_source() {
+            mv "$hidden_root/agent-sec-cli" "$source_dir"
+            rmdir "$hidden_root"
+          }
+          trap restore_source EXIT
+
+          unset PYTHONPATH
+          if python3 -c 'import agent_sec_cli' 2>/dev/null; then
+            echo "ERROR: agent_sec_cli remains importable after hiding V1 source"
+            exit 1
+          fi
+          make -C src/agent-sec-core test-e2e-rpm-v2
+
+      - name: Upload V2 RPM artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-sec-core-v2-rpms-${{ github.run_number }}-${{ github.sha }}
+          path: scripts/rpmbuild/RPMS/**/*.rpm
+          retention-days: 7

--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -184,6 +184,64 @@ build_copilot_shell() {
 }
 
 # =============================================================================
+# agent-sec-core: payload shared by the V1 and V2 source tarballs
+#
+# Args: <pkg_dir>  destination staging directory (must already exist)
+#
+# Only the CLI/daemon layer differs between V1 and V2, so both callers stage the
+# same component payload here and then add their own layer. Keeping the trees
+# separate matters: the V1 tarball must keep its original payload inventory, so
+# nothing V2-specific may leak into this helper.
+#
+# Note: rust-toolchain.toml is intentionally excluded from the tarball. The
+# source file pins a Rust version that rpmbuild environments may not have, so by
+# omitting it cargo falls back to whatever Rust the build environment provides.
+# =============================================================================
+stage_sec_core_payload() {
+    local pkg_dir="$1"
+
+    mkdir -p "$pkg_dir"/{skills,linux-sandbox,cosh-extension,openclaw-plugin,hermes-plugin,qwen-code-extension,qoder-plugin,tools}
+
+    # skills: use cp -rp dir/. to include hidden files/directories
+    cp -rp "${SEC_DIR}/skills/." "$pkg_dir/skills/"
+    cp -rp "${SEC_DIR}/linux-sandbox/"* "$pkg_dir/linux-sandbox/"
+    rm -f "$pkg_dir/linux-sandbox/rust-toolchain.toml"
+    cp -rp "${SEC_DIR}/cosh-extension/"* "$pkg_dir/cosh-extension/"
+    cp -p "${SEC_DIR}/tools/sign-skill.sh" "$pkg_dir/tools/"
+    cp "${SEC_DIR}/Makefile" "$pkg_dir/"
+    tar -cf - -C "${SEC_DIR}" \
+        .anolisa/ packaging/systemd/ | tar -xf - -C "$pkg_dir/"
+    [ -f "${SEC_DIR}/LICENSE" ] && cp "${SEC_DIR}/LICENSE" "$pkg_dir/"
+    [ -f "${SEC_DIR}/README.md" ] && cp "${SEC_DIR}/README.md" "$pkg_dir/"
+
+    # openclaw-plugin (exclude node_modules and dev artifacts)
+    tar -cf - -C "${SEC_DIR}" \
+        --exclude='node_modules' \
+        --exclude='.tsbuildinfo' \
+        openclaw-plugin/ | tar -xf - -C "$pkg_dir/"
+
+    # hermes-plugin (exclude __pycache__ and dev artifacts)
+    tar -cf - -C "${SEC_DIR}" \
+        --exclude='__pycache__' \
+        hermes-plugin/src hermes-plugin/scripts | tar -xf - -C "$pkg_dir/"
+
+    # qwen-code-extension (exclude Python cache artifacts)
+    tar -cf - -C "${SEC_DIR}" \
+        --exclude='__pycache__' \
+        qwen-code-extension/ | tar -xf - -C "$pkg_dir/"
+
+    # codex-plugin (hooks + install script + .agents registry, exclude __pycache__)
+    tar -cf - -C "${SEC_DIR}" \
+        --exclude='__pycache__' \
+        codex-plugin/hooks-plugin codex-plugin/install.sh codex-plugin/.agents | tar -xf - -C "$pkg_dir/"
+
+    # qoder-plugin (hooks + install script, exclude __pycache__)
+    tar -cf - -C "${SEC_DIR}" \
+        --exclude='__pycache__' \
+        qoder-plugin/ | tar -xf - -C "$pkg_dir/"
+}
+
+# =============================================================================
 # agent-sec-core
 # =============================================================================
 build_agent_sec_core() {
@@ -217,56 +275,15 @@ build_agent_sec_core() {
     spec_file=$(process_spec_template "$spec_in" "$version")
 
     # Step 2: Create source tarball
-    # Note: rust-toolchain.toml is intentionally excluded from the tarball.
-    # The source file requires Rust 1.93.0, but rpmbuild environments may only
-    # have an older Rust available (BuildRequires: rust >= 1.70). By omitting
-    # rust-toolchain.toml, cargo falls back to whatever system Rust is present.
     log "Step 2/3: Creating source tarball ${tarball_name}..."
     local tmp_dir
     tmp_dir=$(mktemp -d)
     local pkg_dir="${tmp_dir}/${pkg_name}-${version}"
-    mkdir -p "$pkg_dir"/{skills,linux-sandbox,agent-sec-cli,cosh-extension,openclaw-plugin,hermes-plugin,qwen-code-extension,qoder-plugin,scripts,tools}
+    mkdir -p "$pkg_dir"/{agent-sec-cli,scripts}
+    stage_sec_core_payload "$pkg_dir"
 
-    # skills: use cp -rp dir/. to include hidden files/directories
-    cp -rp "${SEC_DIR}/skills/." "$pkg_dir/skills/"
-    cp -rp "${SEC_DIR}/linux-sandbox/"* "$pkg_dir/linux-sandbox/"
-    rm -f "$pkg_dir/linux-sandbox/rust-toolchain.toml"
-    cp -rp "${SEC_DIR}/cosh-extension/"* "$pkg_dir/cosh-extension/"
     cp -p "${SEC_DIR}/scripts/agent-sec-cli-wrapper.sh" "$pkg_dir/scripts/"
     cp -p "${SEC_DIR}/scripts/agent-sec-daemon-wrapper.sh" "$pkg_dir/scripts/"
-    cp -p "${SEC_DIR}/tools/sign-skill.sh" "$pkg_dir/tools/"
-    cp "${SEC_DIR}/Makefile" "$pkg_dir/"
-    tar -cf - -C "${SEC_DIR}" \
-        .anolisa/ packaging/systemd/ | tar -xf - -C "$pkg_dir/"
-    [ -f "${SEC_DIR}/LICENSE" ] && cp "${SEC_DIR}/LICENSE" "$pkg_dir/"
-    [ -f "${SEC_DIR}/README.md" ] && cp "${SEC_DIR}/README.md" "$pkg_dir/"
-
-    # openclaw-plugin (exclude node_modules and dev artifacts)
-    tar -cf - -C "${SEC_DIR}" \
-        --exclude='node_modules' \
-        --exclude='.tsbuildinfo' \
-        openclaw-plugin/ | tar -xf - -C "$pkg_dir/"
-
-    # hermes-plugin (exclude __pycache__ and dev artifacts)
-    tar -cf - -C "${SEC_DIR}" \
-        --exclude='__pycache__' \
-        hermes-plugin/src hermes-plugin/scripts | tar -xf - -C "$pkg_dir/"
-
-    # qwen-code-extension (exclude Python cache artifacts)
-    tar -cf - -C "${SEC_DIR}" \
-        --exclude='__pycache__' \
-        qwen-code-extension/ | tar -xf - -C "$pkg_dir/"
-
-    # codex-plugin (hooks + install script + .agents registry, exclude __pycache__)
-    tar -cf - -C "${SEC_DIR}" \
-        --exclude='__pycache__' \
-        codex-plugin/hooks-plugin codex-plugin/install.sh codex-plugin/.agents | tar -xf - -C "$pkg_dir/"
-
-    # qoder-plugin (hooks + install script, exclude __pycache__)
-    tar -cf - -C "${SEC_DIR}" \
-        --exclude='__pycache__' \
-        qoder-plugin/ | tar -xf - -C "$pkg_dir/"
-
 
     # Include agent-sec-cli source for maturin wheel build
     # Exclude development artifacts (.venv, target, __pycache__, .egg-info, dist)
@@ -289,6 +306,88 @@ build_agent_sec_core() {
         "$spec_file"
 
     ok "agent-sec-core RPM built successfully"
+}
+
+# =============================================================================
+# agent-sec-core-v2 (V2 Rust CLI/daemon instead of the Python wheel)
+# =============================================================================
+build_agent_sec_core_v2() {
+    log "=========================================="
+    log "Building RPM: agent-sec-core (V2)"
+    log "=========================================="
+
+    local spec_in="${SEC_DIR}/agent-sec-core.spec.v2.in"
+    if [ ! -f "$spec_in" ]; then
+        err "Spec template not found: $spec_in"
+        return 1
+    fi
+
+    # Version: prefer $VERSION env, otherwise the V2 workspace owns its version.
+    # V2 deliberately does not read agent-sec-cli/pyproject.toml: the Rust tree
+    # must stand on its own once the Python CLI is retired.
+    local version="${VERSION:-}"
+    if [ -z "$version" ]; then
+        version=$(awk '
+            $0 == "[workspace.package]" { in_section = 1; next }
+            in_section && /^\[/ { exit }
+            in_section && /^version = / {
+                value = $0
+                sub(/^version = "/, "", value)
+                sub(/"$/, "", value)
+                print value
+                exit
+            }
+        ' "${SEC_DIR}/v2/Cargo.toml")
+    fi
+    if [ -z "$version" ]; then
+        err "Cannot determine agent-sec-core V2 version. Set VERSION env or ensure v2/Cargo.toml has [workspace.package] version."
+        return 1
+    fi
+
+    # Both versions are bumped together by scripts/bump-version.sh; warn (do not
+    # fail) on drift, because V1 is on its way out and must not gate a V2 build.
+    local v1_version
+    v1_version=$(grep -m1 '^version' "${SEC_DIR}/agent-sec-cli/pyproject.toml" 2>/dev/null | sed 's/.*"\(.*\)"/\1/')
+    if [ -n "$v1_version" ] && [ "$v1_version" != "$version" ]; then
+        warn "V1 version ($v1_version) differs from V2 version ($version); bump-version.sh may have missed a file"
+    fi
+
+    local pkg_name
+    pkg_name=$(parse_spec_name "$spec_in")
+    local tarball_name="${pkg_name}-${version}.tar.gz"
+
+    # Step 1: Process spec template. The generated name is explicit instead of
+    # derived, so the template suffix does not produce agent-sec-core.spec.v2.
+    log "Step 1/3: Preparing spec file..."
+    local spec_file="${BUILD_DIR}/SPECS/${pkg_name}-v2.spec"
+    log "Processing template: $(basename "$spec_in") -> $(basename "$spec_file") (version=${version})"
+    sed "s/@VERSION@/${version}/g" "$spec_in" > "$spec_file"
+
+    # Step 2: Create source tarball. Same top-level directory as V1 because the
+    # spec still unpacks %{name}-%{version} via `%setup -q`.
+    log "Step 2/3: Creating source tarball ${tarball_name}..."
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local pkg_dir="${tmp_dir}/${pkg_name}-${version}"
+    mkdir -p "$pkg_dir"
+    stage_sec_core_payload "$pkg_dir"
+
+    # V2 layer: the Rust workspace replaces agent-sec-cli/ and the two Python
+    # wrapper scripts, which are therefore absent from this tarball.
+    tar -cf - -C "${SEC_DIR}" \
+        --exclude='target' \
+        v2/ | tar -xf - -C "$pkg_dir/"
+
+    tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}-${version}"
+    rm -rf "$tmp_dir"
+
+    # Step 3: rpmbuild (--nodeps: BuildRequires are handled by yum-builddep in CI)
+    log "Step 3/3: Running rpmbuild..."
+    "$RPMBUILD" -ba --nodeps \
+        --define "_topdir ${BUILD_DIR}" \
+        "$spec_file"
+
+    ok "agent-sec-core V2 RPM built successfully"
 }
 
 # =============================================================================
@@ -1221,6 +1320,7 @@ usage() {
     echo "Packages:"
     echo "  copilot-shell             Build copilot-shell RPM"
     echo "  agent-sec-core            Build agent-sec-core RPM"
+    echo "  agent-sec-core-v2         Build agent-sec-core RPM with the V2 Rust CLI/daemon"
     echo "  os-skills                 Build os-skills RPM"
     echo "  agentsight                Build agentsight RPM"
     echo "  tokenless                 Build tokenless RPM"
@@ -1269,6 +1369,9 @@ case "$TARGET" in
         ;;
     agent-sec-core)
         build_agent_sec_core
+        ;;
+    agent-sec-core-v2)
+        build_agent_sec_core_v2
         ;;
     os-skills)
         build_agentic_os_skills

--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -65,7 +65,7 @@ rust-lint: ## Run cargo clippy on Rust crates (linux-sandbox on Linux only)
 test-python: ## Run Python unit and integration tests
 	@echo "🧪 Running Python tests..."
 	cd agent-sec-cli && uv sync
-	uv run --project agent-sec-cli pytest tests/ --ignore=tests/e2e/ -v
+	uv run --project agent-sec-cli pytest tests/ --ignore=tests/e2e/ --ignore=tests/v2 -v
 	uv run --project agent-sec-cli pytest tests/e2e/cli -v
 	uv run --project agent-sec-cli pytest tests/e2e/daemon -v
 	uv run --project agent-sec-cli pytest tests/e2e/prompt-scanner -v
@@ -92,6 +92,49 @@ test-e2e-rpm: ## Run E2E tests against RPM-installed agent-sec-cli binary
 		-v --tb=short
 	@# linux-sandbox e2e skipped: requires privileged container
 
+# V1 e2e files are ignored one by one, each with the V2 capability it waits for.
+# Delete a line as soon as its capability lands in the V2 CLI/daemon; do not
+# collapse the list into a directory-level ignore, or migrated coverage will
+# stay silently disabled.
+.PHONY: test-e2e-rpm-v2
+test-e2e-rpm-v2: ## Run E2E tests against V2 RPM-installed binaries
+	@echo "🧪 Running V2 E2E tests on installed RPM..."
+	@command -v agent-sec-cli >/dev/null 2>&1 || { echo "ERROR: agent-sec-cli not found on PATH"; exit 1; }
+	@command -v agent-sec-daemon >/dev/null 2>&1 || { echo "ERROR: agent-sec-daemon not found on PATH"; exit 1; }
+	@command -v pytest >/dev/null 2>&1 || pip3 install --quiet pytest
+	python3 -m pytest tests/e2e/ tests/v2/e2e/ \
+		--import-mode=importlib \
+		--ignore=tests/e2e/cli/test_capabilities_e2e.py \
+		--ignore=tests/e2e/cli/test_events_e2e.py \
+		--ignore=tests/e2e/cli/test_observability_record_jsonl_e2e.py \
+		--ignore=tests/e2e/cli/test_observability_record_sqlite_e2e.py \
+		--ignore=tests/e2e/cli/test_scan_pii_e2e.py \
+		--ignore=tests/e2e/cli/test_session_report_e2e.py \
+		--ignore=tests/e2e/cli/test_skill_ledger_analyze_e2e.py \
+		--ignore=tests/e2e/code-scanner/e2e_test.py \
+		--ignore=tests/e2e/codex-hooks/test_codex_hooks_e2e.py \
+		--ignore=tests/e2e/daemon/test_daemon_e2e.py \
+		--ignore=tests/e2e/prompt-scanner/test_prompt_scanner_e2e.py \
+		--ignore=tests/e2e/qoder-hooks/test_qoder_skill_ledger_hook_e2e.py \
+		--ignore=tests/e2e/qwen-code-extension/test_qwen_direct_hook_execution.py \
+		--ignore=tests/e2e/skill-ledger/e2e_test.py \
+		--ignore=tests/e2e/skill-signing/e2e_test.py \
+		--ignore=tests/e2e/linux-sandbox \
+		-v --tb=short
+	@# Pending V2 capabilities behind the ignores above:
+	@#   cli/test_capabilities_e2e.py             -> capability view command
+	@#   cli/test_events_e2e.py                   -> security event query
+	@#   cli/test_observability_record_*_e2e.py   -> observability record sinks
+	@#   cli/test_scan_pii_e2e.py                 -> PII scanning
+	@#   cli/test_session_report_e2e.py           -> session report
+	@#   cli/test_skill_ledger_analyze_e2e.py     -> skill ledger analyze
+	@#   code-scanner/e2e_test.py                 -> code scanning
+	@#   codex|qoder|qwen hook tests              -> hooks calling the V2 CLI
+	@#   daemon/test_daemon_e2e.py                -> V1 daemon wire protocol
+	@#   prompt-scanner/test_prompt_scanner_e2e.py -> prompt scanning
+	@#   skill-ledger, skill-signing              -> skill ledger and signing
+	@#   linux-sandbox                            -> privileged container (same as V1)
+
 VENV_PYTHON ?= $(HOME)/.local/lib/anolisa/sec-core/venv/bin/python
 
 .PHONY: test-e2e-source-build
@@ -114,6 +157,7 @@ test-python-coverage: ## Run Python tests with coverage report
 		--ignore=tests/e2e/linux-sandbox \
 		--ignore=tests/e2e/skill-ledger \
 		--ignore=tests/e2e/skill-signing \
+		--ignore=tests/v2 \
 		-v --cov --cov-config=agent-sec-cli/pyproject.toml --cov-report=xml --cov-report=term-missing
 
 .PHONY: test-rust
@@ -171,6 +215,24 @@ BUILD_DIR ?= target
 CLI_WHEEL_BUILD_DIR ?= agent-sec-cli/target/wheels
 CLI_WHEEL_PATTERN := agent_sec_cli-*.whl
 
+# Component targets shared by the V1 and V2 aggregates. Only the CLI/daemon
+# build differs between them, so one list prevents the two aggregates from
+# drifting apart as components are added. $(1) is the CLI slot; its position is
+# preserved so prerequisite order stays identical to the pre-V2 build-all.
+define component_build_targets
+build-sandbox $(1) build-openclaw-plugin build-hermes-plugin build-qwen-code-extension stage-codex-plugin stage-qoder-plugin stage-cosh-extension stage-skills stage-component-manifest
+endef
+
+# Install targets shared by the V1 and V2 rpmbuild aggregates; the CLI install
+# target is prepended by each aggregate.
+RPM_INSTALL_COMMON_TARGETS := install-cosh-hook install-codex-plugin install-qoder-plugin \
+	install-openclaw-plugin install-hermes-plugin install-qwen-code-extension \
+	install-skills install-component-manifest install-systemd-user
+
+# V2 Rust binaries are collected here by build-cli-v2 and consumed by
+# install-cli-v2, mirroring the build/install split used for linux-sandbox.
+V2_BIN_BUILD_DIR ?= $(BUILD_DIR)/v2/bin
+
 define require_single_cli_wheel
 set -- "$(1)"/$(CLI_WHEEL_PATTERN); \
 if [ "$$#" -ne 1 ] || [ ! -f "$$1" ]; then \
@@ -194,6 +256,13 @@ build-cli: ## Build agent-sec-cli wheel with maturin (Rust + Python)
 		uv run --no-sync maturin build --release -i python3.11 --manylinux off
 	@$(call require_single_cli_wheel,$(CLI_WHEEL_BUILD_DIR)) \
 		cp -p "$$1" $(BUILD_DIR)/wheels/
+
+.PHONY: build-cli-v2
+build-cli-v2: ## Build V2 Rust CLI and daemon binaries
+	cd v2 && cargo build --release --locked --workspace
+	install -d -m 0755 $(V2_BIN_BUILD_DIR)
+	cp -p v2/target/release/agent-sec-cli v2/target/release/agent-sec-daemon \
+		$(V2_BIN_BUILD_DIR)/
 
 .PHONY: setup
 setup: ## Install all dependencies (including dev), create .venv
@@ -255,7 +324,11 @@ stage-component-manifest: ## Stage component.toml into BUILD_DIR
 		$(BUILD_DIR)/share/anolisa/components/sec-core/component.toml
 
 .PHONY: build-all
-build-all: build-sandbox build-cli build-openclaw-plugin build-hermes-plugin build-qwen-code-extension stage-codex-plugin stage-qoder-plugin stage-cosh-extension stage-skills stage-component-manifest ## Build all components
+build-all: $(call component_build_targets,build-cli) ## Build all components
+	@echo "📦 All artifacts collected to $(BUILD_DIR)/"
+
+.PHONY: build-all-v2
+build-all-v2: $(call component_build_targets,build-cli-v2) ## Build all components with the V2 Rust CLI/daemon
 	@echo "📦 All artifacts collected to $(BUILD_DIR)/"
 
 .PHONY: export-requirements
@@ -415,6 +488,14 @@ install-cli-site: ## RPM: Copy staged site-packages to private dir + wrappers
 	install -p -m 0755 scripts/agent-sec-cli-wrapper.sh $(DESTDIR)/usr/bin/agent-sec-cli
 	install -p -m 0755 scripts/agent-sec-daemon-wrapper.sh $(DESTDIR)/usr/bin/agent-sec-daemon
 
+.PHONY: install-cli-v2
+install-cli-v2: ## RPM: Install V2 Rust CLI and daemon binaries
+	install -d -m 0755 $(DESTDIR)/usr/bin
+	install -p -m 0755 $(V2_BIN_BUILD_DIR)/agent-sec-cli \
+		$(DESTDIR)/usr/bin/agent-sec-cli
+	install -p -m 0755 $(V2_BIN_BUILD_DIR)/agent-sec-daemon \
+		$(DESTDIR)/usr/bin/agent-sec-daemon
+
 .PHONY: install-cli-venv
 install-cli-venv: ## Create venv, install deps from uv.lock, install wheel, symlink
 	@echo "Creating Python venv at $(VENV_DIR) ..."
@@ -514,7 +595,17 @@ install-all-for-rpmbuild: HERMES_PLUGIN_DIR := $(RPM_HERMES_PLUGIN_DIR)
 install-all-for-rpmbuild: QWEN_CODE_EXTENSION_DIR := $(RPM_QWEN_CODE_EXTENSION_DIR)
 install-all-for-rpmbuild: CODEX_PLUGIN_DIR := $(RPM_CODEX_PLUGIN_DIR)
 install-all-for-rpmbuild: QODER_PLUGIN_DIR := $(RPM_QODER_PLUGIN_DIR)
-install-all-for-rpmbuild: install-cli-site install-cosh-hook install-codex-plugin install-qoder-plugin install-openclaw-plugin install-hermes-plugin install-qwen-code-extension install-skills install-component-manifest install-systemd-user ## Install all (RPM build)
+install-all-for-rpmbuild: install-cli-site $(RPM_INSTALL_COMMON_TARGETS) ## Install all (RPM build)
+
+# V2 differs from install-all-for-rpmbuild only in the CLI/daemon implementation;
+# both versions install the same systemd unit contract.
+.PHONY: install-all-for-rpmbuild-v2
+install-all-for-rpmbuild-v2: OPENCLAW_PLUGIN_DIR := $(RPM_OPENCLAW_PLUGIN_DIR)
+install-all-for-rpmbuild-v2: HERMES_PLUGIN_DIR := $(RPM_HERMES_PLUGIN_DIR)
+install-all-for-rpmbuild-v2: QWEN_CODE_EXTENSION_DIR := $(RPM_QWEN_CODE_EXTENSION_DIR)
+install-all-for-rpmbuild-v2: CODEX_PLUGIN_DIR := $(RPM_CODEX_PLUGIN_DIR)
+install-all-for-rpmbuild-v2: QODER_PLUGIN_DIR := $(RPM_QODER_PLUGIN_DIR)
+install-all-for-rpmbuild-v2: install-cli-v2 $(RPM_INSTALL_COMMON_TARGETS) ## Install all (V2 RPM build)
 
 # =============================================================================
 # UNINSTALL

--- a/src/agent-sec-core/agent-sec-core.spec.v2.in
+++ b/src/agent-sec-core/agent-sec-core.spec.v2.in
@@ -1,0 +1,331 @@
+
+%define anolis_release 1
+%global debug_package %{nil}
+
+# Disable stripping of ELF binaries.  Bundled .so files (the crate-backed
+# agent_sec_cli._native extension and prebuilt wheel extensions such as
+# cryptography and pydantic-core) have precise ELF segment alignment that
+# `strip` breaks, causing "ELF load command address/offset not page-aligned"
+# at runtime.
+%global __strip /bin/true
+
+# Use default zstd compression (level 3) instead of -19 to speed up packaging
+# of bundled native extensions; -19 takes noticeably longer with no real gain.
+%define _binary_payload w.zstdio
+%define _source_payload w.zstdio
+%{!?_userunitdir:%global _userunitdir /usr/lib/systemd/user}
+
+# Preserve original shebang (#!/usr/bin/env bash) for cross-platform compatibility
+%undefine __brp_mangle_shebangs
+
+# Exclude bundled site-packages from RPM auto-dependency scanning.
+# Prebuilt wheel .so files reference host system libraries or use hash-named
+# internal libraries, neither of which must become hard RPM
+# Requires/Provides.
+# Using path-based exclusion instead of AutoReqProv:no so that other subpackages
+# (e.g. linux-sandbox in agent-sec-cosh-hook) retain proper auto-dependency detection.
+%global __requires_exclude_from /opt/agent-sec/lib/python3\.11/site-packages/.*
+%global __provides_exclude_from /opt/agent-sec/lib/python3\.11/site-packages/.*
+
+Name:           agent-sec-core
+Version:        @VERSION@
+Release:        %{anolis_release}%{?dist}
+Summary:        Agent Security Core Package (metapackage)
+
+License:        Apache-2.0
+URL:            https://github.com/alibaba/anolisa
+Source0:        %{name}-%{version}.tar.gz
+
+# Build dependencies
+# NOTE: The following build tools are required but NOT declared as BuildRequires
+# because they are provided by the CI environment (GitHub Actions):
+#   - Rust toolchain >= 1.93.0  (dtolnay/rust-toolchain)
+#   - Python 3.11.6 + uv        (astral-sh/setup-uv)
+#   - Node.js >= 20              (actions/setup-node)
+#   - gcc, clang, llvm, openssl-devel, libseccomp-devel, bubblewrap
+# If building outside CI, ensure these are installed manually.
+BuildRequires:  make
+BuildRequires:  systemd-rpm-macros
+
+%{!?systemd_user_post:%{error:missing %%systemd_user_post; install systemd-rpm-macros in the rpmbuild environment}}
+%{!?systemd_user_preun:%{error:missing %%systemd_user_preun; install systemd-rpm-macros in the rpmbuild environment}}
+%{!?systemd_user_postun:%{error:missing %%systemd_user_postun; install systemd-rpm-macros in the rpmbuild environment}}
+
+# Metapackage: pull all subpackages
+Requires:       agent-sec-cli = %{version}-%{release}
+Requires:       agent-sec-cosh-hook = %{version}-%{release}
+Requires:       agent-sec-codex-hook = %{version}-%{release}
+Requires:       agent-sec-qoder-hook = %{version}-%{release}
+Requires:       agent-sec-openclaw-hook = %{version}-%{release}
+Requires:       agent-sec-hermes-hook = %{version}-%{release}
+Requires:       agent-sec-qwen-code-hook = %{version}-%{release}
+Requires:       agent-sec-skills = %{version}-%{release}
+
+%description
+Agent-Sec-Core is an OS-level security baseline and hardening framework for AI Agents.
+This metapackage installs all agent-sec-core components including CLI, hooks, and skills.
+
+# =============================================================================
+# Subpackage 1: agent-sec-cli
+# =============================================================================
+%package -n agent-sec-cli
+Summary:        Agent Security CLI tool (Rust, daemon client)
+Requires:       python3 >= 3.11
+Requires:       python3 < 3.12
+Requires:       gnupg2 >= 2.0
+Requires:       loongshield >= 1.2.0
+Requires:       systemd
+Recommends:     python3-pgpy >= 0.5
+
+%description -n agent-sec-cli
+Agent-sec-cli provides Policy, Scope and Binding administration commands.
+Built from the V2 Rust workspace; it talks to agent-sec-daemon over a Unix
+domain socket and carries no Python runtime of its own.
+
+%files -n agent-sec-cli
+%defattr(0644,root,root,0755)
+%attr(0755,root,root) /usr/bin/agent-sec-cli
+%attr(0755,root,root) /usr/bin/agent-sec-daemon
+%{_userunitdir}/agent-sec-core.service
+%dir %{_datadir}/anolisa
+%dir %{_datadir}/anolisa/components
+%dir %{_datadir}/anolisa/components/sec-core
+%{_datadir}/anolisa/components/sec-core/component.toml
+%license LICENSE
+
+%post -n agent-sec-cli
+%systemd_user_post agent-sec-core.service
+
+%preun -n agent-sec-cli
+%systemd_user_preun agent-sec-core.service
+
+%postun -n agent-sec-cli
+%systemd_user_postun_with_restart agent-sec-core.service
+
+# =============================================================================
+# Subpackage 2: agent-sec-cosh-hook
+# =============================================================================
+%package -n agent-sec-cosh-hook
+Summary:        CoPilot Shell security hooks with linux-sandbox
+Requires:       agent-sec-cli = %{version}-%{release}
+Requires:       bubblewrap
+Requires:       python3 >= 3.11
+Requires:       python3 < 3.12
+
+%description -n agent-sec-cosh-hook
+Provides code_scanner_hook and linux-sandbox for copilot-shell integration.
+The linux-sandbox binary provides secure sandboxed execution environments.
+
+%files -n agent-sec-cosh-hook
+%defattr(0644,root,root,0755)
+%attr(0755,root,root) /usr/local/bin/linux-sandbox
+%attr(0755,root,root) /usr/share/anolisa/extensions/agent-sec-core/hooks/*.py
+/usr/share/anolisa/extensions/agent-sec-core/
+%license LICENSE
+
+# =============================================================================
+# Subpackage 3: agent-sec-openclaw-hook
+# =============================================================================
+%package -n agent-sec-openclaw-hook
+Summary:        OpenClaw plugin for agent security
+Requires:       agent-sec-cli = %{version}-%{release}
+Requires:       nodejs >= 18
+Requires:       jq
+
+%description -n agent-sec-openclaw-hook
+OpenClaw IDE plugin providing agent security integration.
+Hooks into OpenClaw to perform code scanning before tool execution.
+
+%files -n agent-sec-openclaw-hook
+%defattr(0644,root,root,0755)
+%attr(0755,root,root) /opt/agent-sec/openclaw-plugin/scripts/deploy.sh
+/opt/agent-sec/openclaw-plugin/
+%license LICENSE
+
+# =============================================================================
+# Subpackage 4: agent-sec-hermes-hook
+# =============================================================================
+%package -n agent-sec-hermes-hook
+Summary:        Hermes Agent plugin for agent security
+Requires:       agent-sec-cli = %{version}-%{release}
+Requires:       jq
+
+%description -n agent-sec-hermes-hook
+Hermes Agent security plugin powered by agent-sec-core.
+Provides OS-level security guardrails for Hermes Agent via agent-sec-cli.
+
+%files -n agent-sec-hermes-hook
+%defattr(0644,root,root,0755)
+%attr(0755,root,root) /opt/agent-sec/hermes-plugin/scripts/deploy.sh
+/opt/agent-sec/hermes-plugin/
+%license LICENSE
+
+# =============================================================================
+# Subpackage 5: agent-sec-qwen-code-hook
+# =============================================================================
+%package -n agent-sec-qwen-code-hook
+Summary:        Qwen Code extension for agent security
+Requires:       agent-sec-cli = %{version}-%{release}
+Requires:       python3 >= 3.11
+Requires:       python3 < 3.12
+
+%description -n agent-sec-qwen-code-hook
+Qwen Code security extension powered by agent-sec-core.
+Provides prompt and PII policy enforcement, lifecycle observability, and
+managed Skill Ledger validation through Qwen Code command hooks.
+
+%files -n agent-sec-qwen-code-hook
+%defattr(0644,root,root,0755)
+%attr(0755,root,root) /opt/agent-sec/qwen-code-extension/scripts/deploy.sh
+%attr(0755,root,root) /opt/agent-sec/qwen-code-extension/hooks/observability_hook.py
+%attr(0755,root,root) /opt/agent-sec/qwen-code-extension/hooks/pii_checker_hook.py
+%attr(0755,root,root) /opt/agent-sec/qwen-code-extension/hooks/skill_ledger_hook.py
+/opt/agent-sec/qwen-code-extension/
+%license LICENSE
+
+# =============================================================================
+# Subpackage 6: agent-sec-skills
+# =============================================================================
+%package -n agent-sec-skills
+Summary:        Agent security skill definitions for copilot-shell
+Requires:       agent-sec-cli = %{version}-%{release}
+
+%description -n agent-sec-skills
+Skill reference files and documentation for copilot-shell integration.
+Includes skill-ledger, code-scanner, prompt-scanner and related skill definitions.
+
+%files -n agent-sec-skills
+%defattr(0644,root,root,0755)
+%{_datadir}/anolisa/skills/
+%license LICENSE
+
+# =============================================================================
+# Subpackage 7: agent-sec-codex-hook
+# =============================================================================
+%package -n agent-sec-codex-hook
+Summary:        Codex plugin security hooks
+Requires:       agent-sec-cli = %{version}-%{release}
+Requires:       python3 >= 3.11
+Requires:       python3 < 3.12
+
+%description -n agent-sec-codex-hook
+Codex security hooks providing code scanning, PII checking, prompt scanning
+and skill ledger verification for Codex agent.
+
+%files -n agent-sec-codex-hook
+%defattr(0644,root,root,0755)
+%attr(0755,root,root) /opt/agent-sec/codex-plugin/install.sh
+/opt/agent-sec/codex-plugin/
+%license LICENSE
+
+# =============================================================================
+# Subpackage 8: agent-sec-qoder-hook
+# =============================================================================
+%package -n agent-sec-qoder-hook
+Summary:        Qoder plugin security hooks
+Requires:       agent-sec-cli = %{version}-%{release}
+Requires:       python3 >= 3.11
+Requires:       python3 < 3.12
+
+%description -n agent-sec-qoder-hook
+Qoder CLI security hooks providing agent-sec-core protection for Qoder agents.
+
+%files -n agent-sec-qoder-hook
+%defattr(0644,root,root,0755)
+%attr(0755,root,root) /opt/agent-sec/qoder-plugin/install.sh
+/opt/agent-sec/qoder-plugin/
+%license LICENSE
+
+# =============================================================================
+# Main package has no files (metapackage)
+# =============================================================================
+%files
+%license LICENSE
+
+# =============================================================================
+# Build & Install
+# =============================================================================
+%prep
+%setup -q
+
+%build
+make build-all-v2
+
+%install
+rm -rf $RPM_BUILD_ROOT
+make install-all-for-rpmbuild-v2 DESTDIR=$RPM_BUILD_ROOT
+
+%changelog
+* Fri Sep 04 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.12.0-1
+- Update version to 0.12.0
+
+* Thu Aug 27 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.11.1-1
+- Update version to 0.11.1
+
+* Fri Aug 21 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.11.0-1
+- Update version to 0.11.0
+
+* Wed Aug 12 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.10.1-1
+- Update version to 0.10.1
+
+* Fri Aug 07 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.10.0-1
+- Update version to 0.10.0
+
+* Fri Jul 24 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.9.0-1
+- Update version to 0.9.0
+
+* Fri Jul 10 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.8.0-1
+- Update version to 0.8.0
+
+* Thu Jul 02 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.7.1-1
+- Update version to 0.7.1
+
+* Fri Jun 26 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.7.0-1
+- Update version to 0.7.0
+
+* Fri Jun 05 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.6.0-1
+- Update version to 0.6.0
+
+* Fri May 22 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.5.0-1
+- Update version to 0.5.0
+
+* Wed May 13 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.4.1-1
+- Update version to 0.4.1
+
+* Sat May 09 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.4.0-1
+- Update version to 0.4.0
+
+* Sun Apr 26 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.3.0-1
+- Update version to 0.3.0
+
+* Mon Mar 23 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.0.8-1
+- Disable brp-mangle-shebangs to preserve #!/usr/bin/env bash for cross-platform compatibility
+
+* Fri Mar 20 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.0.7-1
+- Add defattr and attr in files section for permission protection
+- Fix install section: add explicit permission settings for directories and files
+- Use install -d -m 0755 instead of mkdir -p for deterministic permissions
+- Set executable permissions (0755) for .sh and .py scripts
+- Set read-only permissions (0644) for other files
+- Add build-time skill signing using sign-skill.sh
+
+* Fri Mar 20 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.0.6-1
+- Change skill install path to /usr/share/anolisa/skills/agent-sec-core
+
+* Thu Mar 19 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.0.5-1
+- Add linux-sandbox module
+
+* Thu Mar 19 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.0.4-1
+- Refactor: move test files from scripts/asset-verify/test/ to /tests/
+- scripts/ directory now contains only production files
+- Add asset-verify dependencies version (python3 >= 3.6, gnupg2 >= 2.0, python3-pgpy >= 0.5)
+
+* Tue Mar 17 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.0.3-1
+- Fix spec install section: use cp -r for recursive directory copy
+- Add asset-verify dependencies (python3, gnupg2, python3-pgpy)
+
+* Mon Mar 16 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.0.2-1
+- Add loongshield security hardening capability
+
+* Fri Mar 13 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.0.1-1
+- Initial package

--- a/src/agent-sec-core/docs/design/DAEMON_PROCESS_DEPLOYMENT_CONTRACT_zh.md
+++ b/src/agent-sec-core/docs/design/DAEMON_PROCESS_DEPLOYMENT_CONTRACT_zh.md
@@ -217,11 +217,12 @@ operator-visible semantics 必须进入 compatibility/change record。journald �
 
 ### 8.1 **[TARGET V2][PARTIAL]** 当前 Rust transport bring-up
 
-`v2/apps/asc-daemon` 当前提供可执行的前台 Rust binary 和 composition bootstrap。它接受
-无子命令或显式 `serve` 两种形式，要求通过 `--socket` 提供绝对路径，安装 SIGTERM/SIGINT
-cooperative shutdown，并消费 SIGHUP 而不 reload。bootstrap 使用
-`asc-daemon-service` 完成真实 UDS bind、bounded admission、单请求 frame 读取、drain 和同
-inode socket cleanup。
+`v2/apps/asc-daemon` 当前提供对外名为 `agent-sec-daemon` 的前台 Rust binary 和
+composition bootstrap。它接受无子命令或显式 `serve` 两种形式；`--socket` 可提供显式绝对
+路径，省略时沿用 V1 service 契约，从 `$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock` 解析
+兼容路径。进程安装 SIGTERM/SIGINT cooperative shutdown，并消费 SIGHUP 而不 reload。
+bootstrap 使用 `asc-daemon-service` 完成真实 UDS bind、bounded admission、单请求 frame
+读取、drain 和同 inode socket cleanup。
 
 transport 对 frame read、application dispatch、transport rejection encode、response
 write 和 drain 分别设置显式 deadline。dispatch deadline 到期会释放 connection admission
@@ -249,8 +250,9 @@ Busy、timeout、shutdown 等 transport failure 由独立且有短 deadline 的
 framework 不能证明具体 PAP/Repository 内部没有全局 mutex、长 transaction 或其它共享阻塞
 点；该项必须由 PAP direct-consumer concurrency fixture 在集成时验收。
 
-当前还未实现 packaging-owned system socket 默认值、runtime directory hardening、Host
-singleton/stale-socket 判定、日志/OTel 和 health readiness。因此这一 slice 提供
+当前仅实现了兼容 V1 user service 的 `$XDG_RUNTIME_DIR` socket 默认值，尚未实现目标态的
+packaging-owned system socket 默认值、runtime directory hardening、Host singleton/stale-socket
+判定、日志/OTel 和 health readiness。因此这一 slice 提供
 DPROC-002/DPROC-003 的 focused process evidence，以及 DPROC-013 中 binary + UDS protocol
 注册、server-side permission 和 signal cleanup 的部分证据；它不能宣称 DPROC-012、完整
 DPROC-013、DPROC-014 或 production process gate 已完成。

--- a/src/agent-sec-core/scripts/bump-version.sh
+++ b/src/agent-sec-core/scripts/bump-version.sh
@@ -22,7 +22,8 @@
 #  10. codex-plugin/hooks-plugin/.codex-plugin/plugin.json ("version" field)
 #  11. qoder-plugin/.qoder-plugin/plugin.json ("version" field)
 #  12. qwen-code-extension/qwen-extension.json ("version" field)
-#  13. Lock files: Cargo.lock, uv.lock, package-lock.json (auto-regenerated)
+#  13. v2/Cargo.toml                         (workspace.package.version)
+#  14. Lock files: Cargo.lock, v2/Cargo.lock, uv.lock, package-lock.json (auto-regenerated)
 #
 # Manual update required (not automated):
 #   - agent-sec-core.spec.in  (%changelog entry)
@@ -228,7 +229,18 @@ bump_file "$PROJECT_ROOT/qwen-code-extension/qwen-extension.json" \
     "qwen-code-extension/qwen-extension.json"
 
 # -----------------------------------------------------------------------------
-# 13. Regenerate lock files
+# 13. v2/Cargo.toml
+#
+# The V2 Rust workspace owns its own version source; it is kept in lockstep with
+# the V1 one so a single bump produces one coherent release across both trees.
+# -----------------------------------------------------------------------------
+bump_file "$PROJECT_ROOT/v2/Cargo.toml" \
+    "^version = \"$OLD_VERSION\"" \
+    "version = \"$NEW_VERSION\"" \
+    "v2/Cargo.toml"
+
+# -----------------------------------------------------------------------------
+# 14. Regenerate lock files
 # -----------------------------------------------------------------------------
 log "Regenerating lock files..."
 
@@ -241,6 +253,13 @@ if command -v cargo &>/dev/null; then
         fi
     )
     ok "agent-sec-cli/Cargo.lock"
+    (
+        cd "$PROJECT_ROOT/v2"
+        if ! cargo update --workspace 2>/dev/null; then
+            cargo generate-lockfile 2>/dev/null
+        fi
+    )
+    ok "v2/Cargo.lock"
 else
     warn "cargo not found, skipping Cargo.lock update"
 fi

--- a/src/agent-sec-core/tests/v2/e2e/conftest.py
+++ b/src/agent-sec-core/tests/v2/e2e/conftest.py
@@ -1,0 +1,201 @@
+"""Shared fixtures for the V2 policy-CLI end-to-end suite.
+
+These tests drive the real ``agent-sec-cli`` and ``agent-sec-daemon`` binaries over a
+Unix domain socket, so they only make sense against an RPM-installed
+environment where both binaries are on ``PATH``. A missing binary fails the run
+instead of skipping it: skipping would let a broken package slip through the
+gate silently.
+
+The suite lives under ``tests/v2/`` rather than ``tests/e2e/`` so the V1
+``test-e2e-rpm`` target (which globs ``tests/e2e/``) never collects it.
+"""
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+CLI_BIN = "agent-sec-cli"
+DAEMON_BIN = "agent-sec-daemon"
+
+# The socket appears shortly after the daemon binds; five seconds is generous
+# for a cold binary start under container I/O without masking a real hang.
+_SOCKET_WAIT_SECONDS = 5.0
+# SIGTERM is cooperative: the daemon drains in-flight work before unlinking the
+# socket, so allow a small margin beyond the daemon's own drain timeout.
+_SHUTDOWN_WAIT_SECONDS = 5.0
+_POLL_INTERVAL = 0.02
+
+
+def _require(binary: str) -> str:
+    """Resolves an executable on PATH, failing the test if it is absent."""
+    resolved = shutil.which(binary)
+    if resolved is None:
+        pytest.fail(
+            f"{binary} not found on PATH; install the agent-sec-core V2 RPM "
+            "before running the V2 e2e suite"
+        )
+    return resolved
+
+
+def run_agent_sec_cli(
+    *args: str,
+    timeout: float = 30.0,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess:
+    """Runs ``agent-sec-cli`` with the given argv and no implicit ``--socket``.
+
+    Used by cases that must not reach a daemon (``--help`` / ``--version`` and
+    usage errors), where injecting a socket would change the parse outcome.
+    """
+    return subprocess.run(
+        [_require(CLI_BIN), *args],
+        capture_output=True,
+        text=True,
+        input=input_text,
+        timeout=timeout,
+        check=False,
+    )
+
+
+class DaemonHandle:
+    """A running ``agent-sec-daemon`` process bound to a known socket path."""
+
+    def __init__(self, process: subprocess.Popen, socket_path: Path) -> None:
+        self.process = process
+        self.socket_path = socket_path
+
+    def cli(self, *args: str, timeout: float = 30.0) -> subprocess.CompletedProcess:
+        """Invokes ``agent-sec-cli --socket <this daemon> <args>``."""
+        return subprocess.run(
+            [_require(CLI_BIN), "--socket", str(self.socket_path), *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+
+    def request(self, *args: str, timeout: float = 30.0) -> dict:
+        """Runs a CLI command expected to succeed and returns parsed stdout JSON."""
+        result = self.cli(*args, timeout=timeout)
+        assert (
+            result.returncode == 0
+        ), f"agent-sec-cli {args} failed (rc={result.returncode}): {result.stderr}"
+        assert result.stderr == "", f"unexpected stderr for {args}: {result.stderr}"
+        return json.loads(result.stdout)
+
+
+def _start_daemon(socket_path: Path, admin_uids: list[int]) -> subprocess.Popen:
+    """Starts a foreground daemon and waits for its socket to appear."""
+    argv = [_require(DAEMON_BIN), "--socket", str(socket_path)]
+    for uid in admin_uids:
+        argv += ["--policy-admin-uid", str(uid)]
+    process = subprocess.Popen(
+        argv,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + _SOCKET_WAIT_SECONDS
+    while time.monotonic() < deadline:
+        if socket_path.exists():
+            return process
+        if process.poll() is not None:
+            _, stderr = process.communicate()
+            raise AssertionError(
+                f"agent-sec-daemon exited early (rc={process.returncode}): {stderr}"
+            )
+        time.sleep(_POLL_INTERVAL)
+    stderr = _terminate(process)
+    raise AssertionError(f"agent-sec-daemon did not create {socket_path}: {stderr}")
+
+
+def _terminate(process: subprocess.Popen) -> str:
+    """Sends SIGTERM, waits for cooperative exit, returns captured stderr."""
+    if process.poll() is None:
+        process.send_signal(signal.SIGTERM)
+    try:
+        _, stderr = process.communicate(timeout=_SHUTDOWN_WAIT_SECONDS)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        _, stderr = process.communicate()
+        raise AssertionError("agent-sec-daemon did not exit within the shutdown window")
+    return stderr or ""
+
+
+@pytest.fixture
+def cli():
+    """Returns a runner for ``agent-sec-cli`` with no implicit ``--socket``."""
+    return run_agent_sec_cli
+
+
+@pytest.fixture
+def daemon_bin() -> str:
+    """Resolves ``agent-sec-daemon``, failing if the RPM is not installed."""
+    return _require(DAEMON_BIN)
+
+
+@pytest.fixture
+def start_daemon(tmp_path: Path):
+    """Returns a factory that starts a daemon and tears it down after the test.
+
+    The factory does not assert on shutdown; tests that care about cooperative
+    exit and socket cleanup drive SIGTERM themselves."""
+    started: list[subprocess.Popen] = []
+
+    def _factory(
+        admin_uids: list[int] | None = None, name: str = "daemon.sock"
+    ) -> DaemonHandle:
+        socket_path = tmp_path / name
+        uids = admin_uids if admin_uids is not None else [os.getuid()]
+        process = _start_daemon(socket_path, uids)
+        started.append(process)
+        return DaemonHandle(process, socket_path)
+
+    yield _factory
+    for process in started:
+        _terminate(process)
+
+
+@pytest.fixture
+def daemon(tmp_path: Path):
+    """Yields an authorized daemon: the current uid is a policy administrator.
+
+    Teardown asserts cooperative shutdown — the process must exit on SIGTERM and
+    unlink its own socket.
+    """
+    socket_path = tmp_path / "daemon.sock"
+    process = _start_daemon(socket_path, [os.getuid()])
+    handle = DaemonHandle(process, socket_path)
+    try:
+        yield handle
+    finally:
+        _terminate(process)
+        assert process.returncode is not None
+        assert not socket_path.exists(), "daemon left its socket behind on shutdown"
+
+
+@pytest.fixture
+def unauthorized_daemon(tmp_path: Path):
+    """Yields a daemon whose admin set excludes the caller.
+
+    Only root is authorized, so a non-root caller acts as a plain local user.
+    Root is unconditionally authorized by design, so this scenario is
+    unreachable when the suite itself runs as root.
+    """
+    if os.getuid() == 0:
+        pytest.skip(
+            "root is unconditionally authorized; cannot exercise denial as root"
+        )
+    socket_path = tmp_path / "daemon.sock"
+    process = _start_daemon(socket_path, [])
+    handle = DaemonHandle(process, socket_path)
+    try:
+        yield handle
+    finally:
+        _terminate(process)

--- a/src/agent-sec-core/tests/v2/e2e/test_daemon_process_e2e.py
+++ b/src/agent-sec-core/tests/v2/e2e/test_daemon_process_e2e.py
@@ -1,0 +1,74 @@
+"""Daemon process contract: socket permissions, shutdown, and argument guards.
+
+These checks are about the ``agent-sec-daemon`` process itself rather than the PAP
+methods it serves: the bound socket must be private (0600), SIGTERM must trigger
+a cooperative exit that unlinks the socket, and the V1 systemd invocation must
+resolve its socket below ``XDG_RUNTIME_DIR``.
+"""
+
+import os
+import signal
+import stat
+import subprocess
+import time
+
+
+def test_bound_socket_is_private(daemon):
+    mode = stat.S_IMODE(os.stat(daemon.socket_path).st_mode)
+    assert mode == 0o600, f"socket mode is {oct(mode)}, expected 0o600"
+
+
+def test_sigterm_cooperatively_exits_and_removes_socket(start_daemon):
+    handle = start_daemon()
+    socket_path = handle.socket_path
+    assert socket_path.exists()
+    socket_inode = os.stat(socket_path).st_ino
+
+    handle.process.send_signal(signal.SIGTERM)
+    handle.process.communicate(timeout=5.0)
+
+    assert handle.process.returncode == 0
+    # The daemon owns its socket and unlinks exactly the inode it bound.
+    assert not socket_path.exists(), f"socket inode {socket_inode} was left behind"
+
+
+def test_v1_service_invocation_uses_runtime_socket(daemon_bin, tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    socket_path = runtime_dir / "agent-sec-core" / "daemon.sock"
+    socket_path.parent.mkdir(parents=True)
+    environment = os.environ.copy()
+    environment["XDG_RUNTIME_DIR"] = str(runtime_dir)
+    process = subprocess.Popen(
+        [daemon_bin, "serve", "--policy-admin-uid", str(os.getuid())],
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 5.0
+    try:
+        while time.monotonic() < deadline and not socket_path.exists():
+            assert process.poll() is None, process.communicate()[1]
+            time.sleep(0.02)
+        assert socket_path.exists()
+    finally:
+        if process.poll() is None:
+            process.send_signal(signal.SIGTERM)
+        process.communicate(timeout=5.0)
+    assert process.returncode == 0
+    assert not socket_path.exists()
+
+
+def test_missing_socket_and_runtime_directory_fails(daemon_bin):
+    environment = os.environ.copy()
+    environment.pop("XDG_RUNTIME_DIR", None)
+    result = subprocess.run(
+        [daemon_bin],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=10.0,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert result.stderr != ""

--- a/src/agent-sec-core/tests/v2/e2e/test_policy_cli_e2e.py
+++ b/src/agent-sec-core/tests/v2/e2e/test_policy_cli_e2e.py
@@ -1,0 +1,132 @@
+"""End-to-end CRUD coverage for all 15 PAP commands over a real UDS daemon.
+
+Each command is issued by the real ``agent-sec-cli`` process against a real
+``agent-sec-daemon`` process; nothing is mocked. The flow mirrors the frozen wire
+scenario the Rust suite exercises in-process
+(``asc-daemon-protocol/tests/fixtures/pap-crud-e2e.json``): create, then update
+policy/scope/binding to a second revision, read them back, list them, and
+finally delete. The daemon keeps process-local state and has no reconciler, so
+a deleted binding reports ``PENDING_DELETE`` rather than a terminal state.
+"""
+
+import json
+from pathlib import Path
+
+
+def test_help_and_version_do_not_require_a_daemon(cli):
+    # --help / --version resolve entirely in the parser; no socket, no daemon.
+    for flag in ("--help", "--version"):
+        result = cli(flag)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout != ""
+
+
+def _write_template(tmp_path: Path, name: str, files: list[str]) -> str:
+    """Writes a prevent_file_deletion policy template and returns its path."""
+    path = tmp_path / name
+    path.write_text(json.dumps({"kind": "prevent_file_deletion", "files": files}))
+    return str(path)
+
+
+def test_full_pap_crud_across_all_fifteen_commands(daemon, tmp_path):
+    template_v1 = _write_template(
+        tmp_path, "policy-v1.json", ["/workspace/important/**"]
+    )
+    template_v2 = _write_template(tmp_path, "policy-v2.json", ["/srv/data"])
+
+    # --- create (policy, scope, binding) ---
+    policy = daemon.request(
+        "policy", "create", "--name", "protect-important-files", "--file", template_v1
+    )
+    policy_id = policy["policyId"]
+    assert policy["revision"] == 1
+
+    scope = daemon.request("scope", "create", "--pid", "4242")
+    scope_id = scope["scopeId"]
+    assert scope["revision"] == 1
+
+    binding = daemon.request(
+        "binding",
+        "create",
+        "--policy-id",
+        policy_id,
+        "--policy-revision",
+        "1",
+        "--scope-id",
+        scope_id,
+        "--scope-revision",
+        "1",
+    )
+    binding_id = binding["spec"]["bindingId"]
+    assert binding["status"] == "PENDING_APPLY"
+    # The three resources are distinct identifiers, never aliased.
+    assert len({policy_id, scope_id, binding_id}) == 3
+
+    # --- update to a second revision ---
+    updated_policy = daemon.request(
+        "policy",
+        "update",
+        "--policy-id",
+        policy_id,
+        "--name",
+        "protect-v2",
+        "--file",
+        template_v2,
+    )
+    assert updated_policy["revision"] == 2
+    policy_revision = updated_policy["revision"]
+
+    updated_scope = daemon.request(
+        "scope", "update", "--scope-id", scope_id, "--cgroup-id", "99"
+    )
+    assert updated_scope["revision"] == 2
+    scope_revision = updated_scope["revision"]
+
+    updated_binding = daemon.request(
+        "binding",
+        "update",
+        "--binding-id",
+        binding_id,
+        "--policy-id",
+        policy_id,
+        "--policy-revision",
+        str(policy_revision),
+        "--scope-id",
+        scope_id,
+        "--scope-revision",
+        str(scope_revision),
+    )
+    assert updated_binding["spec"]["bindingId"] == binding_id
+
+    # --- get (reads the current revision) ---
+    got_policy = daemon.request(
+        "policy", "get", "--policy-id", policy_id, "--revision", str(policy_revision)
+    )
+    assert got_policy["policyId"] == policy_id
+    got_scope = daemon.request(
+        "scope", "get", "--scope-id", scope_id, "--revision", str(scope_revision)
+    )
+    assert got_scope["scopeId"] == scope_id
+    got_binding = daemon.request("binding", "get", "--binding-id", binding_id)
+    assert got_binding["spec"]["bindingId"] == binding_id
+
+    # --- list (paginated envelope {items, total}) ---
+    for resource in ("policy", "scope", "binding"):
+        listing = daemon.request(resource, "list", "--limit", "10", "--offset", "0")
+        assert set(listing) == {"items", "total"}
+        assert listing["total"] == 1
+        assert len(listing["items"]) == 1
+
+    # --- delete ---
+    deleted_binding = daemon.request("binding", "delete", "--binding-id", binding_id)
+    # No reconciler yet: deletion is requested, not enforced.
+    assert deleted_binding["status"] == "PENDING_DELETE"
+
+    deleted_policy = daemon.request(
+        "policy", "delete", "--policy-id", policy_id, "--revision", str(policy_revision)
+    )
+    assert deleted_policy["policyId"] == policy_id
+    deleted_scope = daemon.request(
+        "scope", "delete", "--scope-id", scope_id, "--revision", str(scope_revision)
+    )
+    assert deleted_scope["scopeId"] == scope_id

--- a/src/agent-sec-core/tests/v2/e2e/test_policy_cli_errors_e2e.py
+++ b/src/agent-sec-core/tests/v2/e2e/test_policy_cli_errors_e2e.py
@@ -1,0 +1,49 @@
+"""Failure-path coverage: transport errors, usage errors, and authorization.
+
+The CLI exit-code contract is exercised end to end:
+
+* a daemon error envelope goes to stderr with exit code 1;
+* a transport failure (no daemon listening) exits 1 with a diagnostic on
+  stderr and nothing on stdout;
+* a usage error (bad or missing arguments) exits 2 without touching a daemon;
+* an unauthorized caller receives the daemon's ``permission_denied`` envelope.
+"""
+
+import json
+
+
+def test_transport_failure_when_daemon_absent(cli, tmp_path):
+    missing = tmp_path / "absent.sock"
+    result = cli("--socket", str(missing), "policy", "list")
+    # Connect failure is a local/transport error, not a daemon envelope.
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert result.stderr != ""
+
+
+def test_usage_errors_exit_two_without_a_daemon(cli):
+    usage_cases = [
+        # Missing required --socket.
+        ("policy", "list"),
+        # --socket must be absolute.
+        ("--socket", "relative.sock", "policy", "list"),
+        # Repeated --socket at different levels is ambiguous.
+        ("--socket", "/run/a.sock", "policy", "list", "--socket", "/run/b.sock"),
+        # --timeout-ms below the accepted range.
+        ("--socket", "/run/a.sock", "--timeout-ms", "0", "policy", "list"),
+    ]
+    for case in usage_cases:
+        result = cli(*case)
+        assert (
+            result.returncode == 2
+        ), f"{case} -> rc={result.returncode}: {result.stderr}"
+
+
+def test_unauthorized_caller_gets_permission_denied(unauthorized_daemon):
+    result = unauthorized_daemon.cli("policy", "list", "--limit", "10", "--offset", "0")
+    assert result.returncode == 1
+    assert result.stdout == ""
+    envelope = json.loads(result.stderr)
+    assert envelope["error"]["code"] == "permission_denied"
+    assert envelope["error"]["message"] != ""
+    assert envelope["requestId"]

--- a/src/agent-sec-core/v2/Cargo.lock
+++ b/src/agent-sec-core/v2/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "asc-agentsight-client"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "asc-policy-target-contracts",
  "asc-policy-types",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "asc-cli"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "asc-daemon",
  "asc-daemon-client",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "asc-daemon"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "asc-daemon-core",
  "asc-daemon-handler",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "asc-daemon-client"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "asc-daemon-protocol",
  "serde_json",
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "asc-daemon-core"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "asc-foundation-types",
  "asc-pap",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "asc-daemon-handler"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "asc-daemon-core",
  "asc-daemon-protocol",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "asc-daemon-protocol"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "asc-foundation-types",
  "asc-policy-types",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "asc-daemon-service"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "thiserror",
  "tokio",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "asc-foundation-types"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "asc-pap"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "asc-foundation-types",
  "asc-pap-repository-memory",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "asc-pap-repository-memory"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "asc-foundation-types",
  "asc-pap",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "asc-pcp"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "asc-agentsight-client",
  "asc-foundation-types",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "asc-policy-adapter-agentsight"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "asc-policy-types",
  "serde",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "asc-policy-engine"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "asc-foundation-types",
  "asc-pap",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "asc-policy-repository"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "asc-foundation-types",
  "asc-policy-types",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "asc-policy-target-contracts"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "asc-policy-types",
  "serde_json",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "asc-policy-types"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
  "asc-foundation-types",
  "serde",

--- a/src/agent-sec-core/v2/Cargo.toml
+++ b/src/agent-sec-core/v2/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.12.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/agent-sec-core/v2/apps/asc-daemon/Cargo.toml
+++ b/src/agent-sec-core/v2/apps/asc-daemon/Cargo.toml
@@ -8,6 +8,10 @@ rust-version.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[[bin]]
+name = "agent-sec-daemon"
+path = "src/main.rs"
+
 [dependencies]
 asc-daemon-core = { workspace = true }
 asc-daemon-handler = { workspace = true }

--- a/src/agent-sec-core/v2/apps/asc-daemon/src/cli.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/src/cli.rs
@@ -5,9 +5,10 @@ use std::path::PathBuf;
 
 use crate::BootstrapConfig;
 
-const HELP: &str = "Usage: asc-daemon [serve] --socket <ABSOLUTE_PATH> [--policy-admin-uid <UID>]...\n\
+const HELP: &str = "Usage: agent-sec-daemon [serve] [--socket <ABSOLUTE_PATH>] [--policy-admin-uid <UID>]...\n\
 \n\
 Runs the AgentSecCore V2 UDS service with PAP administration methods.\n\
+Without --socket, uses $XDG_RUNTIME_DIR/agent-sec-core/daemon.sock.\n\
 Root is always authorized. --policy-admin-uid adds an administrator at startup.\n\
 Repeat this option for multiple UIDs; omitted means root only.\n\
 PAP state is process-local until durable Repository integration lands.\n";
@@ -33,14 +34,25 @@ pub enum ParseOutcome {
 impl Cli {
     /// Parses an argv sequence including the binary name.
     ///
-    /// Both `asc-daemon --socket ...` and `asc-daemon serve --socket ...` are
-    /// accepted so the foreground entrypoint can be exercised independently
-    /// without selecting a packaging-owned default path.
+    /// Accepts both direct and explicit `serve` forms. When `--socket` is
+    /// omitted, the V1-compatible systemd contract resolves the endpoint below
+    /// `$XDG_RUNTIME_DIR`; explicit paths remain available for tests and tools.
     ///
     /// # Errors
     /// Returns a stable parse error for a missing value, unknown option, repeated
-    /// socket, invalid administrator UID, non-Unicode option, or absent socket path.
+    /// socket, invalid administrator UID, non-Unicode option, or invalid runtime path.
     pub fn parse_from<I, T>(arguments: I) -> Result<ParseOutcome, CliError>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString>,
+    {
+        Self::parse_from_with_runtime_dir(arguments, std::env::var_os("XDG_RUNTIME_DIR"))
+    }
+
+    fn parse_from_with_runtime_dir<I, T>(
+        arguments: I,
+        runtime_dir: Option<OsString>,
+    ) -> Result<ParseOutcome, CliError>
     where
         I: IntoIterator<Item = T>,
         T: Into<OsString>,
@@ -97,7 +109,18 @@ impl Cli {
             return Err(CliError::UnknownArgument(rendered));
         }
 
-        let socket_path = socket_path.ok_or(CliError::MissingSocket)?;
+        let socket_path = if let Some(path) = socket_path {
+            path
+        } else {
+            let runtime_dir = runtime_dir
+                .filter(|path| !path.is_empty())
+                .ok_or(CliError::MissingSocketAndRuntimeDirectory)?;
+            let runtime_dir = PathBuf::from(runtime_dir);
+            if !runtime_dir.is_absolute() {
+                return Err(CliError::RelativeRuntimeDirectory);
+            }
+            runtime_dir.join("agent-sec-core").join("daemon.sock")
+        };
         if !socket_path.is_absolute() {
             return Err(CliError::RelativeSocket);
         }
@@ -117,9 +140,12 @@ pub enum CliError {
     /// Kernel UIDs are unsigned 32-bit decimal values.
     #[error("--policy-admin-uid must be a decimal integer between 0 and 4294967295")]
     InvalidAdminUid,
-    /// A socket path is required until packaging freezes a system-owned default.
-    #[error("--socket <ABSOLUTE_PATH> is required")]
-    MissingSocket,
+    /// Neither an explicit socket nor the V1-compatible runtime root is available.
+    #[error("--socket <ABSOLUTE_PATH> or XDG_RUNTIME_DIR is required")]
+    MissingSocketAndRuntimeDirectory,
+    /// The inherited runtime root cannot safely form an absolute socket path.
+    #[error("XDG_RUNTIME_DIR must be an absolute path")]
+    RelativeRuntimeDirectory,
     /// `--socket` was not followed by a value.
     #[error("--socket requires a value")]
     MissingSocketValue,
@@ -140,31 +166,57 @@ mod tests {
 
     #[test]
     fn no_subcommand_and_serve_select_the_same_foreground_process() {
-        let direct = Cli::parse_from(["asc-daemon", "--socket", "/run/asc/daemon.sock"]);
-        let explicit = Cli::parse_from(["asc-daemon", "serve", "--socket", "/run/asc/daemon.sock"]);
+        let direct = Cli::parse_from(["agent-sec-daemon", "--socket", "/run/asc/daemon.sock"]);
+        let explicit = Cli::parse_from([
+            "agent-sec-daemon",
+            "serve",
+            "--socket",
+            "/run/asc/daemon.sock",
+        ]);
 
         assert_eq!(direct, explicit);
         assert!(matches!(direct, Ok(ParseOutcome::Serve(_))));
     }
 
     #[test]
-    fn socket_is_explicit_absolute_and_unambiguous() {
+    fn socket_uses_the_v1_runtime_default_or_an_explicit_absolute_path() {
+        let ParseOutcome::Serve(default) = Cli::parse_from_with_runtime_dir(
+            ["agent-sec-daemon", "serve"],
+            Some(OsString::from("/run/user/1000")),
+        )
+        .unwrap() else {
+            panic!("expected daemon invocation");
+        };
         assert_eq!(
-            Cli::parse_from(["asc-daemon"]),
-            Err(CliError::MissingSocket)
+            default.bootstrap.socket_path,
+            PathBuf::from("/run/user/1000/agent-sec-core/daemon.sock")
         );
         assert_eq!(
-            Cli::parse_from(["asc-daemon", "--socket", "daemon.sock"]),
+            Cli::parse_from_with_runtime_dir(["agent-sec-daemon"], None),
+            Err(CliError::MissingSocketAndRuntimeDirectory)
+        );
+        assert_eq!(
+            Cli::parse_from_with_runtime_dir(
+                ["agent-sec-daemon"],
+                Some(OsString::from("relative")),
+            ),
+            Err(CliError::RelativeRuntimeDirectory)
+        );
+        assert_eq!(
+            Cli::parse_from_with_runtime_dir(["agent-sec-daemon", "--socket", "daemon.sock"], None,),
             Err(CliError::RelativeSocket)
         );
         assert_eq!(
-            Cli::parse_from([
-                "asc-daemon",
-                "--socket",
-                "/run/one.sock",
-                "--socket",
-                "/run/two.sock",
-            ]),
+            Cli::parse_from_with_runtime_dir(
+                [
+                    "agent-sec-daemon",
+                    "--socket",
+                    "/run/one.sock",
+                    "--socket",
+                    "/run/two.sock",
+                ],
+                None,
+            ),
             Err(CliError::RepeatedSocket)
         );
     }
@@ -172,13 +224,13 @@ mod tests {
     #[test]
     fn administrator_uids_are_explicit_repeatable_and_bounded() {
         let ParseOutcome::Serve(default) =
-            Cli::parse_from(["asc-daemon", "--socket", "/run/asc.sock"]).unwrap()
+            Cli::parse_from(["agent-sec-daemon", "--socket", "/run/asc.sock"]).unwrap()
         else {
             panic!("expected daemon invocation");
         };
         assert!(default.policy_admin_uids.is_empty());
         let ParseOutcome::Serve(configured) = Cli::parse_from([
-            "asc-daemon",
+            "agent-sec-daemon",
             "serve",
             "--socket",
             "/run/asc.sock",
@@ -199,7 +251,7 @@ mod tests {
         for value in ["", "-1", "+1", "4294967296", "root", "1,2", "--help"] {
             assert_eq!(
                 Cli::parse_from([
-                    "asc-daemon",
+                    "agent-sec-daemon",
                     "--socket",
                     "/run/asc.sock",
                     "--policy-admin-uid",
@@ -210,7 +262,7 @@ mod tests {
         }
         assert_eq!(
             Cli::parse_from([
-                "asc-daemon",
+                "agent-sec-daemon",
                 "--socket",
                 "/run/asc.sock",
                 "--policy-admin-uid",

--- a/src/agent-sec-core/v2/apps/asc-daemon/src/main.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/src/main.rs
@@ -26,7 +26,7 @@ async fn run() -> ExitCode {
     let outcome = match Cli::parse_from(std::env::args_os()) {
         Ok(outcome) => outcome,
         Err(problem) => {
-            eprintln!("asc-daemon: {problem}");
+            eprintln!("agent-sec-daemon: {problem}");
             return ExitCode::from(2);
         }
     };
@@ -41,7 +41,7 @@ async fn run() -> ExitCode {
     let signals = match ProcessSignals::install() {
         Ok(signals) => signals,
         Err(problem) => {
-            eprintln!("asc-daemon: {problem}");
+            eprintln!("agent-sec-daemon: {problem}");
             return ExitCode::FAILURE;
         }
     };
@@ -52,7 +52,7 @@ async fn run() -> ExitCode {
     ));
     let policy_for_handler: Arc<dyn PrincipalPolicy> = principal_policy.clone();
     let dispatcher = Arc::new(DaemonDispatcher::new(pap, policy_for_handler));
-    eprintln!("asc-daemon: warning: PAP state is process-local and is lost on restart");
+    eprintln!("agent-sec-daemon: warning: PAP state is process-local and is lost on restart");
 
     let shutdown = ShutdownToken::new();
     let signal_task = tokio::spawn(signals.request_shutdown(shutdown.clone()));
@@ -75,7 +75,7 @@ async fn run() -> ExitCode {
 }
 
 fn report_error(problem: &dyn std::error::Error) {
-    eprintln!("asc-daemon: {problem}");
+    eprintln!("agent-sec-daemon: {problem}");
     let mut source = problem.source();
     while let Some(cause) = source {
         eprintln!("  caused by: {cause}");

--- a/src/agent-sec-core/v2/apps/asc-daemon/tests/bootstrap.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/tests/bootstrap.rs
@@ -88,7 +88,7 @@ async fn run_binary_scenario(configure_admin: bool) {
     let directory = unique_directory();
     std::fs::create_dir(&directory).unwrap();
     let socket_path = directory.join("daemon.sock");
-    let mut command = Command::new(env!("CARGO_BIN_EXE_asc-daemon"));
+    let mut command = Command::new(env!("CARGO_BIN_EXE_agent-sec-daemon"));
     if configure_admin {
         let uid = std::fs::metadata(&directory).unwrap().uid();
         command.args(["--policy-admin-uid", &uid.to_string()]);


### PR DESCRIPTION
## Why

agent-sec-core V2 的 Rust CLI 与 daemon 已具备 PAP 基础能力，但此前没有任何门禁验证它们
在真实 RPM 安装态下的表现。缺少这一层验证，V2 的制品命名、子包依赖、systemd 契约和
CLI 与 daemon 的跨进程交互都只能靠源码测试间接推断。本 PR 补上以 RPM 安装结果为对象的
PR 门禁，同时不改变 V1 的任何构建与安装行为。

## What changed

**打包**

- 新增 `agent-sec-core.spec.v2.in`：保持与 V1 相同的 metapackage 与子包布局
  （`agent-sec-cli`、cosh/codex/qoder/openclaw/hermes/qwen-code hook、skills），
  `agent-sec-cli` 子包改为安装 Rust 二进制。对外制品名仍为 `agent-sec-cli` 和
  `agent-sec-daemon`，systemd user unit 与 V1 共用同一份。
- `scripts/rpm-build.sh` 新增 `agent-sec-core-v2` 目标，并抽出 `stage_sec_core_payload()`
  供 V1/V2 共用组件 payload；V2 tarball 以 `v2/` Rust workspace 替代 Python wheel 与两个
  wrapper 脚本。

**构建与安装目标**

- `Makefile` 新增 `build-cli-v2`、`install-cli-v2`、`build-all-v2`、
  `install-all-for-rpmbuild-v2`、`test-e2e-rpm-v2`。
- V1/V2 只在 CLI 一环不同，因此把共同的组件构建目标收敛到 `component_build_targets` 宏、
  共同的安装目标收敛到 `RPM_INSTALL_COMMON_TARGETS`，避免两条链路随组件增加而漂移；
  CLI 槽位位置保留，`build-all` 的前置依赖顺序与改动前一致。
- `bump-version.sh` 纳入 `v2/Cargo.toml` 与 `v2/Cargo.lock`，使一次 bump 同时覆盖两棵树。

**daemon 兼容现有部署契约**

- `asc-daemon` 显式声明 `[[bin]] name = "agent-sec-daemon"`，使二进制名不依赖 crate 名。
- `--socket` 省略时从 `$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock` 解析，以复用 V1
  user service；显式绝对路径保留给测试与工具。新增 `MissingSocketAndRuntimeDirectory`
  与 `RelativeRuntimeDirectory` 两个稳定解析错误，帮助文本与 stderr 前缀统一为
  `agent-sec-daemon`。
- 同步更新 daemon process deployment contract，说明当前只实现兼容 V1 的
  `$XDG_RUNTIME_DIR` 默认值，目标态的 packaging-owned system socket、runtime directory
  hardening 等仍未落地。

**E2E 测试**

- 新增 `tests/v2/e2e/`，全部以安装后的二进制为入口：
  - daemon 进程：socket 权限私有、SIGTERM 协作退出并清理 socket、V1 service 调用形态、
    缺少 socket 与 runtime directory 时的报错。
  - Policy / Scope / Binding 共 15 条命令的完整 CRUD。
  - 错误路径：daemon 缺失时的传输失败、用法错误退出码 2、非授权调用者 permission denied。
- `test-e2e-rpm-v2` 复用 V1 中已可在 V2 下通过的用例，其余 V1 用例**逐文件**忽略，每行注明
  它等待的 V2 能力；能力落地后逐行删除即可启用。刻意不使用目录级忽略，避免已迁移的覆盖被
  静默关闭。
- `test-python` 与 `test-python-coverage` 忽略 `tests/v2`，V2 E2E 只在装好 RPM 的环境运行。

**CI**

- `sec-core-rpmbuild.yaml` 新增 `build-rpm-v2` job，与 V1 的 `build-rpm` 并行（不设
  `needs`），任一失败即 PR 失败。
- 安装后校验 CLI、daemon、linux-sandbox、cosh extension、各 agent 插件、systemd unit 和
  component.toml，并断言 V1 Python site-packages 不存在；逐个 import 校验已安装的 hook 脚本。
- 运行 E2E 前把 V1 Python 源码移出 checkout（`trap` 保证恢复）、清空 `PYTHONPATH`，并断言
  `import agent_sec_cli` 必须失败，确保测试走的是二进制入口而非源码 import fallback。

## Related issue

no-issue: 为进行中的 agent-sec-core V2 迁移补充 RPM 安装态 CI 门禁。

## User / Agent impact

V1 的 RPM、anolisa CLI raw 安装和源码安装入口保持不变。V2 RPM 提供与 V1 同名的
`agent-sec-cli` 与 `agent-sec-daemon`，并复用现有 systemd user service，因此现有部署方式
无需调整。尚未迁移的 V1 能力测试被逐文件明确排除，不会被误认为已通过。

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

daemon 新增了默认 socket 解析路径，属行为扩展：原先必须显式传 `--socket`，现在省略时落到
`$XDG_RUNTIME_DIR` 下的 V1 兼容路径，显式路径语义不变。RPM 安装、systemd unit 和安全相关
E2E 全部进入并行门禁。V1 的 `build-all`、`install-all-for-rpmbuild`、`package-raw`、
`install-all` 经宏重构后展开结果与改动前一致。

## Validation

- upstream CI 全部通过：Docs、PR Lint、Components、sec-core Source Build、sec-core RPM Build。
  其中 `Build agent-sec-core V2 RPM` 完成 V2 RPM 构建、安装态校验和 V2 E2E。
- 本地 v2 workspace（Rust 1.93.1）：`cargo fmt --all -- --check`、
  `cargo build --release --locked --workspace` 通过。
- `v2/Cargo.lock` 相对 main 仅有 17 个 workspace crate 的版本号变化，第三方依赖固定版本
  逐项一致。
- 文档相对链接检查通过。

## Documentation and rollback

已更新 `docs/design/DAEMON_PROCESS_DEPLOYMENT_CONTRACT_zh.md`，记录 V2 daemon 对现有
service 与默认 socket 路径的兼容行为及其当前边界。回滚只需撤销本提交：并行 V2 job、
V2 spec、V2 构建/安装目标和 V2 E2E 一并移除，V1 构建与安装入口不受影响。
