### PR TITLE
fix(memory): classify unsafe-install flag support

### DIFF
--- a/docs/user-guide/en/token-saving/agent-memory.md
+++ b/docs/user-guide/en/token-saving/agent-memory.md
@@ -115,7 +115,7 @@ anolisa adapter status agent-memory
 
 **Prerequisite**: `openclaw` CLI on `$PATH`. The script logs clearly and exits 0 if missing — rerun after installing OpenClaw. `yum remove agent-memory` triggers `%preun` to call the uninstall script, leaving no orphaned config.
 
-Running `anolisa adapter enable agent-memory openclaw` or the agent-memory OpenClaw `install.sh` accepts the plugin's declared capabilities. Both entry points pass `--accept-capabilities` only when `plugins install --help` advertises that exact option, so older hosts keep working.
+Running `anolisa adapter enable agent-memory openclaw` or the agent-memory OpenClaw `install.sh` accepts the plugin's declared capabilities. Both entry points pass `--accept-capabilities` only when `plugins install --help` advertises that exact option, so older hosts keep working. The standalone `install.sh` also passes `--dangerously-force-unsafe-install` only while the installer advertises that option as effective: legacy hosts scan plugin code at install time and flag the `child_process.spawn` this plugin uses as its MCP stdio transport. Hosts that list it as a deprecated no-op (OpenClaw 2026.9.2+) no longer receive it, and the safety scan there follows the operator-owned `security.installPolicy`. Set `AGENT_MEMORY_SAFE_INSTALL=1` to never request the bypass.
 
 Plugin contract ↔ agent-memory MCP tool mapping:
 

--- a/docs/user-guide/zh/token-saving/agent-memory.md
+++ b/docs/user-guide/zh/token-saving/agent-memory.md
@@ -114,7 +114,7 @@ anolisa adapter status agent-memory
 
 **前置条件**：`openclaw` CLI 在 `$PATH` 上。脚本缺失时输出明确日志并以 0 退出，安装 OpenClaw 后重跑即可。`yum remove agent-memory` 时 spec 的 `%preun` 自动调用 uninstall 脚本，配置不残留孤立项。
 
-执行 `anolisa adapter enable agent-memory openclaw` 或 agent-memory 的 OpenClaw `install.sh` 即同意插件声明的能力。两个入口仅在 `plugins install --help` 列出完整的 `--accept-capabilities` 参数时传递它，以兼容旧版宿主。
+执行 `anolisa adapter enable agent-memory openclaw` 或 agent-memory 的 OpenClaw `install.sh` 即同意插件声明的能力。两个入口仅在 `plugins install --help` 列出完整的 `--accept-capabilities` 参数时传递它，以兼容旧版宿主。独立的 `install.sh` 同样只在安装器仍把 `--dangerously-force-unsafe-install` 标注为有效参数时才传入它：旧版宿主会在安装期扫描 Plugin 代码，并把此 Plugin 作为 MCP stdio 传输使用的 `child_process.spawn` 标记为风险。把该参数标注为已废弃空操作的宿主（OpenClaw 2026.9.2+）不再收到它，这些宿主上的安全扫描由运维自己维护的 `security.installPolicy` 决定。设置 `AGENT_MEMORY_SAFE_INSTALL=1` 可始终不请求该绕过参数。
 
 插件 contract 名 ↔ agent-memory MCP 工具映射：
 

--- a/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
+++ b/src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh
@@ -34,19 +34,10 @@ if [ ! -f "$PLUGIN_DIR/dist/index.js" ]; then
     exit 1
 fi
 
-# OpenClaw's security scanner flags child_process.spawn as a
-# "dangerous code pattern". The plugin uses spawn exclusively to
-# launch the agent-memory MCP server as a stdio subprocess — this is
-# the standard MCP transport mechanism and not arbitrary shell
-# execution. Since the scanner cannot distinguish between legitimate
-# subprocess communication and malicious shell usage, we bypass it
-# by default. Set AGENT_MEMORY_SAFE_INSTALL=1 to go through the
-# regular (blocking) safe-install path instead.
-INSTALL_ARGS=("--force" "--dangerously-force-unsafe-install")
-if [ "${AGENT_MEMORY_SAFE_INSTALL:-0}" = "1" ]; then
-    echo "[${COMPONENT}] AGENT_MEMORY_SAFE_INSTALL=1: using OpenClaw safe-install path (may block on child_process scan)." >&2
-    INSTALL_ARGS=("--force")
-fi
+# --force is unconditional: a noninteractive install must never prompt. Every
+# other option depends on what this host's installer advertises, so it is
+# appended after the help probe below.
+INSTALL_ARGS=("--force")
 
 # OpenClaw gates capability-declaring plugins behind install-time consent:
 # a noninteractive `plugins install` is rejected unless --accept-capabilities
