### PR TITLE
feat(memory): consent opt-out and installer test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1032,6 +1032,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # scripts/install.sh talks to the openclaw CLI, which cargo cannot
+      # cover; the stub-based negotiation test needs no Node/npm and runs
+      # in ~1 s using only the runner's bash + make, so it precedes all
+      # toolchain setup — cheapest check fails fastest.
+      - name: Test OpenClaw adapter installer script
+        run: |
+          cd src/agent-memory
+          make test-openclaw-install
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: '1.89.0'

--- a/docs/user-guide/en/token-saving/agent-memory.md
+++ b/docs/user-guide/en/token-saving/agent-memory.md
@@ -115,7 +115,17 @@ anolisa adapter status agent-memory
 
 **Prerequisite**: `openclaw` CLI on `$PATH`. The script logs clearly and exits 0 if missing — rerun after installing OpenClaw. `yum remove agent-memory` triggers `%preun` to call the uninstall script, leaving no orphaned config.
 
-Running `anolisa adapter enable agent-memory openclaw` or the agent-memory OpenClaw `install.sh` accepts the plugin's declared capabilities. Both entry points pass `--accept-capabilities` only when `plugins install --help` advertises that exact option, so older hosts keep working.
+Running `anolisa adapter enable agent-memory openclaw` or the agent-memory OpenClaw `install.sh` accepts the plugin's declared capabilities. Both entry points pass `--accept-capabilities` only when `plugins install --help` advertises that exact option, so older hosts keep working. Set `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` when running `install.sh` to withhold consent — gating hosts then reject the install until you grant it yourself, e.g. via an interactive `openclaw plugins install`.
+
+Install-time environment variables (runtime `MEMORY_*` variables are listed separately under Environment variables):
+
+| Variable | Default | Effect |
+|---|---|---|
+| `AGENT_MEMORY_ACCEPT_CAPABILITIES` | accept | `1`/`true`/`yes`/`on` grant consent when the host advertises the flag; `0`/`false`/`no`/`off` withhold it, so gating hosts reject the install; any other value aborts with an error (exit code 2) before install |
+| `AGENT_MEMORY_SAFE_INSTALL` | unset | `1` omits `--dangerously-force-unsafe-install` from the install call |
+| `OPENCLAW_BIN` | `openclaw` | openclaw CLI binary to invoke |
+| `OPENCLAW_STATE_DIR` | `~/.openclaw` | state directory passed to every openclaw CLI invocation |
+| `OPENCLAW_HOME` | `~/.openclaw` | default for `OPENCLAW_STATE_DIR` only; never passed to the CLI (unset for every call) |
 
 Plugin contract ↔ agent-memory MCP tool mapping:
 
@@ -592,7 +602,7 @@ RUST_LOG=agent_memory=debug agent-memory
 | search misses just-written content | inside the 200 ms debounce window | retry, or use `mem_grep` (regex on the filesystem, no index) |
 | `mem_promote` reports `session not found` | `MEMORY_SESSION_ID`/`MEMORY_SESSION_DIR` unset or scratch missing | see Promote workflow |
 | OpenClaw plugin not loaded | `openclaw` CLI not on PATH | rerun `install.sh` after installing OpenClaw |
-| install.sh reports `Plugin "memory-anolisa" requires capability consent` | OpenClaw >= 2026.8.1 consent gate; installer-options probe failed, or script predates the fix | check install output for the probe WARNING line; update agent-memory, or run `openclaw plugins install <plugin-dir> --force --accept-capabilities` manually |
+| install.sh reports `Plugin "memory-anolisa" requires capability consent` | OpenClaw >= 2026.8.1 consent gate; installer-options probe failed, `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` is set, or script predates the fix | check install output for the probe WARNING or opt-out refusal line; update agent-memory, unset the opt-out, or run `openclaw plugins install <plugin-dir> --force --accept-capabilities` manually. A withheld install rejected by the gate exits with code 3; if OpenClaw rewords the rejection message, the script falls back to exit 1 with the opt-out note |
 | system state out of sync after manual dnf | — | `sudo anolisa --install-mode system repair agent-memory`; use system-scoped `forget` / `adopt` only when intentionally rebuilding the record for a present RPM |
 
 For deeper investigation: start with `RUST_LOG=agent_memory=debug` and inspect both stderr and `<mount>/.anolisa/audit.log`.

--- a/docs/user-guide/zh/token-saving/agent-memory.md
+++ b/docs/user-guide/zh/token-saving/agent-memory.md
@@ -114,7 +114,17 @@ anolisa adapter status agent-memory
 
 **前置条件**：`openclaw` CLI 在 `$PATH` 上。脚本缺失时输出明确日志并以 0 退出，安装 OpenClaw 后重跑即可。`yum remove agent-memory` 时 spec 的 `%preun` 自动调用 uninstall 脚本，配置不残留孤立项。
 
-执行 `anolisa adapter enable agent-memory openclaw` 或 agent-memory 的 OpenClaw `install.sh` 即同意插件声明的能力。两个入口仅在 `plugins install --help` 列出完整的 `--accept-capabilities` 参数时传递它，以兼容旧版宿主。
+执行 `anolisa adapter enable agent-memory openclaw` 或 agent-memory 的 OpenClaw `install.sh` 即同意插件声明的能力。两个入口仅在 `plugins install --help` 列出完整的 `--accept-capabilities` 参数时传递它，以兼容旧版宿主。运行 `install.sh` 时设置 `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` 可拒绝授予同意——带门禁的宿主将拒绝安装，直至自行授予（例如交互式执行 `openclaw plugins install`）。
+
+安装期环境变量（运行期 `MEMORY_*` 变量见「环境变量」一节）：
+
+| 变量 | 默认 | 作用 |
+|---|---|---|
+| `AGENT_MEMORY_ACCEPT_CAPABILITIES` | 接受 | `1`/`true`/`yes`/`on` 在宿主声明该参数时授予同意；`0`/`false`/`no`/`off` 拒绝授予，带门禁的宿主将拒绝安装；其他取值在安装前直接报错中止（退出码 2） |
+| `AGENT_MEMORY_SAFE_INSTALL` | 未设置 | `1` 时安装命令省略 `--dangerously-force-unsafe-install` |
+| `OPENCLAW_BIN` | `openclaw` | 要调用的 openclaw CLI |
+| `OPENCLAW_STATE_DIR` | `~/.openclaw` | 传递给每次 openclaw CLI 调用的 state 目录 |
+| `OPENCLAW_HOME` | `~/.openclaw` | 仅作为 `OPENCLAW_STATE_DIR` 的默认值；不会传给 CLI（每次调用均 unset） |
 
 插件 contract 名 ↔ agent-memory MCP 工具映射：
 
