### PR TITLE
test(tokenless): backport installer-test guards from the memory suite

### DIFF
--- a/src/tokenless/tests/test-openclaw-adapter-install.sh
+++ b/src/tokenless/tests/test-openclaw-adapter-install.sh
@@ -1,12 +1,27 @@
 #!/usr/bin/env bash
 # Check installer flag negotiation (capability consent and the legacy
 # unsafe-install bypass) without installing a real plugin.
+#
+# Guards pinned here (shared with the agent-memory installer suite, whose
+# stub-CLI harness has the same shape):
+#   - probe form: `plugins install --help` is captured into a variable and
+#     matched whole-token, never piped into `grep -q`. The `big` scenario
+#     writes past any pipe buffer, so a piped probe SIGPIPEs the writer and
+#     loses the match under `pipefail`.
+#   - whole-token matching across alternate help layouts (`colon`, `paren`)
+#     as well as near-miss options (`near_match`, `unsafe_near`).
+#   - hermetic scenarios: ambient installer switches are unset per run, and
+#     the suite self-invokes under hostile values at the end.
+#   - diagnosability: counts come from awk (always exit 0) and every
+#     assertion ends in `fail`, so a regression prints a FAIL line instead of
+#     dying silently inside a failing assignment pipeline.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_SH="$SCRIPT_DIR/../adapters/tokenless/openclaw/scripts/install.sh"
 SANDBOX="$(mktemp -d -t tokenless-openclaw-install.XXXXXX)"
 trap 'rm -r -- "$SANDBOX"' EXIT
+# The space in "adapter root" pins argv quoting through ADAPTER_DIR.
 mkdir -p "$SANDBOX/adapter root/openclaw/dist"
 : > "$SANDBOX/adapter root/openclaw/dist/index.js"
 
@@ -18,9 +33,26 @@ set -euo pipefail
 printf '%s\n' "$*" >> "$TEST_ARGV_LOG"
 if [ "$*" = "plugins install --help" ]; then
     echo "--force"
-    case "$TEST_SUPPORT" in
+    case "${TEST_SUPPORT:?}" in
         modern|modern_unsafe) echo "--accept-capabilities" ;;
         near_match) echo "--accept-capabilities-only" ;;
+        # Alternate layouts exercise the whole-token regex boundaries: a
+        # prefix-anchored regex misses these, a substring regex over-matches
+        # the near_match option above.
+        colon) echo "--accept-capabilities: accept declared capabilities" ;;
+        paren) echo "Options (--accept-capabilities):" ;;
+        big)
+            echo "--accept-capabilities"
+            # Exceeds any pipe buffer: if the probe is ever reverted from
+            # capture-into-variable to `cmd | grep -q`, grep's early exit
+            # SIGPIPEs this writer under pipefail and the match is lost.
+            # Same ~2.6 MB help volume as the agent-memory suite's `big`
+            # scenario, laid out as fewer/longer lines: tokenless's install.sh
+            # regex-scans every help line for the unsafe-install token (the
+            # agent-memory installer matches the whole buffer once), so here
+            # line count — not byte count — is what this scenario costs.
+            big_line="filler$(printf '%.0s-' {1..512})"
+            for _ in {1..5000}; do printf '%s\n' "$big_line"; done ;;
         failed) echo "cannot inspect --accept-capabilities" >&2; exit 3 ;;
     esac
     case "$TEST_SUPPORT" in
@@ -43,7 +75,7 @@ for arg in "$@"; do
     [ "$arg" != --dangerously-force-unsafe-install ] || unsafe=1
 done
 case "$TEST_SUPPORT" in
-    modern|modern_unsafe)
+    modern|modern_unsafe|colon|paren|big)
         [ "$accepted" = 1 ] || { echo 'Plugin requires capability consent' >&2; exit 1; }
         ;;
     *)
