### PR TITLE
test(sight): isolate skill-scan test temp dir name

### DIFF
--- a/src/agentsight/src/skill_metrics/extractor.rs
+++ b/src/agentsight/src/skill_metrics/extractor.rs
@@ -642,7 +642,10 @@ Some text after"#;
     #[test]
     fn test_scan_skills_dir_recursive_in_tempdir() {
         use std::fs;
-        let tmp = std::env::temp_dir().join(format!("agentsight_test_{}", std::process::id()));
+        let tmp = std::env::temp_dir().join(format!(
+            "agentsight_test_scan_skills_{}",
+            std::process::id()
+        ));
         // Create: tmp/ai/install-copaw/SKILL.md  and  tmp/network/SKILL.md
         fs::create_dir_all(tmp.join("ai").join("install-copaw")).unwrap();
         fs::write(


### PR DESCRIPTION
## Description

`test_scan_skills_dir_recursive_in_tempdir` (skill_metrics/extractor.rs) and `test_get_token_savings_no_stats_db` (server/token_savings.rs) both use the bare `/tmp/agentsight_test_<pid>` path. They run in the same lib-test process under `--test-threads=8`, so the extractor test's `remove_dir_all` cleanup can race the other test between setup and `Connection::open`, producing `SqliteFailure(CannotOpen)` flakes; the panic then poisons `ENV_MUTEX` and fails `test_get_token_savings_with_stats` as a follow-on.

Observed on PR #3151 CI (job 101990620021, pid 3670) and previously on main (run 34114563323, noted in #3112). All other tests already carry a semantic suffix (`agentsight_test_stats_*`, `agentsight_test_sess_*`, dashboard's `agentsight_test_<pid>_<suffix>`); these two bare-prefix users are the only collision pair.

Fix: rename the extractor test's dir to `agentsight_test_scan_skills_<pid>`. One-line change, no production code touched.

## Validation

- `cargo fmt --all -- --check` passes
- Discrimination: with the rename, the two tests can no longer share a directory, so the race cannot reproduce; reverting restores the shared path
- Local `cargo test` blocked on this host (perl `IPC::Cmd` missing for the vendored openssl build); the change is test-only and CI runs the full suite

no-issue: trivial test-hygiene fix for a CI flake root-caused in review

Assisted-by: Qoder:1.7.0
Signed-off-by: Jiangtian Feng <jiangtianf97@163.com>