@@ -591,7 +601,7 @@ RUST_LOG=agent_memory=debug agent-memory
 | 索引检索对刚写入的内容查不到 | 还在 200 ms debounce 窗口内 | 重试，或用 `mem_grep`（直接走文件系统正则，不依赖索引） |
 | `mem_promote` 报 `session not found` | `MEMORY_SESSION_ID`/`MEMORY_SESSION_DIR` 未设或 scratch 不存在 | 见 Promote 工作流 |
 | OpenClaw 插件未加载 | `openclaw` CLI 不在 PATH | 安装 OpenClaw 后重跑 `install.sh` |
-| install.sh 报 `Plugin "memory-anolisa" requires capability consent` | OpenClaw >= 2026.8.1 的能力同意门禁；安装参数探测失败或脚本早于修复版本 | 查看安装输出中的探测 WARNING 行；升级 agent-memory，或手动执行 `openclaw plugins install <插件目录> --force --accept-capabilities` |
+| install.sh 报 `Plugin "memory-anolisa" requires capability consent` | OpenClaw >= 2026.8.1 的能力同意门禁；安装参数探测失败、设置了 `AGENT_MEMORY_ACCEPT_CAPABILITIES=0`，或脚本早于修复版本 | 查看安装输出中的探测 WARNING 或 opt-out 拒绝行；升级 agent-memory、取消该环境变量，或手动执行 `openclaw plugins install <插件目录> --force --accept-capabilities`。被拒绝授予且遭门禁拦截的安装以退出码 3 结束；若 OpenClaw 调整拒绝文案，脚本会退回退出码 1 并附带 opt-out 提示 |
 | 手动 dnf 操作后 system 状态不同步 | — | `sudo anolisa --install-mode system repair agent-memory`；仅在为仍存在的 RPM 重建记录时使用 system-scoped `forget` / `adopt` |
 
 深入排查：`RUST_LOG=agent_memory=debug` 启动，检查服务端 stderr 与 `<mount>/.anolisa/audit.log`。

--- a/src/agent-memory/Makefile
+++ b/src/agent-memory/Makefile
@@ -47,7 +47,7 @@ COMPONENT_CONTRACT := .anolisa/component.toml
 RPMBUILD_DIR ?= $(HOME)/rpmbuild
 SPEC_FILE := $(NAME).spec
 
-.PHONY: all build build-openclaw-plugin sync-versions generate-component-contract test lint fmt clean install \
+.PHONY: all build build-openclaw-plugin sync-versions generate-component-contract test test-openclaw-install lint fmt clean install \
         install-adapter-resources uninstall dist spec rpm srpm \
         smoke help
 
@@ -130,9 +130,16 @@ build-debug: ## Build debug binary
 # TEST
 # =============================================================================
 
-test: ## Run all tests (Linux only — use `make remote-test` on macOS/Windows)
+test: test-openclaw-install ## Run all tests (Linux only — use `make remote-test` on macOS/Windows)
 	@echo "==> Running tests..."
 	cargo test --locked
+
+# Bash-only consent-negotiation test for the OpenClaw installer (no Node).
+# A future npm/tsx-based plugin unit-test target is a separate entry point
+# and deliberately not part of `make test`.
+test-openclaw-install: ## Run the OpenClaw adapter installer consent-negotiation test
+	@echo "==> Testing OpenClaw adapter installer..."
+	bash tests/test-openclaw-adapter-install.sh
 
 test-mcp: ## Run MCP integration tests only
 	cargo test --test mcp_integration_test
@@ -164,7 +171,7 @@ remote-build: remote-push ## Push + ssh $(REMOTE_HOST): pull + cargo build --rel
 
 remote-test: remote-push ## Push + ssh $(REMOTE_HOST): full test + clippy
 	@echo "==> Testing on $(REMOTE_HOST):$(REMOTE_PATH)..."
-	ssh $(REMOTE_HOST) 'cd $(REMOTE_PATH) && $(REMOTE_RESET_GUARD) git fetch $(REMOTE_REPO) $(REMOTE_BRANCH) && git reset --hard $(REMOTE_REPO)/$(REMOTE_BRANCH) && cd src/agent-memory && cargo test --release | grep "test result" && cargo clippy --release --all-targets -- -D warnings | tail -3'
+	ssh $(REMOTE_HOST) 'cd $(REMOTE_PATH) && $(REMOTE_RESET_GUARD) git fetch $(REMOTE_REPO) $(REMOTE_BRANCH) && git reset --hard $(REMOTE_REPO)/$(REMOTE_BRANCH) && cd src/agent-memory && bash tests/test-openclaw-adapter-install.sh && cargo test --release | grep "test result" && cargo clippy --release --all-targets -- -D warnings | tail -3'
 
 # =============================================================================
 # CODE QUALITY

--- a/src/agent-memory/README.md
+++ b/src/agent-memory/README.md
@@ -26,6 +26,16 @@ anolisa install agent-memory
 sudo yum install agent-memory
 ```
 
+### OpenClaw adapter
+
+The bundled plugin (`memory-anolisa`) is deployed by
+`/usr/share/anolisa/adapters/agent-memory/openclaw/scripts/install.sh`, which
+grants the plugin's declared capabilities by default. Set
+`AGENT_MEMORY_ACCEPT_CAPABILITIES=0` to withhold consent — on hosts that gate
+consent the install then fails until consent is granted interactively. Set
+`AGENT_MEMORY_SAFE_INSTALL=1` to omit the unsafe-install bypass flag. Full
+reference: [user guide](../../docs/user-guide/en/token-saving/agent-memory.md).
+
 ### Integration (MCP client)
 
 Add to your MCP config (Claude Code, Cursor, etc.):

--- a/src/agent-memory/README_zh.md
+++ b/src/agent-memory/README_zh.md
@@ -26,6 +26,13 @@ anolisa install agent-memory
 sudo yum install agent-memory
 ```
 