@@ -70,50 +102,161 @@ export OPENCLAW_HOME="$SANDBOX/ignored home"
 export TEST_STATE_DIR="$OPENCLAW_STATE_DIR"
 export TEST_ARGV_LOG="$SANDBOX/argv"
 export TEST_INSTALLED="$SANDBOX/installed"
-export ANOLISA_DRY_RUN=0
 
-for TEST_SUPPORT in modern legacy near_match unsafe_effective unsafe_noop unsafe_noop_upper unsafe_near modern_unsafe; do
-    export TEST_SUPPORT
+fail() {
+    echo "FAIL: $1" >&2
+    sed 's/^/    /' "$SANDBOX/output" >&2
+    exit 1
+}
+
+# run_installer [KEY=VAL ...] — invoke install.sh against a cleared argv log
+# and no installed marker. The installer switches are unset first so ambient
+# values in the caller's environment cannot falsify a baseline scenario;
+# per-scenario KEY=VAL overrides are applied after the unsets.
+run_installer() {
     : > "$TEST_ARGV_LOG"
-    bash "$INSTALL_SH" > "$SANDBOX/output" 2>&1 || { cat "$SANDBOX/output" >&2; exit 1; }
-    [ -f "$TEST_INSTALLED" ]
-    [ "$(grep -c '^plugins install --help$' "$TEST_ARGV_LOG")" = 1 ]
+    rm -f "$TEST_INSTALLED"
+    env -u ANOLISA_DRY_RUN -u ANOLISA_TARGET -u ANOLISA_COMPONENT \
+        "$@" bash "$INSTALL_SH" >"$SANDBOX/output" 2>&1
+}
+
+# Full expected install argv for the given flag combination:
+# argv <accept-capabilities:yes|no> <unsafe-install:yes|no>
+argv() {
+    local a="plugins install $ANOLISA_ADAPTER_DIR/openclaw --force"
+    if [ "$1" = yes ]; then a="$a --accept-capabilities"; fi
+    if [ "$2" = yes ]; then a="$a --dangerously-force-unsafe-install"; fi
+    printf '%s' "$a"
+}
+
+# Counters use awk (always exit 0) rather than `grep -c` or `grep -v | wc -l`:
+# a zero-count grep or a failing pipeline in an assignment kills the whole
+# suite under `set -euo pipefail` before the fail() below can print anything.
+count_probes() { awk '/^plugins install --help$/ {n++} END {print n+0}' "$TEST_ARGV_LOG"; }
+count_installs() { awk '/^plugins install / && !/--help$/ {n++} END {print n+0}' "$TEST_ARGV_LOG"; }
+
+expect_one_probe() {
+    local label="$1" probes
+    probes="$(count_probes)"
+    [ "$probes" = 1 ] || fail "$label: expected exactly one help probe, got $probes"
+}
+
+check_argv_log() {
+    local label="$1" want_argv="$2" installs install_argv
+    expect_one_probe "$label"
+    installs="$(count_installs)"
+    [ "$installs" = 1 ] || fail "$label: expected exactly one install invocation, got $installs"
+    install_argv="$(awk '/^plugins install / && !/--help$/ {print}' "$TEST_ARGV_LOG")"
+    [ "$install_argv" = "$want_argv" ] || fail "$label: install argv '$install_argv' != '$want_argv'"
+}
+
+expect_no_install() {
+    local label="$1" installs
+    installs="$(count_installs)"
+    [ "$installs" = 0 ] || fail "$label: install ran despite failure ($installs invocation(s))"
+}
+
+expect_log() { grep -q -- "$2" "$SANDBOX/output" || fail "$1: expected log line: $2"; }
+expect_no_log() { ! grep -q -- "$2" "$SANDBOX/output" || fail "$1: unexpected log line: $2"; }
+
+for TEST_SUPPORT in modern legacy near_match colon paren big \
+                    unsafe_effective unsafe_noop unsafe_noop_upper unsafe_near \
+                    modern_unsafe; do
+    export TEST_SUPPORT
+    want_caps=no
+    want_unsafe=no
+    case "$TEST_SUPPORT" in
+        modern|colon|paren|big) want_caps=yes ;;
+        modern_unsafe) want_caps=yes; want_unsafe=yes ;;
+        unsafe_effective) want_unsafe=yes ;;
+    esac
+    rc=0
+    run_installer || rc=$?
+    [ "$rc" = 0 ] || fail "$TEST_SUPPORT installer: rc=$rc, want 0"
+    [ -f "$TEST_INSTALLED" ] || fail "$TEST_SUPPORT installer: install did not run"
+    check_argv_log "$TEST_SUPPORT installer" "$(argv "$want_caps" "$want_unsafe")"
     case "$TEST_SUPPORT" in
         unsafe_effective|modern_unsafe)