@@ -76,9 +67,58 @@ elif [ -n "$INSTALL_HELP" ]; then
     echo "[${COMPONENT}] OpenClaw did not advertise --accept-capabilities (pre-2026.8.1 host); installing with the base flags."
 fi
 
+# Legacy hosts gate installs on a safety scan of child_process usage whose only
+# non-interactive bypass is --dangerously-force-unsafe-install. That scan cannot
+# tell memory-anolisa's spawn of the agent-memory MCP server (the standard stdio
+# MCP transport) from arbitrary shell execution, so those hosts need the bypass.
+# Current OpenClaw keeps the token as a deprecated no-op — 2026.9.2 advertises
+# "Deprecated no-op; security.installPolicy may still block" — where passing it
+# accomplishes nothing and breaks outright once the token is removed, so keep it
+# only while the advertised option still has effect; on no-op hosts the scan
+# follows the operator-owned security.installPolicy. Classified from the help
+# text the consent probe above already captured — one CLI call, no version
+# gate — with the same whole-token match and the same line-scoped "no-op" check
+# as anolisa-core's unsafe_install_support() and tokenless's installer. The
+# lowercase fold uses tr, not ${var,,}, keeping the idiom identical to
+# tokenless's installer, which must stay runnable on macOS bash 3.2.
+#
+# AGENT_MEMORY_SAFE_INSTALL=1 keeps its historical meaning — never request the
+# bypass — which is observable only where the flag still has effect. On no-op
+# hosts both settings install identically because there is no install-time scan
+# left to bypass, so the old "bypass vs. blocking safe-install scan" wording is
+# gone rather than redefined into something the host no longer does.
+UNSAFE_SUPPORT=absent
+while IFS= read -r help_line; do
+    if [[ "$help_line" =~ (^|[^[:alnum:]_.-])--dangerously-force-unsafe-install([^[:alnum:]_.-]|$) ]]; then
+        help_line_lc="$(printf '%s' "$help_line" | tr '[:upper:]' '[:lower:]')"
+        case "$help_line_lc" in
+            *"no op"*|*"no-op"*) UNSAFE_SUPPORT=noop ;;
+            *) UNSAFE_SUPPORT=effective ;;
+        esac
+        break
+    fi
+done <<< "$INSTALL_HELP"
+
+if [ "${AGENT_MEMORY_SAFE_INSTALL:-0}" = "1" ]; then
+    echo "[${COMPONENT}] AGENT_MEMORY_SAFE_INSTALL=1: not requesting --dangerously-force-unsafe-install." >&2
+elif [ "$UNSAFE_SUPPORT" = "effective" ]; then
+    INSTALL_ARGS+=("--dangerously-force-unsafe-install")
+    echo "[${COMPONENT}] Passing --dangerously-force-unsafe-install: this OpenClaw still scans plugin code at install time and would flag the MCP server's child_process.spawn."
+elif [ "$UNSAFE_SUPPORT" = "noop" ]; then
+    # Silent omission would leave the operator guessing why a bypass their
+    # runbook expects was not sent; a failed probe stays silent here because
+    # its WARNING above already reports base-flags-only.
+    echo "[${COMPONENT}] Skipping --dangerously-force-unsafe-install: this OpenClaw advertises it as a deprecated no-op; the install-time scan moved to security.installPolicy."
+fi
+
 env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install "$PLUGIN_DIR" \
     "${INSTALL_ARGS[@]}" || {
     echo "[${COMPONENT}] openclaw CLI install failed — check OpenClaw version >= 5.0.0" >&2
+    if [ "$UNSAFE_SUPPORT" = "noop" ]; then
+        echo "[${COMPONENT}]       this OpenClaw advertises --dangerously-force-unsafe-install as a" >&2
+        echo "[${COMPONENT}]       deprecated no-op; the safety scan follows the operator-owned" >&2
+        echo "[${COMPONENT}]       security.installPolicy instead." >&2
+    fi
     exit 1
 }
 


### PR DESCRIPTION
## Why

`install.sh` passed `--dangerously-force-unsafe-install` unconditionally and documented an install-time dangerous-code scanner as the reason. Current OpenClaw keeps that token only as a deprecated no-op — 2026.9.2's own option description reads "Deprecated no-op; security.installPolicy may still block", and #3099's install log confirmed it "is deprecated and no longer affects plugin installs". So the script advertised a bypass it was not performing, `AGENT_MEMORY_SAFE_INSTALL`'s documented bypass-vs-blocking-scan distinction collapsed (both paths are equivalent on current hosts), and the script diverged from `anolisa-core`, which already classifies the same option as `UnsafeInstallSupport::{Effective, DeprecatedNoOp, Unsupported}`, refuses `--allow-unsafe-plugin-install` when it is absent or a no-op, and points operators at `security.installPolicy`.