+### OpenClaw 适配器
+
+随包附带的插件（`memory-anolisa`）由
+`/usr/share/anolisa/adapters/agent-memory/openclaw/scripts/install.sh` 部署，默认授予插件声明的能力。设置
+`AGENT_MEMORY_ACCEPT_CAPABILITIES=0` 可拒绝授予同意——带门禁的宿主上安装将失败，直至交互式授予。设置
+`AGENT_MEMORY_SAFE_INSTALL=1` 可省略 unsafe-install 覆盖参数。完整说明见[用户指南](../../docs/user-guide/zh/token-saving/agent-memory.md)。
+
 ### 集成（MCP 客户端）
 
 添加到 MCP 配置（Claude Code、Cursor 等）：

--- a/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
+++ b/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
@@ -19,6 +19,29 @@ OPENCLAW_STATE_DIR="${OPENCLAW_STATE_DIR%/}"
 OPENCLAW_HOME="${OPENCLAW_HOME%/}"
 OPENCLAW_BIN="${OPENCLAW_BIN:-openclaw}"
 
+# Normalize the consent switch with the same systemd-style token table as
+# the Rust side's env_bool() (src/config.rs): only leading/trailing
+# whitespace is trimmed — deleting interior whitespace would normalize
+# 't rue' into a grant — and matching is case-insensitive. Unset or empty
+# accepts (the documented default); every other value, including
+# whitespace-only, aborts with rc=2 before any CLI call — the operator
+# must never believe they have withheld consent while the script accepts
+# it. This runs before every early exit (missing CLI, missing dist) so a
+# bad value is reported unconditionally.
+ACCEPT_CAPABILITIES=1
+_consent="${AGENT_MEMORY_ACCEPT_CAPABILITIES-}"
+if [ -n "$_consent" ]; then
+    _consent="${_consent#"${_consent%%[![:space:]]*}"}"
+    _consent="${_consent%"${_consent##*[![:space:]]}"}"
+    case "$(printf '%s' "$_consent" | tr '[:upper:]' '[:lower:]')" in
+        1|true|yes|on) ACCEPT_CAPABILITIES=1 ;;
+        0|false|no|off) ACCEPT_CAPABILITIES=0 ;;
+        *)
+            echo "[${COMPONENT}] ERROR: AGENT_MEMORY_ACCEPT_CAPABILITIES='${AGENT_MEMORY_ACCEPT_CAPABILITIES}' is not a boolean (use 1/true/yes/on or 0/false/no/off)." >&2
+            exit 2 ;;
+    esac
+fi
+
 echo "[${COMPONENT}] Installing ${AGENT} plugin..."
 
 if ! command -v "$OPENCLAW_BIN" &>/dev/null; then
@@ -69,18 +92,65 @@ if [ "$PROBE_RC" -ne 0 ]; then
     printf '[%s]          Installing with the base flags only.\n' "$COMPONENT" >&2
     INSTALL_HELP=""
 fi
+CONSENT_WITHHELD=0
 if [[ "$INSTALL_HELP" =~ (^|[^[:alnum:]_.-])--accept-capabilities([^[:alnum:]_.-]|$) ]]; then
-    INSTALL_ARGS+=("--accept-capabilities")
-    echo "[${COMPONENT}] Passing --accept-capabilities: granting install-time consent to memory-anolisa's declared capabilities."
+    if [ "$ACCEPT_CAPABILITIES" = "0" ]; then
+        # Deliberate refusal, not a silent skip: policies that forbid
+        # non-interactive consent grants must see the install fail loudly
+        # on gating hosts instead of succeeding with an implicit grant.
+        CONSENT_WITHHELD=1
+        echo "[${COMPONENT}] AGENT_MEMORY_ACCEPT_CAPABILITIES=0: withholding --accept-capabilities — capability consent is not granted by this script." >&2
+        echo "[${COMPONENT}]          Hosts that gate consent will reject this install until consent is granted interactively." >&2
+    else
+        INSTALL_ARGS+=("--accept-capabilities")
+        echo "[${COMPONENT}] Passing --accept-capabilities: granting install-time consent to memory-anolisa's declared capabilities."
+    fi
 elif [ -n "$INSTALL_HELP" ]; then
     echo "[${COMPONENT}] OpenClaw did not advertise --accept-capabilities (pre-2026.8.1 host); installing with the base flags."
+elif [ "$ACCEPT_CAPABILITIES" = "0" ]; then
+    # Unreachable unless the probe failed: the host's gating status is
+    # unknown, so surface that the opt-out is shaping the install.
+    echo "[${COMPONENT}] AGENT_MEMORY_ACCEPT_CAPABILITIES=0 is active; if this host gates consent, the install will fail." >&2
 fi
 