-            grep -q -- '--dangerously-force-unsafe-install is required' "$SANDBOX/output" ;;
+            expect_log "$TEST_SUPPORT installer" '--dangerously-force-unsafe-install is required' ;;
         *)
-            ! grep -q -- '--dangerously-force-unsafe-install is required' "$SANDBOX/output" ;;
+            expect_no_log "$TEST_SUPPORT installer" '--dangerously-force-unsafe-install is required' ;;
     esac
-    rm "$TEST_INSTALLED"
     echo "PASS: $TEST_SUPPORT installer"
 done
 
 export TEST_SUPPORT=noop_rejected
-if bash "$INSTALL_SH" > "$SANDBOX/output" 2>&1; then
-    echo 'FAIL: policy-rejected install reported success' >&2
-    exit 1
-fi
-[ ! -f "$TEST_INSTALLED" ]
-grep -q 'security.installPolicy' "$SANDBOX/output"
-grep -q 'deprecated no-op' "$SANDBOX/output"
+rc=0
+run_installer || rc=$?
+[ "$rc" = 1 ] || fail "noop_rejected: policy-rejected install reported rc=$rc, want 1"
+[ ! -f "$TEST_INSTALLED" ] || fail 'noop_rejected: install completed despite the policy refusal'
+# The install IS attempted with base flags; the host then refuses it because
+# the safety scan moved to security.installPolicy.
+check_argv_log 'noop_rejected' "$(argv no no)"
+expect_log 'noop_rejected' 'security.installPolicy'
+expect_log 'noop_rejected' 'deprecated no-op'
 echo 'PASS: noop host failure points at security.installPolicy'
 
 export TEST_SUPPORT=failed
-if bash "$INSTALL_SH" > "$SANDBOX/output" 2>&1; then
-    echo 'FAIL: failed help probe allowed installation' >&2
-    exit 1
-fi
-[ ! -f "$TEST_INSTALLED" ]
+rc=0
+run_installer || rc=$?
+[ "$rc" = 1 ] || fail "failed probe: rc=$rc, want 1"
+[ ! -f "$TEST_INSTALLED" ] || fail 'failed probe: install ran despite failure'
+expect_one_probe 'failed probe'
+expect_no_install 'failed probe'
+expect_log 'failed probe' 'Cannot inspect OpenClaw installer options'
 echo 'PASS: failed help probe stops installation'
 
-: > "$TEST_ARGV_LOG"
-ANOLISA_DRY_RUN=1 bash "$INSTALL_SH" > "$SANDBOX/output" 2>&1
-[ ! -s "$TEST_ARGV_LOG" ]
-[ ! -f "$TEST_INSTALLED" ]
-grep -q -- '--accept-capabilities' "$SANDBOX/output"
-grep -q -- '--dangerously-force-unsafe-install' "$SANDBOX/output"
+# Dry-run must describe both gates without touching the CLI at all.
+export TEST_SUPPORT=modern
+rc=0
+run_installer ANOLISA_DRY_RUN=1 || rc=$?
+[ "$rc" = 0 ] || fail "dry-run: rc=$rc, want 0"
+[ ! -s "$TEST_ARGV_LOG" ] || fail 'dry-run: openclaw must not be invoked'
+[ ! -f "$TEST_INSTALLED" ] || fail 'dry-run: install ran'
+expect_log 'dry-run' '--accept-capabilities'
+expect_log 'dry-run' '--dangerously-force-unsafe-install'
 echo 'PASS: dry-run describes consent and bypass gating without invoking OpenClaw'
 