## What changed

- `src/agent-memory/adapters/agent-memory/openclaw/scripts/install.sh` classifies the flag from the `plugins install --help` text the #3149 consent probe already captures — one CLI call, no version gate — with the same whole-token match and the same line-scoped `no-op` check as `anolisa-core`'s `unsafe_install_support()`:
  - **effective** → flag appended (legacy hosts that still scan plugin code at install time), reason logged;
  - **noop** → flag omitted and the omission logged; if such a host then rejects the install, the failure output points at the operator-owned `security.installPolicy`, mirroring `anolisa-core`'s `DeprecatedNoOp` advice;
  - **absent** → flag omitted silently, including the probe-failure path whose existing WARNING already reports base-flags-only.
- The stale scanner comment is rewritten: the pre-2026.8.1 bypass rationale is kept as historical context for old hosts, and current no-op behaviour is stated explicitly.
- `AGENT_MEMORY_SAFE_INSTALL` is kept rather than removed, redefined as "never request the bypass" — observable only where the flag still has effect. Removing it would have silently granted the bypass on exactly those hosts.
- `docs/user-guide/{en,zh}/token-saving/agent-memory.md` record the gating next to the existing consent note.
- The idiom, variable names (`UNSAFE_SUPPORT`, `help_line`, `help_line_lc`) and the `tr` lowercase fold deliberately match the tokenless installer's equivalent gate from 2bcabb24, which landed while this change was in flight, so both scripts and `anolisa-core` now classify the option identically. That is also why this PR carries no tokenless edit: #3161's fourth bullet is already satisfied on main.

## Related issue

fixes #3161

## User / Agent impact

On current OpenClaw hosts `install.sh` no longer sends a flag that does nothing, and says so in its output. On hosts where the flag is still effective the argv is unchanged apart from option order (`--force [--accept-capabilities] [--dangerously-force-unsafe-install]`). `AGENT_MEMORY_SAFE_INSTALL=1` keeps refusing the bypass. If a no-op host's `security.installPolicy` rejects the plugin, the script now fails with actionable advice instead of implying a bypass was attempted.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The security-sensitive change is a narrowing: the bypass is now requested only where the host advertises it as effective. No host loses an install it used to get — on no-op hosts the flag has no effect on the outcome, and on hosts that do not advertise the token the previous argv would have aborted with "does not recognize option". `AGENT_MEMORY_SAFE_INSTALL` keeps its name and its refusal semantics; only its documented meaning is corrected. No contract with `anolisa-core`, the adapter manifest, or the RPM changes.

## Validation

Stub `openclaw` CLI on Linux bash, asserting the exact install argv and the classification log line for each help text — 18 cases, all passing:

- modern no-op host, uppercase `NO-OP`, `no op` spelling, 4000-line help output (SIGPIPE regression) → `plugins install <dir> --force --accept-capabilities`
- legacy effective host (with and without the consent option) and a combined-flag help line → `--force [--accept-capabilities] --dangerously-force-unsafe-install`
- near-miss `--dangerously-force-unsafe-install-only`, and a host omitting the token → flag not sent, no unsafe log line
- `AGENT_MEMORY_SAFE_INSTALL=1` on both host classes → bypass never requested
- probe failure → still installs with the base flags plus the existing WARNING
- policy-blocked no-op host → exit 1 with the `security.installPolicy` advice
- consent gate on a modern host → installs, i.e. #3149's behaviour is preserved

Also run:

- `bash src/tokenless/tests/test-openclaw-adapter-install.sh` → 12 PASS (file unchanged; re-run to confirm the sibling script did not regress)
- `shellcheck -s bash` on the changed script → clean
- `bash scripts/docs-lint.sh` and `python3 scripts/docs-link-check.py` → PASS

Known gap: the `Test agent-memory` job runs `cargo fmt` / `clippy` / `test` only, so this script still has no committed regression test. That harness is #3160 and is deliberately kept a separate change. Shared known limitation with both siblings: the deprecation check reads only the first help line that lists the flag, so a `no-op` marker wrapped onto a continuation line goes undetected — changing that idiom must happen on all sides at once.

## Documentation and rollback

`docs/user-guide/en/token-saving/agent-memory.md` and its `zh` counterpart gained one paragraph describing the gating and `AGENT_MEMORY_SAFE_INSTALL`; the tokenless pages were already updated by 2bcabb24. Rollback is a plain revert of the single script commit — the previous unconditional-bypass argv returns, with no state, config, or packaging migration involved.

Related to AGE-6757 (internal Multica tracking)