-env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install "$PLUGIN_DIR" \
-    "${INSTALL_ARGS[@]}" || {
+# The transcript (tee into a log file, then grep the file — never a
+# short-circuit pipe, whose early match would SIGPIPE the producer under
+# pipefail) exists only for the consent-withheld path, the sole consumer of
+# the consent-rejection signal; every other install runs the CLI exactly as
+# before — stderr stays stderr, stdout stays the operator's terminal, so
+# TTY-gated colour/prompts survive on the SAFE_INSTALL blocking-scan path.
+# The merged 2>&1 on the withheld path is deliberate for a non-interactive
+# refusal transcript: the CLI's stderr surfaces on this script's stdout.
+INSTALL_CMD=(env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" \
+    "$OPENCLAW_BIN" plugins install "$PLUGIN_DIR" "${INSTALL_ARGS[@]}")
+INSTALL_RC=0
+if [ "$CONSENT_WITHHELD" = "1" ]; then
+    INSTALL_LOG="$(mktemp -t agent-memory-openclaw-install.XXXXXX)"
+    trap 'rm -f "$INSTALL_LOG"' EXIT
+    "${INSTALL_CMD[@]}" 2>&1 | tee "$INSTALL_LOG" || INSTALL_RC=${PIPESTATUS[0]}
+else
+    INSTALL_LOG=""
+    "${INSTALL_CMD[@]}" || INSTALL_RC=$?
+fi
+if [ "$INSTALL_RC" -ne 0 ]; then
+    # Attribute the failure to the withheld consent only when OpenClaw's
+    # output carries the documented consent-rejection phrase ("Plugin "…"
+    # requires capability consent. …"); permissions, a broken manifest, or
+    # a security scan must keep the generic failure code so callers do not
+    # mistake a real install failure for a policy refusal. If OpenClaw
+    # rewords the message, this degrades to rc=1 with the opt-out note.
+    if [ "$CONSENT_WITHHELD" = "1" ] && grep -qi 'requires capability consent' "$INSTALL_LOG"; then
+        echo "[${COMPONENT}] install failed with consent withheld by AGENT_MEMORY_ACCEPT_CAPABILITIES=0 — grant consent interactively or unset the variable to let this script grant it." >&2
+        echo "[${COMPONENT}]   openclaw plugins install <plugin-dir> --force --accept-capabilities" >&2
+        echo "[${COMPONENT}]   plugin-dir: $PLUGIN_DIR" >&2
+        exit 3
+    fi
+    if [ "$CONSENT_WITHHELD" = "1" ]; then
+        echo "[${COMPONENT}] Note: AGENT_MEMORY_ACCEPT_CAPABILITIES=0 is active, but this failure does not look like a consent rejection." >&2
+    fi
     echo "[${COMPONENT}] openclaw CLI install failed — check OpenClaw version >= 5.0.0" >&2
     exit 1
-}
+fi
 
 # OpenClaw 2026.6.11 requires non-bundled plugins to explicitly opt-in
 # to conversation hooks (agent_end, before_prompt_build, etc.). Without

--- a/src/agent-memory/tests/test-openclaw-adapter-install.sh
+++ b/src/agent-memory/tests/test-openclaw-adapter-install.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# Pin the capability-consent negotiation of scripts/install.sh against a
+# stub openclaw CLI: probe form (help captured, not piped to grep), whole-
+# token flag matching, consent opt-out, and per-outcome log lines. No real
+# plugin is installed.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_SH="$SCRIPT_DIR/../adapters/agent-memory/openclaw/scripts/install.sh"
+SANDBOX="$(mktemp -d -t agent-memory-openclaw-install.XXXXXX)"
+trap 'rm -r -- "$SANDBOX"' EXIT
+# The space in "adapter root" pins argv quoting through PLUGIN_DIR.
+mkdir -p "$SANDBOX/adapter root/openclaw/dist"
+: > "$SANDBOX/adapter root/openclaw/dist/index.js"
+
+cat > "$SANDBOX/openclaw" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+[ -z "${OPENCLAW_HOME+x}" ]
+[ "$OPENCLAW_STATE_DIR" = "$TEST_STATE_DIR" ]
+printf '%s\n' "$*" >> "$TEST_ARGV_LOG"
+if [ "$1" = plugins ] && [ "$2" = install ] && [ "$3" = --help ]; then
+    case "${TEST_HELP:?}" in
+        modern)
+            echo 'Usage: openclaw plugins install [options] <path>'
+            echo 'Options:'
+            echo "  --accept-capabilities  Accept the plugin's declared capabilities (default: false)"
+            echo '  --force  Overwrite an existing installed plugin (default: false)' ;;
+        legacy)
+            echo 'Options:'
+            echo '  --dangerously-force-unsafe-install  Bypass built-in dangerous-code install blocking'
+            echo '  --force  Overwrite an existing installed plugin' ;;
+        near_match)
+            echo 'Options:'
+            echo '  --accept-capabilities-only          unrelated option (default: false)'
+            echo '  --no-accept-capabilities             reverse switch (default: false)' ;;
+        colon)
+            echo '  --accept-capabilities: accept declared capabilities' ;;
+        paren)
+            echo 'Options (--accept-capabilities):'
+            echo '  --force  overwrite' ;;
+        big)
+            echo "  --accept-capabilities  Accept the plugin's declared capabilities"
+            # Exceeds any pipe buffer: if the probe is ever reverted from
+            # capture-into-variable to `cmd | grep -q`, grep's early exit
+            # SIGPIPEs this writer under pipefail and the match is lost.
+            printf 'filler line %.0s\n' {1..200000} ;;
+        failed)
+            echo 'OpenClaw could not start: --accept-capabilities requires a TTY' >&2
+            exit 3 ;;
+    esac
+    exit 0
+fi
+if [ "$1" = config ] && [ "$2" = set ]; then
+    exit 0
+fi
+[ "$1" = plugins ] && [ "$2" = install ]
+[ "$3" = "$ANOLISA_ADAPTER_DIR/openclaw" ]
+accepted=0
+for arg in "$@"; do
+    [ "$arg" != --accept-capabilities ] || accepted=1
+done
+if [ "${TEST_GATE:?}" = new ]; then
+    [ "$accepted" = 1 ] || {
+        echo 'Plugin "memory-anolisa" requires capability consent. Use --accept-capabilities, then retry.' >&2
+        # Large trailing output: if the consent-signal check is ever
+        # reverted to a short-circuit pipe (printf | grep -q), grep's early
+        # exit SIGPIPEs this writer under pipefail and rc=3 degrades to 1.
+        if [ "${TEST_INSTALL_BIG:-0}" = 1 ]; then
+            printf 'filler line %.0s\n' {1..200000} >&2
+        fi
+        exit 1; }
+elif [ "$TEST_GATE" = unrelated ]; then
+    # Unconditional: an environment failure (e.g. EACCES) hits regardless
+    # of whether the consent flag was passed, so the stream contract is
+    # observable on the default path too.
+    echo 'EACCES: permission denied, open plugin manifest' >&2; exit 1
+else
+    [ "$accepted" = 0 ] || { echo 'OpenClaw does not recognize option "--accept-capabilities".' >&2; exit 1; }
+fi
+: > "$TEST_INSTALLED"
+STUB
+chmod +x "$SANDBOX/openclaw"
+
+export ANOLISA_ADAPTER_DIR="$SANDBOX/adapter root"
+export OPENCLAW_BIN="$SANDBOX/openclaw"
+export OPENCLAW_STATE_DIR="$SANDBOX/state root"
+export OPENCLAW_HOME="$SANDBOX/ignored home"
+export TEST_STATE_DIR="$OPENCLAW_STATE_DIR"
+export TEST_ARGV_LOG="$SANDBOX/argv"
+export TEST_INSTALLED="$SANDBOX/installed"
+
+fail() {
+    echo "FAIL: $1" >&2
+    sed 's/^/    /' "$SANDBOX/output" >&2
+    exit 1
+}
+
+# Full expected install argv for the given flag combination.
+argv() {
+    local a="plugins install $ANOLISA_ADAPTER_DIR/openclaw --force"
+    if [ "$1" = yes ]; then a="$a --dangerously-force-unsafe-install"; fi
+    if [ "$2" = yes ]; then a="$a --accept-capabilities"; fi
+    printf '%s' "$a"
+}
+
+# scenario <label> <want-rc> <want-argv> [KEY=VAL ...] — run install.sh with
+# the current TEST_HELP/TEST_GATE gating and assert rc, argv, and the
+# config-set follow-up. The two installer switches are unset first so
+# ambient values cannot leak into baseline scenarios; per-scenario KEY=VAL
+# overrides are applied after the unsets.
+scenario() {
+    local label="$1" want_rc="$2" want_argv="$3"
+    shift 3
+    local rc=0
+    : > "$TEST_ARGV_LOG"
+    rm -f "$TEST_INSTALLED"
+    env -u AGENT_MEMORY_SAFE_INSTALL -u AGENT_MEMORY_ACCEPT_CAPABILITIES \
+        "$@" bash "$INSTALL_SH" >"$SANDBOX/output" 2>&1 || rc=$?
+    [ "$rc" = "$want_rc" ] || fail "$label: rc=$rc, want $want_rc"
+    [ "$(grep -c '^plugins install --help$' "$TEST_ARGV_LOG")" = 1 ] \
+        || fail "$label: expected exactly one help probe"
+    # awk (always exit 0) instead of grep -v | wc -l: a failing pipeline in
+    # an assignment kills the whole suite under `set -euo pipefail` before
+    # the fail() below can print its diagnostic.
+    local install_calls
+    install_calls="$(awk '/^plugins install / && !/--help$/ {n++} END {print n+0}' "$TEST_ARGV_LOG")"
+    [ "$install_calls" = 1 ] \
+        || fail "$label: expected exactly one install invocation, got $install_calls"
+    local install_argv
+    install_argv="$(awk '/^plugins install / && !/--help$/ {print}' "$TEST_ARGV_LOG")"
+    [ "$install_argv" = "$want_argv" ] \
+        || fail "$label: install argv '$install_argv' != '$want_argv'"
+    if [ "$want_rc" = 0 ]; then
+        [ -f "$TEST_INSTALLED" ] || fail "$label: install did not run"
+        [ "$(grep -c '^config set plugins.entries.memory-anolisa.hooks.allowConversationAccess true$' "$TEST_ARGV_LOG")" = 1 ] \
+            || fail "$label: allowConversationAccess config-set missing"
+    else
+        [ ! -f "$TEST_INSTALLED" ] || fail "$label: install ran despite failure"
+    fi
+    echo "PASS: $label"
+}
+
+expect_log() { grep -q -- "$1" "$SANDBOX/output" || fail "expected log line: $1"; }
+expect_no_log() { ! grep -q -- "$1" "$SANDBOX/output" || fail "unexpected log line: $1"; }
+
+# channel_scenario <label> <want-rc> <want-streams: split|merged> <marker> [KEY=VAL ...]
+# — like scenario() but with separated capture (stdout and stderr to
+# distinct files), pinning the stream contract itself: on the default path
+# the CLI's stderr must stay on stderr (base behavior), while the withheld
+# path deliberately merges the transcript into stdout. <marker> is the
+# CLI-authored text to track across the two channels.
+channel_scenario() {
+    local label="$1" want_rc="$2" want_streams="$3" marker="$4"
+    shift 4
+    local rc=0
+    : > "$TEST_ARGV_LOG"
+    rm -f "$TEST_INSTALLED"
+    env -u AGENT_MEMORY_SAFE_INSTALL -u AGENT_MEMORY_ACCEPT_CAPABILITIES \
+        "$@" bash "$INSTALL_SH" >"$SANDBOX/out" 2>"$SANDBOX/err" || rc=$?
+    [ "$rc" = "$want_rc" ] || { echo "FAIL: $label: rc=$rc, want $want_rc" >&2; channel_dump; exit 1; }
+    local install_calls
+    install_calls="$(awk '/^plugins install / && !/--help$/ {n++} END {print n+0}' "$TEST_ARGV_LOG")"
+    [ "$install_calls" = 1 ] \
+        || { echo "FAIL: $label: expected exactly one install invocation, got $install_calls" >&2; exit 1; }
+    if [ "$want_streams" = merged ]; then
+        grep -qF -- "$marker" "$SANDBOX/out" \
+            || { echo "FAIL: $label: CLI text '$marker' missing from stdout (merged transcript expected)" >&2; channel_dump; exit 1; }
+    else
+        ! grep -qF -- "$marker" "$SANDBOX/out" \
+            || { echo "FAIL: $label: CLI text '$marker' leaked into stdout on the split-stream path" >&2; channel_dump; exit 1; }
+        grep -qF -- "$marker" "$SANDBOX/err" \
+            || { echo "FAIL: $label: CLI text '$marker' missing from stderr (split streams expected)" >&2; channel_dump; exit 1; }
+    fi
+    echo "PASS: $label"
+}
+
+channel_dump() {
+    echo "    --- captured stdout ---" >&2
+    sed 's/^/    /' "$SANDBOX/out" >&2
+    echo "    --- captured stderr ---" >&2
+    sed 's/^/    /' "$SANDBOX/err" >&2
+}
+
+export TEST_HELP=modern TEST_GATE=new
+scenario 'modern host, default' 0 "$(argv yes yes)"
+expect_log 'Passing --accept-capabilities'
+scenario 'modern host, safe install' 0 "$(argv no yes)" AGENT_MEMORY_SAFE_INSTALL=1
+scenario 'modern host, explicit opt-in' 0 "$(argv yes yes)" AGENT_MEMORY_ACCEPT_CAPABILITIES=1
+# Opting out must be a visible refusal: no flag, no consent log, and the
+# gated install fails with the refusal conclusion (rc=3) instead of
+# silently succeeding.
+scenario 'modern host, consent opt-out' 3 "$(argv yes no)" AGENT_MEMORY_ACCEPT_CAPABILITIES=0
+expect_log 'AGENT_MEMORY_ACCEPT_CAPABILITIES=0'
+expect_no_log 'Passing --accept-capabilities'
+expect_log 'install failed with consent withheld'
+# Pins the merged-stream decision: the CLI's own rejection text stays
+# visible in the script's output (streamed live via tee).
+expect_log 'requires capability consent'
+# The token table accepts the full boolean vocabulary, not just literal 0.
+scenario 'modern host, consent opt-out via false' 3 "$(argv yes no)" AGENT_MEMORY_ACCEPT_CAPABILITIES=false
+scenario 'modern host, consent opt-in via TRUE' 0 "$(argv yes yes)" AGENT_MEMORY_ACCEPT_CAPABILITIES=TRUE
+# Leading/trailing whitespace is trimmed, matching Rust env_bool().
+scenario 'modern host, consent opt-out with padding' 3 "$(argv yes no)" AGENT_MEMORY_ACCEPT_CAPABILITIES=' 0 '
+# A consent rejection buried in large CLI output must still be attributed
+# (rc=3): the signal check must never be a short-circuit pipe.
+export TEST_INSTALL_BIG=1
+scenario 'consent rejection with large install output' 3 "$(argv yes no)" AGENT_MEMORY_ACCEPT_CAPABILITIES=0
+expect_log 'install failed with consent withheld'
+unset TEST_INSTALL_BIG
+# An install failure under opt-out that does not carry the consent-rejection
+# phrase must stay a generic rc=1 failure with an opt-out note — never a
+# misattributed policy refusal.
+export TEST_GATE=unrelated
+scenario 'opt-out with unrelated install error' 1 "$(argv yes no)" AGENT_MEMORY_ACCEPT_CAPABILITIES=0
+expect_log 'does not look like a consent rejection'
+expect_log 'EACCES'
+expect_no_log 'install failed with consent withheld'
+export TEST_GATE=new
+
+export TEST_HELP=legacy TEST_GATE=old
+scenario 'legacy host, default' 0 "$(argv yes no)"
+expect_log 'did not advertise --accept-capabilities'
+scenario 'legacy host, safe install' 0 "$(argv no no)" AGENT_MEMORY_SAFE_INSTALL=1
+# Nothing to refuse when the host does not gate consent.
+scenario 'legacy host, consent opt-out' 0 "$(argv yes no)" AGENT_MEMORY_ACCEPT_CAPABILITIES=0
+
+export TEST_HELP=near_match
+scenario 'near-miss options only' 0 "$(argv yes no)"
+expect_log 'did not advertise --accept-capabilities'
+
+# Alternate help layouts pin the whole-token match: a prefix-only regex
+# misses these, a substring regex over-matches near-miss options.
+export TEST_HELP=colon TEST_GATE=new
+scenario 'colon help style' 0 "$(argv yes yes)"
+export TEST_HELP=paren
+scenario 'paren help style' 0 "$(argv yes yes)"
+export TEST_HELP=big
+scenario 'large help output' 0 "$(argv yes yes)"
+
+# A failing probe whose error text names the flag must not be mistaken for
+# an advertised option; the install degrades to base flags with a WARNING.
+export TEST_HELP=failed TEST_GATE=old
+scenario 'failed help probe' 0 "$(argv yes no)"
+expect_log 'WARNING: cannot inspect OpenClaw installer options (rc=3)'
+expect_no_log 'did not advertise --accept-capabilities'
+# The same probe failure with the opt-out active must surface the switch —
+# the advertised branch (and its refusal line) never runs. On a gating host
+# the install then fails generically (rc=1, not 3): the host's gating
+# status was never confirmed, so the refusal is not attributed.
+scenario 'failed probe with opt-out' 0 "$(argv yes no)" AGENT_MEMORY_ACCEPT_CAPABILITIES=0
+expect_log 'WARNING: cannot inspect OpenClaw installer options (rc=3)'
+expect_log 'AGENT_MEMORY_ACCEPT_CAPABILITIES=0 is active'
+export TEST_GATE=new
+scenario 'failed probe with opt-out, gating host' 1 "$(argv yes no)" AGENT_MEMORY_ACCEPT_CAPABILITIES=0
+expect_log 'AGENT_MEMORY_ACCEPT_CAPABILITIES=0 is active'
+expect_no_log 'install failed with consent withheld'
+export TEST_GATE=old
+
+# Stream contract under separated capture: a default (consent-granted)
+# install keeps the CLI's own stderr text on stderr — identical to base —
+# while the withheld path deliberately merges the refusal transcript into
+# stdout. The default-path case uses the unrelated-failure gate so the CLI
+# actually writes stderr text to track.
+export TEST_HELP=modern TEST_GATE=unrelated
+channel_scenario 'default path keeps CLI stderr on stderr' 1 split 'EACCES'
+export TEST_GATE=new
+channel_scenario 'withheld path merges transcript into stdout' 3 merged 'requires capability consent' AGENT_MEMORY_ACCEPT_CAPABILITIES=0
+
+# An unparseable switch value aborts before any OpenClaw invocation —
+# including on hosts without the CLI at all (the validation precedes the
+# missing-CLI early exit).
+: > "$TEST_ARGV_LOG"
+rc=0
+env AGENT_MEMORY_ACCEPT_CAPABILITIES=maybe bash "$INSTALL_SH" >"$SANDBOX/output" 2>&1 || rc=$?
+[ "$rc" = 2 ] || fail "invalid switch value: expected rc 2, got $rc"
+[ ! -s "$TEST_ARGV_LOG" ] || fail 'invalid switch value: openclaw must not be invoked'
+grep -q 'is not a boolean' "$SANDBOX/output" || fail 'invalid switch value: expected the boolean error'
+echo 'PASS: invalid switch value aborts before any OpenClaw call'
+
+# Interior whitespace must never be normalized into a valid token ('t rue'
+# must not become a grant), and a whitespace-only value is "another value"
+# per the documented contract — both abort before any CLI call.
+for bad in 't rue' 'tr ue' '   '; do
+    : > "$TEST_ARGV_LOG"
+    rc=0
+    env AGENT_MEMORY_ACCEPT_CAPABILITIES="$bad" bash "$INSTALL_SH" >"$SANDBOX/output" 2>&1 || rc=$?
+    [ "$rc" = 2 ] || fail "switch value '$bad': expected rc 2, got $rc"
+    [ ! -s "$TEST_ARGV_LOG" ] || fail "switch value '$bad': openclaw must not be invoked"
+    grep -q 'is not a boolean' "$SANDBOX/output" || fail "switch value '$bad': expected the boolean error"
+done
+echo 'PASS: interior-whitespace and blank values abort before any OpenClaw call'
+
+rc=0
+env OPENCLAW_BIN="$SANDBOX/missing-openclaw" AGENT_MEMORY_ACCEPT_CAPABILITIES=maybe \
+    bash "$INSTALL_SH" >"$SANDBOX/output" 2>&1 || rc=$?
+[ "$rc" = 2 ] || fail "invalid switch value without CLI: expected rc 2, got $rc"
+grep -q 'is not a boolean' "$SANDBOX/output" \
+    || fail 'invalid switch value without CLI: expected the boolean error'
+echo 'PASS: invalid switch value aborts even when the CLI is missing'
+
+: > "$TEST_ARGV_LOG"
+rc=0
+OPENCLAW_BIN="$SANDBOX/missing-openclaw" bash "$INSTALL_SH" >"$SANDBOX/output" 2>&1 || rc=$?
+[ "$rc" = 0 ] || fail "missing CLI: expected rc 0, got $rc"
+[ ! -s "$TEST_ARGV_LOG" ] || fail 'missing CLI: openclaw must not be invoked'
+grep -q 'skipping plugin installation' "$SANDBOX/output" \
+    || fail 'missing CLI: expected skip behavior'
+echo 'PASS: missing CLI preserves the existing skip behavior'
+
+# Diagnosability pin: a regressed install.sh that probes but never invokes
+# install must produce a FAIL diagnostic — not a silent set -e death from
+# a failing pipeline inside an assignment. The scenario runs in a child
+# bash -c: an OR-list subshell would suppress errexit inside it and hide
+# exactly the silent death this pin guards against.
+export TEST_HELP=modern TEST_GATE=new
+fake_install="$SANDBOX/fake-install.sh"
+cat > "$fake_install" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "[agent-memory] Installing openclaw plugin..."
+env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install --help >/dev/null 2>&1
+# Regressed: exits successfully without invoking the install.
+exit 0
+FAKE
+pin_rc=0
+env SANDBOX="$SANDBOX" INSTALL_SH="$fake_install" \
+    bash -c "set -euo pipefail; $(declare -f scenario fail); scenario 'harness pin: install never invoked' 0 'plugins install never-ran'" \
+    >"$SANDBOX/pin-output" 2>&1 || pin_rc=$?
+[ "$pin_rc" -ne 0 ] || fail 'harness pin: scenario should have failed'
+grep -q 'expected exactly one install invocation' "$SANDBOX/pin-output" \
+    || fail 'harness pin: no diagnosable FAIL line (silent death)'
+echo 'PASS: missing install invocation fails with a diagnostic'
+
+# remote-test is the only test path for macOS/Windows contributors; pin
+# that its ssh command includes this suite (dry-run — nothing executes).
+if command -v make >/dev/null 2>&1; then
+    make -C "$SCRIPT_DIR/.." -n remote-test 2>/dev/null \
+        | grep -q 'tests/test-openclaw-adapter-install.sh' \
+        || fail 'remote-test does not run the installer test'
+    echo 'PASS: remote-test includes the installer test'
+fi
+
+# The suite must be hermetic: hostile ambient switch values must neither
+# leak into baseline scenarios nor break the suite itself.
+if [ -z "${TEST_HOSTILE_AMBIENT:-}" ]; then
+    rc=0
+    env AGENT_MEMORY_ACCEPT_CAPABILITIES=0 AGENT_MEMORY_SAFE_INSTALL=1 TEST_HOSTILE_AMBIENT=1 \
+        bash "$0" >"$SANDBOX/output" 2>&1 || rc=$?
+    [ "$rc" = 0 ] || { sed 's/^/    /' "$SANDBOX/output" >&2; fail "hostile ambient environment broke the suite (rc=$rc)"; }
+    echo 'PASS: hostile ambient environment does not leak into scenarios'
+fi