-OPENCLAW_BIN="$SANDBOX/missing-openclaw" bash "$INSTALL_SH" > "$SANDBOX/output" 2>&1
-grep -q 'skipping plugin installation' "$SANDBOX/output"
+rc=0
+run_installer OPENCLAW_BIN="$SANDBOX/missing-openclaw" || rc=$?
+[ "$rc" = 0 ] || fail "missing CLI: rc=$rc, want 0"
+[ ! -s "$TEST_ARGV_LOG" ] || fail 'missing CLI: openclaw must not be invoked'
+[ ! -f "$TEST_INSTALLED" ] || fail 'missing CLI: install ran'
+expect_log 'missing CLI' 'skipping plugin installation'
 echo 'PASS: missing CLI preserves the existing skip behavior'
+
+# Diagnosability pin: a regressed install.sh that probes but never invokes
+# install must produce a FAIL diagnostic — not a silent set -e death from a
+# failing pipeline inside an assignment. The check runs in a child bash -c:
+# an OR-list subshell would suppress errexit inside it and hide exactly the
+# silent death this pin guards against.
+fake_install="$SANDBOX/fake-install.sh"
+cat > "$fake_install" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "[tokenless] Installing openclaw plugin..."
+env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install --help >/dev/null 2>&1
+# Regressed: exits successfully without invoking the install.
+exit 0
+FAKE
+pin_body="set -euo pipefail
+$(declare -f fail run_installer count_probes count_installs expect_one_probe check_argv_log)
+run_installer
+check_argv_log 'harness pin: install never invoked' 'plugins install never-ran'"
+pin_rc=0
+env SANDBOX="$SANDBOX" INSTALL_SH="$fake_install" bash -c "$pin_body" \
+    >"$SANDBOX/pin-output" 2>&1 || pin_rc=$?
+[ "$pin_rc" -ne 0 ] || fail 'harness pin: check should have failed'
+grep -q 'expected exactly one install invocation' "$SANDBOX/pin-output" \
+    || fail 'harness pin: no diagnosable FAIL line (silent death)'
+echo 'PASS: missing install invocation fails with a diagnostic'
+
+# The suite must be hermetic: hostile ambient installer switches must neither
+# leak into scenarios nor break the suite itself.
+if [ -z "${TEST_HOSTILE_AMBIENT:-}" ]; then
+    rc=0
+    env ANOLISA_DRY_RUN=1 ANOLISA_TARGET=hostile ANOLISA_COMPONENT=hostile \
+        TEST_HOSTILE_AMBIENT=1 bash "$0" >"$SANDBOX/output" 2>&1 || rc=$?
+    [ "$rc" = 0 ] || fail "hostile ambient environment broke the suite (rc=$rc)"
+    echo 'PASS: hostile ambient environment does not leak into scenarios'
+fi


### PR DESCRIPTION
## Why

`src/tokenless/tests/test-openclaw-adapter-install.sh` was the template the agent-memory OpenClaw installer suite was modelled on. That suite has since grown four guard groups covering latent-hazard classes this copy does not pin.

tokenless `install.sh` has **no defect today** — it already captures `plugins install --help` into a variable and matches it whole-token. But nothing pins that form, so a future "simplification" back to `cmd | grep -q` would silently lose matches on large help outputs under `pipefail`, and an ambient installer switch could falsify a baseline scenario without any assertion noticing.

## What changed

Test-only. One file changed: `src/tokenless/tests/test-openclaw-adapter-install.sh` (+174 / -31). No production code changes.

1. **SIGPIPE regression** — new `big` scenario: ~2.6 MB of help output, far past any pipe buffer, with `--accept-capabilities` advertised before the filler. A piped `grep -q` probe matches early, exits, SIGPIPEs the writer, and loses the match under `pipefail`.
2. **Hostile ambient environment** — every scenario now runs `install.sh` through `env -u ANOLISA_DRY_RUN -u ANOLISA_TARGET -u ANOLISA_COMPONENT`, with per-scenario `KEY=VAL` overrides applied *after* the unsets. The suite then re-invokes itself under hostile values for those switches and asserts it still passes.
3. **Alternate help layouts** — new `colon` (`--flag: desc`) and `paren` (`Options (--flag):`) scenarios exercise the whole-token regex boundaries beyond the existing near-miss options.
4. **Harness diagnosability** — probe/install counts come from `awk` (always exit 0) instead of `grep -c` / `grep -v | wc -l`; every assertion ends in a `fail` diagnostic that dumps the captured installer output; and a child-`bash -c` pin proves that a regressed installer which probes but never installs reports a FAIL line instead of dying silently inside a failing assignment pipeline.

Scenarios also assert the exact install argv now, not just the installed marker, so a dropped or reordered flag is caught. The previous bare `bash "$INSTALL_SH" || { cat ...; exit 1; }` forms all route through the shared `run_installer` / `fail` helpers.

### One deliberate deviation: the `big` filler layout

The agent-memory suite emits 200k short filler lines. Here the same ~2.6 MB is spread over 5000 long lines instead. tokenless `install.sh` regex-scans *every* help line looking for `--dangerously-force-unsafe-install` (the agent-memory installer matches the whole buffer once), so line count — not byte count — drives this scenario's cost. With 200k short lines the scenario took ~18 s and the suite runs it twice (outer run + hostile self-invocation), for ~38 s total. Identical byte volume keeps the SIGPIPE property unchanged at ~1.3 s per scenario; whole-suite runtime goes 0.2 s → 2.9 s instead of 0.2 s → 38 s. Only bytes matter for the SIGPIPE hazard: `grep -q` exits at the first match regardless of how many lines follow.

## Related issue

closes #3170

## User / Agent impact

None. Test-only; no runtime behavior changes.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk — none of the above apply. The suite stays bash-3.2 compatible (no `${var,,}`, no associative arrays, no `mapfile`) and `shellcheck`-clean. `make test-adapters` invokes it the same way as before.

## Validation

### Environment

- Linux, x86_64, 32 cores
- GNU bash 4.4.20, GNU Awk 4.2.1, GNU grep 3.1, GNU coreutils `env`
- ShellCheck 0.10.0

### Commands run

| Check | Result |
| --- | --- |
| `bash -n src/tokenless/tests/test-openclaw-adapter-install.sh` | pass (syntax) |
| `shellcheck -s bash src/tokenless/tests/test-openclaw-adapter-install.sh` | pass, 0 findings (file at `HEAD~1` also 0 findings — no new warnings) |
| `bash src/tokenless/tests/test-openclaw-adapter-install.sh` | **17/17 PASS**, rc=0, 2.9 s |
| `cd src/tokenless && bash tests/test-openclaw-adapter-install.sh` (exactly how `make test-adapters` invokes it) | **17/17 PASS**, rc=0 |
| same, via absolute path | **17/17 PASS**, rc=0 |
| same, executed directly (`./tests/...`) | **17/17 PASS**, rc=0 |
| same, under hostile ambient env: `ANOLISA_DRY_RUN=1 ANOLISA_TARGET=x ANOLISA_COMPONENT=y OPENCLAW_BIN=/nonexistent OPENCLAW_HOME=/nonexistent ANOLISA_ADAPTER_DIR=/nonexistent` | **17/17 PASS**, rc=0 |
| 3 consecutive repeat runs | rc=0 / rc=0 / rc=0 — no flakiness |
| leftover `mktemp -d` sandboxes after all runs | 0 (EXIT trap cleans up) |

Baseline before this change: 12/12 PASS in 0.18 s.