### PR DESCRIPTION
## Why

#3149 taught install.sh to negotiate the capability-consent flag, but two gaps remained (tracked in #3160):

1. **No opt-out.** install.sh grants `--accept-capabilities` on the operator's behalf whenever the host advertises it. Operators whose policy forbids non-interactive consent grants cannot refuse — the script decides for them, leaving only a stdout log line.
2. **Zero CI coverage for the probe's bash logic.** The Test agent-memory job runs only `cargo fmt/clippy/test`. #3149's review found two latent defects in the first probe form (SIGPIPE-lost matches under `pipefail`; prefix-regex over/under-matching) — exactly the class that tests pin down and eyes miss. #3134 additionally dangles: it wires a `tests/unit/install-script-test.ts` that no longer exists on main.

## What changed

- `install.sh`: `AGENT_MEMORY_ACCEPT_CAPABILITIES` withholds the flag. It parses the same systemd-style token table as the Rust side's `env_bool()` (src/config.rs) — trim semantics included: leading/trailing whitespace is trimmed, **interior whitespace stays invalid** (deleting it would normalize `'t rue'` into a grant), case-insensitive. Unset or empty accepts (the documented default); every other value, whitespace-only included, aborts with rc=2 before any CLI call, validated ahead of every early exit so a bad value is reported even on hosts without openclaw. An unrecognized value never silently grants consent.
- Failure attribution: the transcript machinery (live `2>&1 | tee <log>`; the consent-signal check **greps the file, never a short-circuit pipe** — an early `grep -q` match SIGPIPEs the producer under `pipefail` and a real consent rejection in large output would degrade to rc=1) exists **only on the consent-withheld path**, its sole consumer. Default installs run the CLI exactly as before this PR: stderr stays stderr, stdout stays the operator's terminal (TTY-gated colour/prompts survive on the SAFE_INSTALL blocking-scan path), and no temp file is created. When consent was withheld, rc=3 and the consent conclusion line are emitted only if the output carries OpenClaw's documented consent-rejection phrase ("requires capability consent"); unrelated failures (permissions, broken manifest, security scan) keep rc=1 with a note that the opt-out is active.
- `src/agent-memory/tests/test-openclaw-adapter-install.sh` (new): a stub-CLI test modeled on tokenless's `test-openclaw-adapter-install.sh`, pinning the exact install argv across **28 PASS checks** (19 `scenario()` cases + 2 separated-capture stream-contract scenarios + 7 standalone assertions) — help styles (commander / colon / paren / near-miss-only / 200k-line / probe-failure), new/old/unrelated gating, safe-install, opt-out (literal, `false`, padded `' 0 '`, interior-whitespace `'t rue'`, whitespace-only, invalid value), opt-in (`1`, `TRUE`), consent rejection buried in 200k lines of output, missing-CLI, probe-failure+opt-out on gating hosts, and the env contract (`OPENCLAW_HOME` unset, `OPENCLAW_STATE_DIR` propagated), exactly-one-probe / exactly-one-install-invocation counts, and the `allowConversationAccess` follow-up call. The separated-capture scenarios pin the stream contract itself: the CLI's stderr text stays on stderr for default installs (base behavior), while the withheld path deliberately merges the refusal transcript into stdout. Scenario counting uses awk (always exit 0) rather than `grep -v | wc -l` — a failing pipeline inside an assignment silently kills the suite under `set -euo pipefail` before `fail()` can print; a child-bash diagnosability pin guards that. Scenarios unset both installer switches so ambient values cannot leak; the suite re-invokes itself under hostile ambient values to pin hermeticity.
- Wiring: chained into `make test` via a new `test-openclaw-install` target (bash-only, no Node — #3134's Option A/B tradeoff collapses), into the `remote-test` ssh command (macOS/Windows contributors' only test path, asserted via `make -n` inside the suite), and directly after `actions/checkout` in the `Test agent-memory` CI job — before the ~2 min of toolchain/cache/apt setup.
- Docs: en/zh component READMEs gained an "OpenClaw adapter" install subsection summarizing both installer switches; en/zh user guides document the opt-out in the consent paragraph, add an install-time environment variable table with exit codes (`OPENCLAW_HOME` documented as never passed to the CLI — the script unsets it for every call), and extend the troubleshooting row (rc=3 semantics, reworded-message degradation to rc=1).

## Related issue

closes #3160
closes #3134 (superseded: the referenced `install-script-test.ts` is gone; the underlying need — CI coverage for install.sh — is satisfied by this bash test, with no Node dependency)

## User / Agent impact

Operators can run `AGENT_MEMORY_ACCEPT_CAPABILITIES=0 bash install.sh` to withhold consent; on OpenClaw >= 2026.8.1 hosts the install fails with rc=3 when (and only when) OpenClaw's output identifies the consent gate, the script's refusal line explains why, and the failure conclusion points at the switch (not the OpenClaw version). Unrelated install failures under opt-out stay rc=1 with an opt-out note. Default installs are byte-for-byte the pre-PR CLI invocation — no stream merge, no temp file, no TTY loss.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The change only *narrows* what the script grants: it never adds consent where the previous version withheld it. New exit codes: rc=2 for an unparseable switch value (no CLI call happens), rc=3 for an install rejected by the consent gate while consent was deliberately withheld; callers that check non-zero are unaffected. The transcript/stream changes are confined to the withheld path. The opt-out is script-only — `anolisa adapter enable` still treats enable as consent; unifying the three entry points' consent policy is tracked in #3167.

## Validation

- `shellcheck` clean on install.sh and the test; `cargo fmt --all --check` unchanged; CI YAML parses; `scripts/docs-lint.sh` (naming + en/zh parity) and `scripts/docs-link-check.py` both pass.
- The 28-PASS-check suite passes locally (`make test-openclaw-install`), including the self-invocation under hostile ambient `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` + `AGENT_MEMORY_SAFE_INSTALL=1`.
- Stream contract: a stream-separating repro (`bash install.sh >/dev/null 2>err.log` against a stub CLI writing `EACCES` to stderr) keeps OpenClaw's diagnostics on stderr on the default path — identical to base — while the withheld path merges the transcript into stdout; both pinned by the two separated-capture scenarios.
- Mutation checks (each verified to redden the suite): pipe-form probe fails 'large help output' (SIGPIPE under pipefail); substring match fails 'near-miss options only'; removing outcome logging fails the legacy log assertion; reverting awk counting to `grep -vc` fails the harness-diagnosability pin; reverting the outer trim to `tr -d` fails the interior-whitespace scenario (`'t rue'` would grant); reverting the file-based signal check to `printf | grep -q` fails 'consent rejection with large install output' (rc degrades 3 → 1); reverting the scoped tee to unconditional fails 'default path keeps CLI stderr on stderr' (CLI stderr leaks into stdout). Both `grep -vc` and `grep -v | wc -l` forms were also verified to die under `set -euo pipefail` by direct repro.
- `make -n remote-test` includes the suite (asserted by the suite itself).
- CI: the installer step runs at the after-checkout position (green on `7b31a508` and prior heads); re-runs on this head.

## Documentation and rollback

en/zh component README install sections and user guides (consent paragraph, install-time env table, troubleshooting rows) updated per specs/documentation-standard.md §5. CHANGELOG is left to the release version-bump PR per the same spec. Revert the single commit to restore previous behavior.