Scenario list now emitted: `modern`, `legacy`, `near_match`, `colon`, `paren`, `big`, `unsafe_effective`, `unsafe_noop`, `unsafe_noop_upper`, `unsafe_near`, `modern_unsafe`, `noop_rejected`, `failed` probe, dry-run, missing CLI, harness diagnosability pin, hostile-ambient hermeticity.

### Mutation testing — each guard proven load-bearing

Every mutation was applied to a throwaway scratch copy of the tree (test + `install.sh`) and was never committed. Each one was run against the final version of the suite.

| # | Mutation | Observed |
| --- | --- | --- |
| M1 | `install.sh`: whole-buffer `[[ =~ ]]` for `--accept-capabilities` reverted to `printf '%s\n' "$INSTALL_HELP"` piped into `grep -qE` with the *same* regex | `modern` … `paren` still PASS, then **`FAIL: big installer: rc=1, want 0`** with `Plugin requires capability consent` — the piped probe SIGPIPEd and lost the match. Only `big` sees it, which is exactly the isolation the scenario is for. |
| M2 | `install.sh`: whole-token regex weakened to a substring test (`== *--accept-capabilities*`) | **`FAIL: near_match installer: rc=1, want 0`** with `unknown option --accept-capabilities` |
| M3 | `install.sh`: token boundary narrowed to whitespace only (`(^|[[:space:]])…([[:space:]]|$)`) | **`FAIL: colon installer: rc=1, want 0`**. Control: with `colon`/`paren` removed from the scenario list the same mutation passes **15/15, rc=0** — the two new scenarios are the only thing that detects it. |
| M4 | suite: drop `-u ANOLISA_DRY_RUN` from the per-scenario `env` guard | **`FAIL: hostile ambient environment broke the suite (rc=1)`**, dumping the nested `FAIL: modern installer: install did not run` and the leaked `DRY-RUN:` output. Caught with no external ambient variable set at all. |
| M5 | suite: `count_installs` reverted to `grep '^plugins install '` piped into `grep -vc -- '--help$'` inside an assignment | rc=1 with **zero FAIL lines printed** — the suite died silently at `expect_no_install 'failed probe'`. This is precisely the trap the `awk` form avoids. |
| M5b | same pipeline, but inlined only in `check_argv_log` so the suite survives long enough to reach the pin | **`FAIL: harness pin: no diagnosable FAIL line (silent death)`**; the mutated counter produced 0 diagnostic lines, confirming the pin detects silent death rather than merely a non-zero rc. |

### Not run (and why)

- **`make test-adapters` end-to-end** — its `build-openclaw-plugin` prerequisite needs an npm/tsc toolchain that is not available in this environment. The suite was instead invoked exactly the way that target invokes it (`cd src/tokenless && bash tests/test-openclaw-adapter-install.sh`); it does not need the built plugin because the harness synthesises its own `dist/index.js` inside a temp sandbox.
- **`cargo check` / `cargo build` / `cargo test` / `cargo fmt` / `cargo clippy`** — this change touches no Rust code; the `test-tokenless` CI job's Rust gates are unaffected.
- **Other adapter suites** (`test-dsh-adapter.sh`, `test-qoder-adapter-install.sh`, `test-opencode-adapter-install.sh`, `test-qwenpaw-adapter-install.sh`, `test-openclaw-lifecycle-v2.mjs`) — untouched, and they share no helper or fixture with this file.
- **Execution under bash 3.2** — not available here. The file was reviewed for 3.2 compatibility instead: no `${var,,}`, no associative arrays, no `mapfile`; the constructs used (numeric brace ranges, `<<<`, `[[ =~ ]]`, `declare -f`, `local`, `env -u`) are all 3.2-era.
- **`shellcheck` gate in CI** — the repo only runs `shellcheck` for `src/cosh-ng`, so this file is not covered by a CI lint gate; it was run locally anyway.

## Documentation and rollback

No documentation changed. Revert the single commit to restore the previous 12-scenario suite; nothing else depends on it.
