### PR TITLE
feat(tokenless): add search path sharing

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/en/token-saving/tokenless/user-manual.md
@@ -44,7 +44,8 @@ the [Python SDK guide](sdk.md) for both layers, runnable examples, and configura
 | Capability | Behavior implemented in the current code | Important boundary |
 |------------|------------------------------------------|--------------------|
 | Schema compression | Removes `title` and `examples`, removes fenced and inline code from descriptions, collapses whitespace, and truncates descriptions | Common BeforeModel passes lossy transformations through without marker-authorized recovery; OpenCode's per-tool path and the direct CLI still compress (Qwen Code skips the declared event) |
-| Content-aware response compression | Successful PostTool JSON is routed to `JsonCompressor`; recognized successful build/test command output is routed to `BuildLogCompressor`; CSV/TSV is routed to `TabularCompressor`; only a smaller end-to-end result is accepted | Other content domains and Tool Errors pass through; recoverable reduction requires either Marker-authorized framework retrieval or a supported Marker command path |
+| Content-aware response compression | Successful PostTool JSON is routed to `JsonCompressor`; recognized successful build/test command output is routed to `BuildLogCompressor`; CSV/TSV is routed to `TabularCompressor`; supported search listings use `SearchResultsCompressor`; only a smaller end-to-end result is accepted | Other content domains and Tool Errors pass through; recoverable reduction requires either Marker-authorized framework retrieval or a supported Marker command path |
+| Search path sharing | Shares paths across consecutive API search records, including native Claude Grep, retaining all received text and positions | Enabled by default; requires API response origin, text replacement and no-context records; file and command outputs pass through this domain |
 | TOON encoding | Encodes JSON and keeps the JSON input when the estimated token count does not decrease | Replaces the original when the host accepts text replacement; hosts without replacement capability pass through |
 | Command rewriting | Calls `rtk rewrite` and submits the rewritten shell input when a rule is available | Recognized build/test commands stay native for Build Log handling; other unsupported or denied rewrites pass through |
 | Tool Ready | Legacy pre-call checks for declared binaries, versions, configuration, permissions, and optional dependencies | Hard-disabled; it cannot inspect, repair, or block tool execution |
@@ -59,7 +60,7 @@ After an adapter is enabled, a tool call may pass through these stages:
 ```text
 Before the tool: hard-disabled Tool Ready hook → command rewrite
 Before the tool: reserve recognized build/test commands; otherwise RTK rewrite → carry output-optimization state
-After the tool: status and optimization bypass → JSON/CSV/TSV/Build Log PostTool Pipeline → optional Stash/TOON → statistics
+After the tool: status and optimization bypass → JSON/CSV/TSV/Search/Build Log PostTool Pipeline → optional Stash/TOON → statistics
 Before the model: schema compression → visible Marker extraction → conditional Retrieve declaration
 Retrieve: visible-Marker authorization → byte-identical Stash read
 ```
@@ -94,6 +95,24 @@ This setting does not disable RTK command rewriting, adapter execution, or retri
 anolisa adapter disable tokenless <framework>
 ```
 
+### Controlling search path sharing
+
+API search path sharing is enabled by default. Set `TOKENLESS_SEARCH_PATH_SHARING_ENABLED=0`
+in the agent process environment to disable it through the CLI. When unset it stays enabled;
+`1`, `true`, and `yes` also enable it (case-insensitively). Empty and other values disable it.
+This setting is independent of `config.json`. Python SDK callers can disable it with
+`TokenlessConfig(search_path_sharing_enabled=False)`; Rust callers set
+`RuntimeConfig.search_path_sharing_enabled` to `false`. All entry points default to enabled.
+
+Disabling this feature returns search listings unchanged. JSON, table, and log compression
+remain available for other tool names. The exact name `Grep` always excludes those compressors
+to preserve received matches, even with path sharing disabled. A custom tool named `Grep`
+therefore cannot restore its pre-feature JSON/table/log compression through this switch.
+Supported no-context Claude Grep results retain all received matches; file reads and command outputs,
+including Bash without RTK, do not enter search path sharing. Other API tools can use the same
+Core capability. Whole-task savings depend on the workload; smaller search results do not
+guarantee lower total token use.
+
 ### CSV/TSV views can be incomplete
 
 Successful CSV/TSV tool results can be compressed when the host can replace output with text.
@@ -125,6 +144,19 @@ provenance are never partially reported.
 
 A reduced candidate must use fewer characters and estimated tokens than both the original and
 full view, including the notice. These checks do not guarantee savings with every model tokenizer.
+
+### Native Grep keeps every received match
+
+On Claude Code 2.1.121 or newer, native Grep content results can share repeated file paths.
+A `File="..."` heading supplies the full path for the following `line:text` rows, until the next
+file heading. All received records, source text, whitespace and line endings are retained.
+The view is used only when it is smaller; it needs no Stash entry or retrieval command.
+
+This first version supports no-context `path:line:text` listings with at least three records
+and paths without colons. Context queries, count/file-list modes, unsupported listings and
+file reads keep their existing behavior. Bash searches continue through RTK. Grep may already
+have applied a host limit before Tokenless receives the result; path sharing does not recover
+those missing matches. Lower first-result size does not guarantee lower total task cost.
 
 ### Reversible compression is conditional
 

--- a/docs/user-guide/zh/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/zh/token-saving/tokenless/user-manual.md
@@ -42,7 +42,8 @@ Python SDK 分为两层。`anolisa-tokenless` 包开放通用 `TokenlessSdk`、�
 | 能力 | 当前代码实际执行的行为 | 重要边界 |
 |------|------------------------|----------|
 | Schema 压缩 | 移除 `title` 和 `examples`，删除描述中的围栏代码和行内代码，合并空白并截断描述 | Common BeforeModel 在没有 Marker 授权恢复时透传有损变换；OpenCode 逐工具路径和直接 CLI 仍会压缩（Qwen Code 会跳过声明的事件） |
-| Content-aware 响应压缩 | 成功的 PostTool JSON 路由给 `JsonCompressor`；已识别的成功构建/测试命令输出路由给 `BuildLogCompressor`；CSV/TSV 路由给 `TabularCompressor`；只接受端到端更小的结果 | 其他内容域与 Tool Error 透传；可恢复缩减需要受 Marker 授权的 Framework 恢复或受支持的 Marker 命令路径 |
+| Content-aware 响应压缩 | 成功的 PostTool JSON 路由给 `JsonCompressor`；已识别的成功构建/测试命令输出路由给 `BuildLogCompressor`；CSV/TSV 路由给 `TabularCompressor`；支持的搜索列表交给 `SearchResultsCompressor`；只接受端到端更小的结果 | 其他内容域与 Tool Error 透传；可恢复缩减需要受 Marker 授权的 Framework 恢复或受支持的 Marker 命令路径 |
+| 搜索路径共享 | API 搜索记录（含 Claude 原生 Grep）的连续行共享完整路径，保留收到的全部文本与位置 | 默认开启；需要 API 响应来源、文本替换能力及无上下文记录；文件和命令输出不进入此域 |
 | TOON 编码 | 编码 JSON；估算 Token 没有下降时保留 JSON 输入 | 宿主支持文本替换时替换原文；无替换能力的宿主透传 |
 | 命令重写 | 有匹配规则时调用 `rtk rewrite`，再向框架提交改写后的 Shell 输入 | 已识别的构建/测试命令保持原生输出交给 Build Log；其他无规则或被拒绝的改写透传 |
 | Tool Ready | 旧版调用前能力，用于检查声明的二进制、版本、配置、权限和可选依赖 | 已硬关闭；不会检查、修复或阻断工具调用 |
@@ -56,7 +57,7 @@ Python SDK 分为两层。`anolisa-tokenless` 包开放通用 `TokenlessSdk`、�
 
 ```text
 工具调用前：已识别的构建/测试命令预留给 Build Log；其他命令 RTK 改写 → 传递输出优化状态
-工具调用后：状态与优化旁路 → JSON/CSV/TSV/Build Log PostTool Pipeline → 可选 Stash/TOON → 写入统计
+工具调用后：状态与优化旁路 → JSON/CSV/TSV/Search/Build Log PostTool Pipeline → 可选 Stash/TOON → 写入统计
 模型调用前：Schema 压缩 → 提取可见 Marker → 条件式 Retrieve 声明
 Retrieve：可见 Marker 授权 → 字节级一致的 Stash Read
 ```
@@ -90,6 +91,21 @@ CLI-only 用法不需要 Adapter。
 anolisa adapter disable tokenless <framework>
 ```
 
+### 控制搜索路径共享
+
+API 搜索路径共享默认开启。在 Agent 进程环境中设置 `TOKENLESS_SEARCH_PATH_SHARING_ENABLED=0`，
+可通过 CLI 关闭该功能。未设置时保持开启，`1`、`true`、`yes`（不区分大小写）也表示开启；
+空值和其他值均关闭。该设置独立于 `config.json`。Python SDK 可使用
+`TokenlessConfig(search_path_sharing_enabled=False)` 关闭；Rust 将
+`RuntimeConfig.search_path_sharing_enabled` 设为 `false`。所有入口均默认开启。
+
+关闭此功能时搜索列表原样返回。其他工具名仍可使用 JSON、表格和日志压缩。精确名称 `Grep`
+始终排除这些压缩器以保留已收到命中，即使路径共享关闭也不例外。因此，自定义 `Grep` 工具
+无法通过此开关恢复此功能引入前的 JSON、表格和日志压缩。支持的无上下文 Claude Grep 结果
+保留全部已收到命中；
+文件读取和命令输出（包括没有 RTK 的 Bash）均不进入搜索路径共享。其他 API 工具也可使用同一 Core 能力。
+整任务节省取决于工作负载；搜索结果变小并不保证总 Token 用量更低。
+
 ### CSV/TSV 视图可能不完整
 
 宿主支持用文本替换输出时，成功的 CSV/TSV 工具结果可以被压缩。文件来源结果、失败工具、
@@ -114,6 +130,17 @@ Markdown 或定宽表格。
 
 计入提示后，缩减候选的字符数和估算 Token 数必须同时小于原文及全量视图。
 这些检查不保证在所有模型的 Tokenizer 下都有节省。
+
+### 原生 Grep 保留收到的全部命中
+
+Claude Code 2.1.121 及更新版本的原生 Grep 文本结果可以共享重复文件路径。
+`File="..."` 头提供后续 `line:text` 记录的完整路径，直到下一个文件头。
+收到的全部记录、源码正文、空白和换行均保留。仅采用更小的表示，不需要 Stash 条目或回取命令。
+
+首版支持至少三条记录的无上下文 `path:line:text` 列表，路径不能包含冒号。
+上下文查询、计数/文件列表模式、不支持的格式和文件读取保持现有行为；Bash 搜索继续经过 RTK。
+Grep 可能在 Tokenless 收到结果前已经应用宿主限额，路径共享无法恢复此前未交付的命中。
+首次结果变短不保证整个任务的总消耗下降。
 
 ### 可逆压缩是有条件的
 

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -6,7 +6,7 @@
 
 Token-Less combines complementary strategies to minimize LLM token consumption:
 
-- **Lifecycle-aware Compression** — Protocol v2 owns BeforeModel schema handling, PreTool RTK rewriting, PostTool routing, and authorized Retrieve; the PostTool Pipeline compresses JSON, CSV/TSV tables, and recognized build/test command logs.
+- **Lifecycle-aware Compression** — Protocol v2 owns BeforeModel schema handling, PreTool RTK rewriting, PostTool routing, and authorized Retrieve; the PostTool Pipeline compresses JSON, CSV/TSV tables, supported search listings, and recognized build/test command logs.
 - **TOON Context Compression** — Encodes JSON responses to TOON (Token-Oriented Object Notation) format via the `toon-format` library linked into `tokenless`, reducing syntax overhead for suitable structured data.
 - **Command Rewriting** — Integrates [RTK](https://github.com/rtk-ai/rtk) to filter and rewrite CLI command output, eliminating noise that would otherwise waste 60–90% of tokens.
 - **Tool Ready (legacy, hard-disabled)** — Its pre-call dependency checks are retained in source but unconditionally bypassed while the readiness model is redesigned.
@@ -35,6 +35,7 @@ retrieval, and attribution.
 | Schema compression | 47.3% on reference fixture | Compresses OpenAI Function Calling tool schemas |
 | Content-aware response compression | 36.3% lossless savings on the JSON reference fixture | Routes successful JSON through `JsonCompressor`; lossless candidates saving at least 15% take priority, while recoverable record arrays can be reduced to a 32-record base budget |
 | Build-log compression | workload-dependent | Cleans terminal control output and reduces repeated routine progress in recognized Cargo, pytest, npm/Jest, Go, Make/C, and generic command logs while preserving diagnostics, summaries, phases, and stack traces |
+| Search path sharing | workload-dependent | Enabled by default: API search listings, including Claude native Grep, share consecutive file paths and retain every received match; disable with `TOKENLESS_SEARCH_PATH_SHARING_ENABLED=0` or SDK `search_path_sharing_enabled=False`; command output remains on its existing route |
 | CSV/TSV table compression | workload-dependent | Preserves every cell when compacting quoting and record separators; larger tables can retain selected rows with an explicit incomplete-table notice and byte-exact original retrieval. Requires a text replacement slot; file reads pass through |
 | Reversible compression (stash) | — | Omitted record collections and bounded values are stashed; supported agents run `tokenless retrieve HASH` or call their static Retrieve Tool when full data is needed |
 | TOON context compression | 17.0% on reference response | Encodes JSON to TOON format for LLMs |

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -11,6 +11,7 @@ LLM Token 优化工具包——content-aware 压缩 + 命令重写 + 环境失�
 | Schema 压缩 | 参考 fixture 47.3% | 压缩 OpenAI Function Calling 工具定义 |
 | Content-aware 响应压缩 | JSON 参考 fixture 无损节省 36.3% | 把成功 JSON 路由给 `JsonCompressor`；达到 15% 的无损候选优先，可恢复的 Record Array 使用 32 条基础预算 |
 | Build Log 压缩 | 取决于具体负载 | 清理终端控制输出，并缩减已识别 Cargo、pytest、npm/Jest、Go、Make/C 和通用命令日志中的重复常规进度，同时保留诊断、摘要、阶段和 Stack Trace |
+| 搜索路径共享 | 取决于工作负载 | API 搜索列表（含 Claude 原生 Grep）可共享连续记录的文件路径并保留全部已收到命中；默认开启，通过 `TOKENLESS_SEARCH_PATH_SHARING_ENABLED=0` 或 SDK `search_path_sharing_enabled=False` 关闭；命令输出保持原路由 |
 | CSV/TSV 表格压缩 | 取决于具体负载 | 压紧引号和记录分隔符时保留全部单元格；较大的表格可保留选定行，明确提示表格不完整，并支持取回字节一致的原文。需要文本替换能力；文件读取透传 |
 | TOON 上下文压缩 | 参考响应 17.0% | 将 JSON 编码为 TOON 格式 |
 | 命令重写 | 60–90% | 通过 RTK 过滤 CLI 输出（支持 70+ 命令） |

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
@@ -275,9 +275,26 @@ def main() -> None:
     # instead of log-blind JSON; ensure_ascii=False matches the entry
     # point's normalization, so size gates measure Unicode characters on
     # both sides.
-    shell_field = _shell_text_field(tool_name, model_visible_before)
-    if shell_field is not None:
-        content = shell_field[1]
+    text_field = _shell_text_field(tool_name, model_visible_before)
+    tool_input = input_data.get("tool_input", {})
+    grep_content = (
+        agent_id == _CLAUDE_AGENT_ID
+        and tool_name == "Grep"
+        and isinstance(model_visible_before, dict)
+        and model_visible_before.get("mode") == "content"
+        and isinstance(model_visible_before.get("content"), str)
+        and isinstance(tool_input, dict)
+        and not any(
+            tool_input.get(flag)
+            for flag in ("-A", "-B", "-C", "context")
+        )
+    )
+    if grep_content:
+        # Native Grep has a text slot inside its schema-checked output object.
+        # Context queries retain their existing route until that format is supported.
+        text_field = ("content", model_visible_before["content"])
+    if text_field is not None:
+        content = text_field[1]
     elif isinstance(model_visible_before, str):
         content = model_visible_before
     elif isinstance(model_visible_before, (dict, list)):
@@ -292,12 +309,12 @@ def main() -> None:
     elif agent_id in {_QODER_AGENT_ID, _OPENCODE_AGENT_ID}:
         can_replace = True
         # An unwrapped shell field is plain text regardless of its envelope.
-        replace_with_text = shell_field is not None or not isinstance(
+        replace_with_text = text_field is not None or not isinstance(
             tool_response_raw, (dict, list)
         )
     elif agent_id == _CLAUDE_AGENT_ID:
         can_replace = _claude_supports_replacement()
-        replace_with_text = shell_field is not None or not isinstance(
+        replace_with_text = text_field is not None or not isinstance(
             tool_response_raw, (dict, list)
         )
         if not can_replace:
@@ -312,7 +329,10 @@ def main() -> None:
         replace_with_text = True
 
     # 9. Map host facts into the required lifecycle fields.
-    if tool_name in SKIP_TOOLS:
+    if grep_content:
+        # A filtered match listing is a tool response, not an authoritative file copy.
+        content_origin = "api_response"
+    elif tool_name in SKIP_TOOLS:
         content_origin = "file_content"
     elif tool_name in SHELL_TOOLS:
         content_origin = "command_output"
@@ -395,13 +415,13 @@ def main() -> None:
         _emit_attribution_or_skip(env_attribution)
 
     # 11. Envelope construction — dispatch by agent runtime. An unwrapped
-    # shell field is re-injected into a same-shaped envelope: the compressed
+    # text field is re-injected into a same-shaped envelope: the compressed
     # text replaces exactly the field that was sent, every other field stays
     # byte-identical.
     rewrapped = None
-    if shell_field is not None:
+    if text_field is not None:
         rewrapped = dict(model_visible_before)
-        rewrapped[shell_field[0]] = output_text
+        rewrapped[text_field[0]] = output_text
 
     if cosh_ng_detected:
         hook_specific = {

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -562,6 +562,14 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                 &request,
                 &EntryOptions {
                     compression_enabled: compression_on,
+                    search_path_sharing_enabled: std::env::var(
+                        "TOKENLESS_SEARCH_PATH_SHARING_ENABLED",
+                    )
+                    .map_or(true, |value| {
+                        value == "1"
+                            || value.eq_ignore_ascii_case("true")
+                            || value.eq_ignore_ascii_case("yes")
+                    }),
                     stash_enabled: true,
                     rtk_path,
                     rtk_data_dir,

--- a/src/tokenless/crates/tokenless-compressors/src/lib.rs
+++ b/src/tokenless/crates/tokenless-compressors/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod build_log;
 mod json;
+mod search_results;
 mod tabular;
 mod terminal_cleanup;
 
@@ -13,5 +14,6 @@ pub use json::{
     JsonCompressionConfig, JsonCompressionContext, JsonCompressor, JsonError, JsonMetrics,
     JsonOperation, JsonOutcome, Recoverability,
 };
+pub use search_results::SearchResultsCompressor;
 pub use tabular::{TabularCompressor, TabularMetrics, TabularOperation, TabularOutcome};
 pub use tokenless_protocol::RecoveryMethod;

--- a/src/tokenless/crates/tokenless-compressors/src/search_results.rs
+++ b/src/tokenless/crates/tokenless-compressors/src/search_results.rs
@@ -1,0 +1,156 @@
+//! Complete search listings with repeated paths shared across consecutive rows.
+
+use tokenless_protocol::estimate_tokens;
+
+const HEADER: &str = "[Search results grouped by file; all received lines retained]\n";
+
+/// Stateless path sharing for no-context `path:line:text` search results.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SearchResultsCompressor;
+
+impl SearchResultsCompressor {
+    /// Returns a smaller, byte-reversible view, or no candidate.
+    ///
+    /// Requires at least three records, each with a path containing `/` or
+    /// `.` and no colon or line ending. Unsupported records reject the whole
+    /// input. Row suffixes, including line numbers and line endings, are copied
+    /// verbatim; only consecutive identical paths share a JSON-quoted header.
+    #[must_use]
+    pub fn compress(&self, input: &str) -> Option<String> {
+        let mut output = String::from(HEADER);
+        let mut previous_path = None;
+        let mut records = 0;
+        for line in input.split_inclusive('\n') {
+            let (path, suffix) = line.split_once(':')?;
+            if !(path.contains('/') || path.contains('.')) || path.contains(['\r', '\n']) {
+                return None;
+            }
+            let (number, _) = suffix.split_once(':')?;
+            if number.is_empty() || !number.bytes().all(|byte| byte.is_ascii_digit()) {
+                return None;
+            }
+            if previous_path != Some(path) {
+                output.push_str("File=");
+                output.push_str(&serde_json::Value::String(path.to_owned()).to_string());
+                output.push('\n');
+                previous_path = Some(path);
+            }
+            output.push_str(suffix);
+            records += 1;
+            if output.len() >= input.len() {
+                return None;
+            }
+        }
+        (records >= 3
+            && output.len() < input.len()
+            && estimate_tokens(&output) < estimate_tokens(input))
+        .then_some(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SearchResultsCompressor;
+
+    fn restore(view: &str) -> String {
+        let mut lines = view.split_inclusive('\n');
+        assert_eq!(
+            lines.next(),
+            Some("[Search results grouped by file; all received lines retained]\n")
+        );
+        let mut path = String::new();
+        let mut original = String::new();
+        for line in lines {
+            if let Some(quoted) = line.strip_prefix("File=") {
+                path = serde_json::from_str(quoted).unwrap();
+            } else {
+                assert!(!path.is_empty());
+                original.push_str(&path);
+                original.push(':');
+                original.push_str(line);
+            }
+        }
+        original
+    }
+
+    #[test]
+    fn preserves_every_byte_and_consecutive_file_order() {
+        let paths = [
+            "crates/long_directory_name/src/first_file.rs",
+            "crates/中文 空格/with_\"quote\\slash.rs",
+            "crates/long_directory_name/src/first_file.rs",
+        ];
+        for ending in ["\n", "\r\n"] {
+            for trailing in [true, false] {
+                let mut input = String::new();
+                for path in paths {
+                    for (number, body) in [
+                        ("001", "  indented text  "),
+                        ("39", "File=\"literal.rs\""),
+                        ("12", ""),
+                        ("9", "123:content:with:colons"),
+                        ("7", "--"),
+                        ("2", "Unicode 中文\tvalue"),
+                    ] {
+                        input.push_str(&format!("{path}:{number}:{body}{ending}"));
+                    }
+                }
+                if !trailing {
+                    input.truncate(input.len() - ending.len());
+                }
+                let candidate = SearchResultsCompressor.compress(&input).unwrap();
+                assert_eq!(restore(&candidate), input);
+                assert_eq!(candidate.matches("\nFile=").count(), 3);
+                assert!(candidate.len() < input.len());
+            }
+        }
+    }
+
+    #[test]
+    fn preserves_long_lines_and_mixed_line_endings() {
+        let path = "crates/long_directory_name/src/search_records.rs";
+        let input = format!(
+            "{path}:1:{} decision_code=737\r\n{path}:2:  value  \n{path}:3:last",
+            "x".repeat(10_000)
+        );
+        let candidate = SearchResultsCompressor.compress(&input).unwrap();
+        assert!(candidate.contains("decision_code=737\r\n"));
+        assert_eq!(restore(&candidate), input);
+    }
+
+    #[test]
+    fn rejects_the_whole_input_on_an_unsupported_record() {
+        let valid = "crates/long_directory_name/file.rs:1:match\n".repeat(8);
+        for unsupported in [
+            "--\n",
+            "crates/long_directory_name/file.rs-2-context\n",
+            "1:no path\n",
+            "file.rs:no_number:body\n",
+            "file.rs::body\n",
+            "C:\\source\\file.rs:1:body\n",
+            "folder:with:colon/file.rs:1:body\n",
+            "{\"path\":\"file.rs\",\"line\":1}\n",
+            "\n",
+        ] {
+            assert!(
+                SearchResultsCompressor
+                    .compress(&format!("{valid}{unsupported}"))
+                    .is_none()
+            );
+        }
+    }
+
+    #[test]
+    fn small_or_path_diverse_results_are_not_expanded() {
+        for input in [
+            String::new(),
+            "x.rs:1:a\nx.rs:2:b\nx.rs:3:c\n".to_owned(),
+            "crates/very_long_path/file.rs:1:match\n".repeat(2),
+            (0..30)
+                .map(|i| format!("crates/unique_directory_{i}/file.rs:{i}:match\n"))
+                .collect(),
+        ] {
+            assert!(SearchResultsCompressor.compress(&input).is_none());
+        }
+    }
+}

--- a/src/tokenless/crates/tokenless-protocol/src/lib.rs
+++ b/src/tokenless/crates/tokenless-protocol/src/lib.rs
@@ -390,6 +390,7 @@ pub struct PostToolRequest {
     /// Whether this is an ordinary tool or Retrieve result.
     pub result_kind: ResultKind,
     /// Name of the tool that produced the result.
+    /// The exact name `Grep` restricts Core to search path sharing.
     pub tool_name: String,
     /// Model-visible result content.
     pub content: String,
@@ -498,6 +499,8 @@ pub enum AppliedOperation {
     TabularCompaction,
     /// CSV/TSV rows were omitted behind a reference to the original text.
     TabularRowReduction,
+    /// Consecutive search records share a full path without removing source text.
+    SearchPathSharing,
     /// Empty and diagnostic JSON fields were removed.
     JsonCleanup,
     /// A JSON record collection was reduced with retrievable omissions.
@@ -518,6 +521,7 @@ impl AppliedOperation {
             Self::BuildLogReduction => "build_log_reduction",
             Self::TabularCompaction => "tabular_compaction",
             Self::TabularRowReduction => "tabular_row_reduction",
+            Self::SearchPathSharing => "search_path_sharing",
             Self::JsonCleanup => "json_cleanup",
             Self::JsonRecordReduction => "json_record_reduction",
             Self::JsonTruncation => "json_truncation",

--- a/src/tokenless/crates/tokenless-protocol/tests/protocol_tests.rs
+++ b/src/tokenless/crates/tokenless-protocol/tests/protocol_tests.rs
@@ -143,9 +143,10 @@ fn record_reduction_has_a_stable_wire_name() {
 }
 
 #[test]
-fn tabular_operations_have_stable_wire_names() {
+fn content_operations_have_stable_wire_names() {
     for (operation, name) in [
         (AppliedOperation::TabularCompaction, "tabular_compaction"),
+        (AppliedOperation::SearchPathSharing, "search_path_sharing"),
         (
             AppliedOperation::TabularRowReduction,
             "tabular_row_reduction",

--- a/src/tokenless/crates/tokenless-runtime/src/entry.rs
+++ b/src/tokenless/crates/tokenless-runtime/src/entry.rs
@@ -34,6 +34,8 @@ const RTK_TIMEOUT: Duration = Duration::from_secs(5);
 pub struct EntryOptions {
     /// Whether accepted candidates replace the original content.
     pub compression_enabled: bool,
+    /// Whether API search listings may share paths; independent of other domains.
+    pub search_path_sharing_enabled: bool,
     /// Whether lifecycle operations may use the attached stash.
     pub stash_enabled: bool,
     /// Resolved RTK executable for PreTool.
@@ -782,6 +784,7 @@ pub(crate) fn post_tool_with_store(
                 max_input_bytes: MAX_INPUT_BYTES,
                 min_input_chars: MIN_RESPONSE_CHARS,
                 compression_enabled: options.compression_enabled,
+                search_path_sharing_enabled: options.search_path_sharing_enabled,
                 stash_enabled: options.stash_enabled,
                 require_reversibility: true,
                 force_json: false,
@@ -983,6 +986,7 @@ mod tests {
     fn options() -> EntryOptions {
         EntryOptions {
             compression_enabled: true,
+            search_path_sharing_enabled: true,
             stash_enabled: true,
             rtk_path: None,
             rtk_data_dir: Some(PathBuf::from("/tmp/tokenless-test")),
@@ -1742,6 +1746,56 @@ mod tests {
         request.capabilities.recovery = RecoveryMethod::tool("tokenless_retrieve").unwrap();
         let outcome = before_model_with_store(&request, &options(), None).unwrap();
         assert_eq!(outcome.response.tools, request.tools);
+    }
+
+    #[test]
+    fn search_path_sharing_records_stats_and_respects_rtk_ownership() {
+        let content = "crates/long_directory/src/file.rs:12:matching source text\n".repeat(20);
+        let mut request = post_tool_request(&content);
+        request.tool_name = "Grep".into();
+        request.content_origin = ContentOrigin::ApiResponse;
+        let outcome = post_tool_with_store(&request, &options(), None).unwrap();
+        assert_eq!(outcome.response.disposition, Disposition::Applied);
+        assert_eq!(
+            outcome.stats.applied_operations,
+            [AppliedOperation::SearchPathSharing]
+        );
+        assert_eq!(outcome.response.recoverability, Recoverability::Lossless);
+        assert!(outcome.response.stash_keys.is_empty());
+
+        request.tool_name = "Bash".into();
+        request.content_origin = ContentOrigin::CommandOutput;
+        for optimization in [OutputOptimization::None, OutputOptimization::Rtk] {
+            request.output_optimization = optimization;
+            let outcome = post_tool_with_store(&request, &options(), None).unwrap();
+            assert_eq!(outcome.response.disposition, Disposition::Passthrough);
+            assert_eq!(outcome.response.output, content);
+            assert!(outcome.stats.applied_operations.is_empty());
+        }
+    }
+
+    #[test]
+    fn disabling_search_path_sharing_keeps_other_tools_compressible() {
+        let mut options = options();
+        options.search_path_sharing_enabled = false;
+        for tool_name in ["Grep", "SearchFiles"] {
+            let content = "crates/long_directory/src/file.rs:12:matching source text\n".repeat(20);
+            let mut request = post_tool_request(&content);
+            request.tool_name = tool_name.into();
+            request.content_origin = ContentOrigin::ApiResponse;
+            let outcome = post_tool_with_store(&request, &options, None).unwrap();
+            assert_eq!(outcome.response.output, content);
+            assert_eq!(outcome.response.disposition, Disposition::Passthrough);
+            assert!(outcome.stats.applied_operations.is_empty());
+            assert!(outcome.response.stash_keys.is_empty());
+        }
+        let input = serde_json::json!({"debug": "x".repeat(1000), "value": 1}).to_string();
+        let mut request = post_tool_request(&input);
+        request.tool_name = "SearchFiles".into();
+        request.content_origin = ContentOrigin::ApiResponse;
+        let outcome = post_tool_with_store(&request, &options, None).unwrap();
+        assert_eq!(outcome.response.disposition, Disposition::Applied);
+        assert!(!outcome.stats.applied_operations.is_empty());
     }
 
     #[test]

--- a/src/tokenless/crates/tokenless-runtime/src/lib.rs
+++ b/src/tokenless/crates/tokenless-runtime/src/lib.rs
@@ -64,6 +64,8 @@ pub struct RuntimeConfig {
     /// Whether compressed output is returned. Disabled mode calculates and
     /// records predicted savings but returns the original input.
     pub compression_enabled: bool,
+    /// Whether API search results share consecutive file paths. Enabled by default.
+    pub search_path_sharing_enabled: bool,
 }
 
 impl Default for RuntimeConfig {
@@ -73,6 +75,7 @@ impl Default for RuntimeConfig {
             stats_enabled: true,
             sls_enabled: false,
             compression_enabled: true,
+            search_path_sharing_enabled: true,
         }
     }
 }
@@ -407,6 +410,7 @@ impl TokenlessRuntime {
     ) -> Result<BeforeModelResponse, RuntimeError> {
         let options = EntryOptions {
             compression_enabled: self.config.compression_enabled,
+            search_path_sharing_enabled: self.config.search_path_sharing_enabled,
             stash_enabled: true,
             rtk_path: None,
             rtk_data_dir: None,
@@ -452,6 +456,7 @@ impl TokenlessRuntime {
     ) -> Result<PostToolResponse, RuntimeError> {
         let options = EntryOptions {
             compression_enabled: self.config.compression_enabled,
+            search_path_sharing_enabled: self.config.search_path_sharing_enabled,
             stash_enabled: true,
             rtk_path: None,
             rtk_data_dir: None,
@@ -811,6 +816,7 @@ pub fn compress_response_with_store(
             max_input_bytes: MAX_INPUT_BYTES,
             min_input_chars: 0,
             compression_enabled,
+            search_path_sharing_enabled: false,
             stash_enabled: options.stash_enabled,
             require_reversibility: options.require_reversible,
             force_json: true,

--- a/src/tokenless/crates/tokenless-runtime/src/post_tool/pipeline.rs
+++ b/src/tokenless/crates/tokenless-runtime/src/post_tool/pipeline.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use tokenless_ccr::{InMemoryStore, StashStore, StashWrite};
 use tokenless_compressors::{
     BuildLogCompressor, BuildLogOperation, JsonCompressionConfig, JsonCompressionContext,
-    JsonCompressor, JsonOperation, TabularCompressor, TabularOperation,
+    JsonCompressor, JsonOperation, SearchResultsCompressor, TabularCompressor, TabularOperation,
 };
 use tokenless_protocol::{
     AppliedOperation, BYTE_ESTIMATOR_ID, ContentOrigin, ContentType, Disposition, PostToolRequest,
@@ -26,6 +26,7 @@ pub(crate) struct PostToolPipelineConfig {
     pub(crate) max_input_bytes: usize,
     pub(crate) min_input_chars: usize,
     pub(crate) compression_enabled: bool,
+    pub(crate) search_path_sharing_enabled: bool,
     pub(crate) stash_enabled: bool,
     pub(crate) require_reversibility: bool,
     pub(crate) force_json: bool,
@@ -83,14 +84,25 @@ impl PostToolPipeline {
             return Ok(passthrough(request, before_tokens, content_type));
         }
 
-        let json_candidate = config.force_json
-            || content_type == ContentType::Json
-            || is_wrapped_structured_json(&request.content);
-        let build_log_candidate = content_type == ContentType::BuildLog
+        // Grep without line prefixes can return CSV matches classified as
+        // Tabular. Shape detection does not remove the need to retain every
+        // match; other domain compressors may drop rows or rewrite source text.
+        let search_only = request.tool_name == "Grep";
+        let json_candidate = !search_only
+            && (config.force_json
+                || content_type == ContentType::Json
+                || is_wrapped_structured_json(&request.content));
+        let build_log_candidate = !search_only
+            && content_type == ContentType::BuildLog
             && request.content_origin == ContentOrigin::CommandOutput;
-        let tabular_candidate =
-            content_type == ContentType::Tabular && request.capabilities.replace_with_text;
-        if !json_candidate && !build_log_candidate && !tabular_candidate {
+        let tabular_candidate = !search_only
+            && content_type == ContentType::Tabular
+            && request.capabilities.replace_with_text;
+        let search_candidate = config.search_path_sharing_enabled
+            && request.content_origin == ContentOrigin::ApiResponse
+            && content_type == ContentType::SearchResults
+            && request.capabilities.replace_with_text;
+        if !json_candidate && !build_log_candidate && !tabular_candidate && !search_candidate {
             return Ok(passthrough(request, before_tokens, content_type));
         }
 
@@ -144,6 +156,20 @@ impl PostToolPipeline {
                 recoverability: outcome.recoverability,
                 stash_writes: outcome.stash_writes,
                 stash_errors: outcome.metrics.stash_errors,
+                unrecoverable_truncations: None,
+            }
+        } else if search_candidate {
+            let output = SearchResultsCompressor.compress(&request.content);
+            DomainCandidate {
+                operations: if output.is_some() {
+                    vec![AppliedOperation::SearchPathSharing]
+                } else {
+                    Vec::new()
+                },
+                output: output.unwrap_or_else(|| request.content.clone()),
+                recoverability: tokenless_compressors::Recoverability::Lossless,
+                stash_writes: Vec::new(),
+                stash_errors: 0,
                 unrecoverable_truncations: None,
             }
         } else {
@@ -334,6 +360,155 @@ mod tests {
 
     use super::*;
     include!("tests/tabular_pipeline_tests.rs");
+    fn search_input() -> String {
+        (1..30)
+            .map(|line| format!("crates/long_directory/src/search_file.rs:{line}:  value  \r\n"))
+            .collect()
+    }
+
+    #[test]
+    fn search_path_sharing_is_lossless_without_stash_or_recovery() {
+        let input = search_input();
+        let mut req = request(&input);
+        req.content_origin = ContentOrigin::ApiResponse;
+        req.capabilities.recovery = tokenless_protocol::RecoveryMethod::None;
+        let concrete = Arc::new(CountingStore::default());
+        let store: Arc<dyn StashStore> = concrete.clone();
+        let run = PostToolPipeline::run(&req, &build_log_config(), Some(&store)).unwrap();
+        assert_eq!(run.response.disposition, Disposition::Applied);
+        assert_eq!(run.response.content_type, Some(ContentType::SearchResults));
+        assert_eq!(
+            run.response.applied_operations,
+            [AppliedOperation::SearchPathSharing]
+        );
+        assert_eq!(run.response.recoverability, Recoverability::Lossless);
+        assert!(run.response.output.contains("29:  value  \r\n"));
+        assert!(run.response.stash_keys.is_empty());
+        assert_eq!(concrete.stash_calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn grep_protection_is_independent_of_the_search_switch() {
+        for (input, origin, content_type) in [
+            (
+                tabular_input(','),
+                ContentOrigin::ApiResponse,
+                ContentType::Tabular,
+            ),
+            (
+                tabular_input('\t'),
+                ContentOrigin::ApiResponse,
+                ContentType::Tabular,
+            ),
+            (
+                record_array(100),
+                ContentOrigin::ApiResponse,
+                ContentType::Json,
+            ),
+            (
+                build_log(),
+                ContentOrigin::CommandOutput,
+                ContentType::BuildLog,
+            ),
+        ] {
+            let mut req = request(&input);
+            req.tool_name = "Grep".into();
+            req.content_origin = origin;
+            for enabled in [false, true] {
+                let mut config = build_log_config();
+                config.search_path_sharing_enabled = enabled;
+                for force_json in [false, true] {
+                    let concrete = Arc::new(CountingStore::default());
+                    let store: Arc<dyn StashStore> = concrete.clone();
+                    config.force_json = force_json;
+                    let run = PostToolPipeline::run(&req, &config, Some(&store)).unwrap();
+                    assert_eq!(run.response.content_type, Some(content_type));
+                    assert_eq!(run.response.output, input);
+                    assert_eq!(run.response.disposition, Disposition::Passthrough);
+                    assert!(run.operations.is_empty());
+                    assert!(run.response.applied_operations.is_empty());
+                    assert!(run.response.stash_keys.is_empty());
+                    assert_eq!(concrete.stash_calls.load(Ordering::Relaxed), 0);
+                }
+                let mut other_tool = req.clone();
+                other_tool.tool_name = "SearchFiles".into();
+                config.force_json = false;
+                let store: Arc<dyn StashStore> = Arc::new(CountingStore::default());
+                let run = PostToolPipeline::run(&other_tool, &config, Some(&store)).unwrap();
+                assert_eq!(run.response.disposition, Disposition::Applied);
+                assert!(!run.operations.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn native_grep_path_sharing_takes_precedence_over_force_json() {
+        let mut req = request(&search_input());
+        req.tool_name = "Grep".into();
+        req.content_origin = ContentOrigin::ApiResponse;
+        let run = PostToolPipeline::run(&req, &config(Duration::from_secs(1), 32), None).unwrap();
+        assert_eq!(run.response.disposition, Disposition::Applied);
+        assert_eq!(
+            run.response.applied_operations,
+            [AppliedOperation::SearchPathSharing]
+        );
+        assert_eq!(run.response.recoverability, Recoverability::Lossless);
+    }
+
+    #[test]
+    fn search_path_sharing_respects_lifecycle_gates() {
+        let input = search_input();
+        for mode in 0..7 {
+            let mut req = request(&input);
+            req.content_origin = ContentOrigin::ApiResponse;
+            let mut config = build_log_config();
+            match mode {
+                0 => req.content_origin = ContentOrigin::FileContent,
+                1 => req.status = ToolResultStatus::Error,
+                2 => req.capabilities.replace_output = false,
+                3 => req.capabilities.replace_with_text = false,
+                4 => config.max_input_bytes = input.len() - 1,
+                5 => config.min_input_chars = input.chars().count() + 1,
+                6 => config.timeout = Duration::ZERO,
+                _ => unreachable!(),
+            }
+            let run = PostToolPipeline::run(&req, &config, None).unwrap();
+            assert_eq!(run.response.output, input);
+            assert!(run.response.applied_operations.is_empty());
+            assert!(run.response.stash_keys.is_empty());
+        }
+    }
+
+    #[test]
+    fn search_dry_run_measures_candidate_without_replacing_output() {
+        let input = search_input();
+        let mut config = build_log_config();
+        config.compression_enabled = false;
+        let mut req = request(&input);
+        req.content_origin = ContentOrigin::ApiResponse;
+        let run = PostToolPipeline::run(&req, &config, None).unwrap();
+        assert_eq!(run.response.disposition, Disposition::DryRun);
+        assert_eq!(run.response.output, input);
+        assert!(run.response.applied_operations.is_empty());
+        assert_eq!(run.operations, [AppliedOperation::SearchPathSharing]);
+        assert!(run.response.after_tokens < run.response.before_tokens);
+        assert!(run.response.stash_keys.is_empty());
+    }
+
+    #[test]
+    fn search_rejects_no_savings_and_unparsed_suffixes() {
+        for input in [
+            "x.rs:1:a\nx.rs:2:b\nx.rs:3:c".to_owned(),
+            format!("{}--\n", search_input()),
+        ] {
+            let mut req = request(&input);
+            req.content_origin = ContentOrigin::ApiResponse;
+            let run = PostToolPipeline::run(&req, &build_log_config(), None).unwrap();
+            assert_eq!(run.response.output, input);
+            assert_eq!(run.response.disposition, Disposition::NoSavings);
+            assert!(run.response.applied_operations.is_empty());
+        }
+    }
 
     #[derive(Default)]
     struct CountingStore {
@@ -388,6 +563,7 @@ mod tests {
             max_input_bytes: 1024 * 1024,
             min_input_chars: 0,
             compression_enabled: true,
+            search_path_sharing_enabled: true,
             stash_enabled: true,
             require_reversibility: false,
             force_json: true,

--- a/src/tokenless/docs/design/runtime-library.md
+++ b/src/tokenless/docs/design/runtime-library.md
@@ -47,6 +47,47 @@ tool-name collisions fail fast. Normal Core dispositions such as passthrough, no
 recoverability unavailable return typed results. A candidate is applied only when it is strictly
 smaller; schema and response truncation must also remain retrievable.
 
+## Search path sharing
+
+PostTool routes detected `search_results` through `SearchResultsCompressor` only when search path
+sharing is enabled, the origin is `api_response`, and text replacement is available. This is a
+content-based Core capability; it is not restricted to a particular agent ID. File content and
+command output do not enter it, including Bash output without RTK. Successful `path:line:text` listings with at least three records can share full
+paths across consecutive rows. Line numbers, row text, order and line endings remain byte-reversible.
+The input contract excludes colons in paths and context listings. Unsupported rows reject the whole
+candidate; byte length and estimated tokens must both decrease before normal Runtime arbitration.
+The applied operation is `search_path_sharing` (`AppliedOperation.SEARCH_PATH_SHARING` in the
+Python SDK), with `lossless` recoverability and no Stash writes.
+
+Search path sharing is enabled by default. CLI callers can disable it with
+`TOKENLESS_SEARCH_PATH_SHARING_ENABLED=0`. When unset it stays enabled; `1`, `true`, and `yes`
+also enable it (case-insensitively). Empty and other values disable it. This variable is
+independent of the JSON config file.
+Rust callers use `RuntimeConfig.search_path_sharing_enabled`; Python callers use
+`TokenlessConfig(search_path_sharing_enabled=False)` or the matching `TokenlessRuntime` keyword.
+Disabling this domain returns search listings unchanged without computing a search candidate.
+JSON, table, and log compression remain available for other tool names. The exact name `Grep`
+always excludes those domains to retain every received match; disabling path sharing does not
+restore pre-feature JSON/table/log dispatch for a custom tool named `Grep`.
+The global compression switch still controls dry-run behavior for enabled domains.
+Whole-task savings depend on the workload; preserving all received bytes does not guarantee
+fewer follow-up tool calls or lower total token use.
+
+The first line is the fixed format header. Subsequent `File=` lines contain a JSON-encoded path;
+data lines always begin with ASCII digits followed by `:`, so they cannot be mistaken for file
+headers. To reconstruct, prefix each data line with the decoded current path and `:` and retain
+its original line ending. Repeated nonconsecutive paths receive separate headers.
+
+The Claude Code adapter unwraps only native Grep `mode=content` responses without context options,
+declares that slot as API response text, and replaces only `content` in the original output object.
+It preserves host metadata, including any limits; completeness means all received rows, not all
+possible matches before host truncation. Other Grep modes and hosts keep their existing route.
+Unwrapped Grep listings are recorded as `api_response` in statistics, rather than `file_content`:
+they are filtered tool responses, not authoritative file copies. Historical origin-grouped queries
+therefore have a version boundary. Core treats the exact tool name `Grep` as a search-only tool:
+it cannot enter JSON, table, or log compressors, even when search path sharing is disabled. SDK
+callers should use that name only for this search contract. RTK-owned output still bypasses Core.
+
 ## Statistics queries
 
 `TokenlessStats` is a read-only public query client backed by the same Rust `StatsRecorder` and

--- a/src/tokenless/docs/design/runtime-library_zh.md
+++ b/src/tokenless/docs/design/runtime-library_zh.md
@@ -42,6 +42,41 @@ SDK 不保存进程级“当前 Session”。`before_model` 返回精确的可�
 No Savings 和 Recoverability Unavailable 等正常 Core Disposition 返回 typed 结果。候选
 只有严格更短时才会采用；Schema 和响应截断还必须能够恢复。
 
+## 搜索路径共享
+
+PostTool 仅在搜索路径共享已开启、来源为 `api_response` 且支持文本替换时，将识别为
+`search_results` 的内容交给 `SearchResultsCompressor`。这是按内容派发的 Core 能力，不限定 Agent ID；
+文件内容和命令输出均不进入该域，包括未由 RTK 处理的 Bash 输出。
+成功的 `path:line:text` 列表至少包含三条记录，连续记录可以共享完整文件路径。
+行号、正文、顺序和换行保持字节可逆。输入契约不包含路径内的冒号和上下文列表；
+任意不支持的记录都会拒绝整份候选。字节数与估算 Token 均减少后，再经过现有 Runtime 仲裁。
+实际采用时操作为 `search_path_sharing`，Python SDK 对应 `AppliedOperation.SEARCH_PATH_SHARING`；
+恢复等级为 `lossless`，不写入 Stash。
+
+Claude Code Adapter 仅提取无上下文选项的原生 Grep `mode=content` 响应，将其文本槽声明为
+API 响应，再只替换原输出对象的 `content` 字段。包括宿主限额在内的其他元数据保持不变；
+完整性指保留收到的所有记录，不表示宿主裁剪前的全部可能命中。
+其他 Grep 模式和宿主保留既有路由。RTK 负责的 Bash 输出继续绕过原生 PostTool 压缩。
+
+搜索路径共享默认开启。CLI 可通过 `TOKENLESS_SEARCH_PATH_SHARING_ENABLED=0` 关闭；
+未设置时保持开启，`1`、`true`、`yes`（不区分大小写）也表示开启；空值和其他值均关闭。
+该变量独立于 JSON 配置文件。
+Rust 使用 `RuntimeConfig.search_path_sharing_enabled`；Python 使用
+`TokenlessConfig(search_path_sharing_enabled=False)` 或 `TokenlessRuntime` 的同名参数。
+关闭该域时搜索列表原样返回且不计算搜索候选。其他工具名仍可使用 JSON、表格和日志压缩。
+精确名称 `Grep` 始终排除这些域，以保留全部已收到命中；关闭路径共享不会恢复此功能引入前
+自定义 `Grep` 工具的 JSON、表格和日志派发。全局压缩开关仍控制已开启域的 dry-run。
+整任务节省取决于工作负载；保留全部收到的字节并不保证后续工具调用更少或总 Token 用量更低。
+
+首行为固定格式声明，后续 `File=` 行包含 JSON 编码的路径；数据行必以 ASCII 数字和 `:` 开头，
+因此不可能被误认为文件头。还原时在每个数据行前拼接当前解码路径与 `:`，保留原始行尾；
+同一路径在非连续位置出现时会生成新的文件头。
+
+解包的 Grep 列表在统计中记作 `api_response`，而非 `file_content`，因为它是筛选后的工具响应，
+不是权威文件副本。按来源分组的历史查询因此存在版本边界。Core 将精确工具名 `Grep` 视为
+仅适用搜索压缩的工具；即使搜索路径共享关闭，也不会转入 JSON、表格或日志压缩。SDK 调用者
+仅应对符合此搜索契约的工具使用该名称。
+
 ## Stats 查询
 
 `TokenlessStats` 是只读的公开查询客户端，复用 CLI 相同的 Rust `StatsRecorder` 和

--- a/src/tokenless/python/agentscope/src/tokenless_agentscope/_contracts.py
+++ b/src/tokenless/python/agentscope/src/tokenless_agentscope/_contracts.py
@@ -102,6 +102,8 @@ _API_TOOLS = frozenset(
         "search_file",
         "list_directory",
         "list_dir",
+        # Core reserves this exact name for complete search listings, even
+        # with path sharing disabled; JSON/table/log compression is excluded.
         "Grep",
         "grep",
         "grep_code",

--- a/src/tokenless/python/tokenless/python/anolisa_tokenless/_native.pyi
+++ b/src/tokenless/python/tokenless/python/anolisa_tokenless/_native.pyi
@@ -53,6 +53,7 @@ class TokenlessRuntime:
         data_dir: str | os.PathLike[str] | None = None,
         *,
         compression_enabled: bool = True,
+        search_path_sharing_enabled: bool = True,
         stats_enabled: bool = True,
         sls_enabled: bool = False,
     ) -> None: ...

--- a/src/tokenless/python/tokenless/python/anolisa_tokenless/sdk.py
+++ b/src/tokenless/python/tokenless/python/anolisa_tokenless/sdk.py
@@ -128,6 +128,7 @@ class AppliedOperation(StrEnum):
     BUILD_LOG_REDUCTION = "build_log_reduction"
     TABULAR_COMPACTION = "tabular_compaction"
     TABULAR_ROW_REDUCTION = "tabular_row_reduction"
+    SEARCH_PATH_SHARING = "search_path_sharing"
     JSON_CLEANUP = "json_cleanup"
     JSON_RECORD_REDUCTION = "json_record_reduction"
     JSON_TRUNCATION = "json_truncation"
@@ -164,6 +165,7 @@ class TokenlessConfig:
     data_dir: str | os.PathLike[str] | None = None
     retrieve_tool_name: str = "tokenless_retrieve"
     rtk_enabled: bool = True
+    search_path_sharing_enabled: bool = True
 
     def __post_init__(self) -> None:
         try:
@@ -256,7 +258,11 @@ class PostToolCapabilities:
 
 @dataclass(frozen=True)
 class PostToolRequest:
-    """One final model-visible tool result before Core routing."""
+    """One final model-visible tool result before Core routing.
+
+    The exact tool name ``Grep`` opts into search-only routing; its output
+    never enters JSON, table, or log compressors.
+    """
 
     result_kind: ResultKind
     tool_name: str
@@ -312,7 +318,10 @@ class TokenlessSdk:
 
     def __init__(self, config: TokenlessConfig | None = None) -> None:
         self.config = config or TokenlessConfig()
-        self.runtime = TokenlessRuntime(self.config.data_dir)
+        self.runtime = TokenlessRuntime(
+            self.config.data_dir,
+            search_path_sharing_enabled=self.config.search_path_sharing_enabled,
+        )
         self._rtk_path = self._resolve_rtk() if self.config.rtk_enabled else None
         self._stats: TokenlessStats | None = None
 

--- a/src/tokenless/python/tokenless/src/lib.rs
+++ b/src/tokenless/python/tokenless/src/lib.rs
@@ -280,12 +280,14 @@ impl PyTokenlessRuntime {
         data_dir=None,
         *,
         compression_enabled=true,
+        search_path_sharing_enabled=true,
         stats_enabled=true,
         sls_enabled=false
     ))]
     fn new(
         data_dir: Option<PathBuf>,
         compression_enabled: bool,
+        search_path_sharing_enabled: bool,
         stats_enabled: bool,
         sls_enabled: bool,
     ) -> PyResult<Self> {
@@ -294,6 +296,7 @@ impl PyTokenlessRuntime {
             stats_enabled,
             sls_enabled,
             compression_enabled,
+            search_path_sharing_enabled,
         })
         .map_err(to_python_error)?;
         Ok(Self { inner })

--- a/src/tokenless/python/tokenless/tests/test_sdk.py
+++ b/src/tokenless/python/tokenless/tests/test_sdk.py
@@ -130,12 +130,12 @@ class TokenlessSdkTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaisesRegex(TokenlessError, "not authorized"):
             await sdk.retrieve(RetrieveRequest(marker.group(1), frozenset(), self.attribution))
 
-    def test_config_contains_only_runtime_resources(self) -> None:
+    def test_config_contains_runtime_resources_and_search_control(self) -> None:
         with self.assertRaisesRegex(ValueError, "absolute path"):
             TokenlessConfig(data_dir="relative")
         self.assertEqual(
             {field.name for field in fields(TokenlessConfig)},
-            {"data_dir", "retrieve_tool_name", "rtk_enabled"},
+            {"data_dir", "retrieve_tool_name", "rtk_enabled", "search_path_sharing_enabled"},
         )
 
     def test_config_identifies_invalid_retrieve_tool_names(self) -> None:
@@ -307,6 +307,53 @@ class TokenlessSdkTests(unittest.IsolatedAsyncioTestCase):
             )
         )
         self.assertEqual(json.loads(restored.payload), records)
+
+    async def test_search_path_sharing_exposes_the_typed_operation(self) -> None:
+        sdk = self.sdk(rtk_enabled=False)
+        self.assertTrue(sdk.config.search_path_sharing_enabled)
+        original = "crates/long_directory/src/file.rs:42:  matching text  \r\n" * 12
+        result = await sdk.post_tool(
+            PostToolRequest(
+                result_kind=ResultKind.TOOL,
+                tool_name="Grep",
+                content=original,
+                status=ToolResultStatus.SUCCESS,
+                content_origin=ContentOrigin.API_RESPONSE,
+                output_optimization=OutputOptimization.NONE,
+                capabilities=PostToolCapabilities(
+                    replace_output=True, recovery=RecoveryMethod(), replace_with_text=True
+                ),
+                attribution=Attribution("sdk-agent", "sdk-session", "search-1"),
+            )
+        )
+        self.assertEqual(result.applied_operations, (AppliedOperation.SEARCH_PATH_SHARING,))
+        self.assertEqual(result.content_type.value, "search_results")
+        self.assertEqual(result.recoverability.value, "lossless")
+        self.assertEqual(result.stash_keys, ())
+        self.assertEqual(result.output.count("42:  matching text  \r\n"), 12)
+        self.assertLess(len(result.output), len(original))
+
+    async def test_search_path_sharing_can_be_disabled(self) -> None:
+        sdk = self.sdk(rtk_enabled=False, search_path_sharing_enabled=False)
+        original = "crates/long_directory/src/file.rs:42:matching text\n" * 12
+        result = await sdk.post_tool(
+            PostToolRequest(
+                result_kind=ResultKind.TOOL,
+                tool_name="SearchFiles",
+                content=original,
+                status=ToolResultStatus.SUCCESS,
+                content_origin=ContentOrigin.API_RESPONSE,
+                output_optimization=OutputOptimization.NONE,
+                capabilities=PostToolCapabilities(
+                    replace_output=True, recovery=RecoveryMethod(), replace_with_text=True
+                ),
+                attribution=Attribution("sdk-agent", "sdk-session", "search-disabled"),
+            )
+        )
+        self.assertFalse(sdk.config.search_path_sharing_enabled)
+        self.assertEqual(result.output, original)
+        self.assertEqual(result.applied_operations, ())
+        self.assertEqual(result.stash_keys, ())
 
     def test_stats_client_is_lazy_and_uses_runtime_data_dir(self) -> None:
         sdk = self.sdk(rtk_enabled=False)

--- a/src/tokenless/tests/release_regression/probe.py
+++ b/src/tokenless/tests/release_regression/probe.py
@@ -107,6 +107,12 @@ def core_checks(raw_log: str, failure_log: str, records: str) -> None:
     )
     cases = [
         ("build_success", raw_log, {}, "build_log_reduction"),
+        (
+            "search_path_sharing",
+            "".join(f"crates/long_directory/src/file.rs:{i}:match-{i}\r\n" for i in range(100)),
+            {"tool_name": "Grep", "content_origin": "api_response"},
+            "search_path_sharing",
+        ),
         ("full_toon", full_records, {}, "toon"),
         ("records_contract", records, {}, "json_record_reduction"),
         (
@@ -181,14 +187,22 @@ def core_checks(raw_log: str, failure_log: str, records: str) -> None:
             assert result["disposition"] == "applied", (name, result["disposition"])
             assert operation in result["applied_operations"], (name, result["applied_operations"])
             assert result["recoverability"] == (
-                "lossless" if name == "full_toon" or name.startswith("tabular_full") else "retrievable"
+                "lossless"
+                if name in ("full_toon", "search_path_sharing") or name.startswith("tabular_full")
+                else "retrievable"
             )
             assert result["after_tokens"] < result["before_tokens"]
             assert set(keys) == set(REFERENCE.findall(result["output"]))
             assert "<<tokenless:" not in result["output"]
             stashed = rows(directory, "stash.db", "SELECT hash, payload FROM stash")
             assert len(stashed) == len(keys) == (stats[0]["stash_writes"] or 0)
-            if name == "records_contract":
+            if name == "search_path_sharing":
+                lines = result["output"].splitlines(keepends=True)
+                assert lines[0] == "[Search results grouped by file; all received lines retained]\n"
+                path = json.loads(lines[1].removeprefix("File="))
+                assert "".join(path + ":" + line for line in lines[2:]) == content
+                assert not keys
+            elif name == "records_contract":
                 REPORT["record_target"] = next(
                     record["id"]
                     for record in json.loads(content)[4:-4]

--- a/src/tokenless/tests/test_compress_response_hook.py
+++ b/src/tokenless/tests/test_compress_response_hook.py
@@ -42,7 +42,8 @@ def _create_mock_tokenless(tmpdir: str, behavior: str = "compress") -> str:
 
     Every invocation appends its argv to a `spawn_log` file next to the
     binary, so tests can assert the one-subprocess contract (§5.6). The
-    mock also validates the request shape: a malformed request from the
+    mock also overwrites `request.json` with the latest PostTool input. The
+    mock validates the request shape: a malformed request from the
     hook exits non-zero, which the hook fails open on — surfacing
     request-construction bugs as envelope mismatches.
 
@@ -67,6 +68,9 @@ def _create_mock_tokenless(tmpdir: str, behavior: str = "compress") -> str:
             sys.exit(2)
         operation_input = request["input"]
         content = operation_input["content"]
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               "request.json"), "w") as captured:
+            json.dump(operation_input, captured)
 
         def respond(output, disposition, additional_context=None):
             result = {
@@ -783,6 +787,94 @@ class TestShellEnvelopeUnwrap(unittest.TestCase):
         self.assertIsInstance(updated, str,
                               "Qoder requires a string updatedToolOutput")
         self.assertEqual(json.loads(updated), self._bash_envelope(log[:40], ""))
+
+
+@unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")
+class TestGrepEnvelopeUnwrap(unittest.TestCase):
+    def test_claude_content_slot_is_replaced_without_changing_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            binary = _create_mock_tokenless(directory, "compress-text")
+            _create_mock_claude(directory)
+            content = "crates/long_directory/file.rs:7:  matching text  \n" * 12
+            envelope = {
+                "mode": "content", "content": content, "numLines": 12,
+                "numFiles": 0, "filenames": [], "appliedLimit": 12,
+            }
+            result = _run_hook(
+                {"tool_name": "Grep", "tool_response": envelope},
+                "claude-code", binary, directory,
+            )
+            self.assertEqual(
+                result["hookSpecificOutput"]["updatedToolOutput"],
+                dict(envelope, content=content[:40]),
+            )
+            with open(os.path.join(directory, "request.json")) as captured:
+                request = json.load(captured)
+            self.assertEqual(request["content"], content)
+            self.assertEqual(request["content_origin"], "api_response")
+            self.assertTrue(request["capabilities"]["replace_with_text"])
+            self.assertEqual(len(_spawn_log_lines(binary)), 1)
+
+    def test_invalid_tool_input_keeps_the_existing_route(self) -> None:
+        for tool_input in [None, "grep -rn foo", ["-C"], 3]:
+            with self.subTest(tool_input=tool_input), tempfile.TemporaryDirectory() as directory:
+                binary = _create_mock_tokenless(directory, "compress-text")
+                _create_mock_claude(directory)
+                result = _run_hook(
+                    {"tool_name": "Grep", "tool_input": tool_input, "tool_response": {
+                        "mode": "content", "content": "file.rs:1:match\n" * 20,
+                    }},
+                    "claude-code", binary, directory,
+                )
+                self.assertEqual(result, {})
+                with open(os.path.join(directory, "request.json")) as captured:
+                    request = json.load(captured)
+                self.assertEqual(request["content_origin"], "file_content")
+
+    def test_other_modes_hosts_and_context_keep_the_existing_json_route(self) -> None:
+        cases = [
+            ("claude-code", "count", {}),
+            ("claude-code", "files_with_matches", {}),
+            ("qoder-cli", "content", {}),
+            ("opencode", "content", {}),
+            *[("claude-code", "content", {flag: 2})
+              for flag in ("-A", "-B", "-C", "context")],
+        ]
+        for agent, mode, tool_input in cases:
+            with self.subTest(agent=agent, mode=mode, tool_input=tool_input):
+                with tempfile.TemporaryDirectory() as directory:
+                    binary = _create_mock_tokenless(directory, "no-savings")
+                    _create_mock_claude(directory)
+                    envelope = {"mode": mode, "content": "file.rs:1:match\n" * 20}
+                    result = _run_hook(
+                        {"tool_name": "Grep", "tool_response": envelope,
+                         "tool_input": tool_input},
+                        agent, binary, directory,
+                    )
+                    self.assertEqual(result, {})
+                    with open(os.path.join(directory, "request.json")) as captured:
+                        request = json.load(captured)
+                    self.assertEqual(json.loads(request["content"]), envelope)
+                    self.assertFalse(request["capabilities"]["replace_with_text"])
+
+    def test_no_savings_and_old_claude_do_not_emit_replacements(self) -> None:
+        for version in ["2.1.120", "2.1.259"]:
+            with self.subTest(version=version), tempfile.TemporaryDirectory() as directory:
+                binary = _create_mock_tokenless(directory, "no-savings")
+                _create_mock_claude(directory, version)
+                result = _run_hook(
+                    {"tool_name": "Grep", "tool_response": {
+                        "mode": "content", "content": "file.rs:1:match\n" * 20,
+                    }},
+                    "claude-code", binary, directory,
+                )
+                self.assertEqual(result, {})
+                with open(os.path.join(directory, "request.json")) as captured:
+                    request = json.load(captured)
+                self.assertEqual(
+                    request["capabilities"]["replace_output"], version == "2.1.259"
+                )
+                self.assertEqual(request["content_origin"], "api_response")
 
 
 @unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")


### PR DESCRIPTION
## Why

Search results repeat full paths on every match. Sharing consecutive paths reduces this repetition while retaining every received record. The feature is enabled by default, with an independent switch for workloads that benefit from the original format.

## What changed

Add byte-reversible path sharing for no-context `path:line:text` API results, gated by smaller bytes and token estimates. Default to enabled in the CLI, Rust Runtime, and Python Runtime/SDK; disable with `TOKENLESS_SEARCH_PATH_SHARING_ENABLED=0` or `search_path_sharing_enabled=False` (Rust: `false`). Core excludes command/file outputs and keeps native `Grep` out of other compressors; the Claude adapter replaces only the supported content slot and preserves metadata.

## Related issue

no-issue: add native path sharing for API search results.

## User / Agent impact

Supported API search listings, including native Claude Grep, share JSON-quoted file headers by default; unsupported records pass through. Disabling search path sharing returns original search results. JSON/table/log compression remains available for other tool names; the exact name `Grep` always excludes those domains, including when path sharing is disabled. Context queries retain their existing route; command output, including Bash without RTK, does not enter search path sharing. Malformed hook tool arguments keep the existing route without a traceback.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Adds `search_path_sharing` to protocol/SDK operations and a default-enabled configuration field. The exact tool name `Grep` has a documented search-only dispatch contract. Custom tools with that name lose their pre-feature JSON/table/log dispatch, and the search switch does not restore it; the unconditional protection prevents dropping native Grep matches when path sharing is disabled. Successful unwrapped Grep listings are recorded as `api_response`, creating a version boundary for origin-grouped statistics. Completeness covers received records, not upstream-truncated matches. Rust callers constructing configuration structs exhaustively must supply the new field. Smaller results do not guarantee lower whole-task token use.

## Validation

- Further blocking review follow-up (`7294f501`): clarified why shape classification does not establish whether text is a received search match, and added explicit `Tabular`/`Json`/`BuildLog` assertions to the existing protection test. A fresh four-arm, network-disabled container replay generated matches with real `rg --no-line-number`, supplied native-Grep-shaped hook fixtures, and exercised production hooks/CLI binaries: current on/off retain 100 CSV matches classified as `tabular`, while the proposed conditional guard with search off retains only 32. This is a hook integration replay, not a new live model run. Format, Clippy, 788 Rust tests (3 existing ignored), and complete-range Commitlint passed. No compression behavior or defaults changed.
- Blocking review #1 follow-up only: confirmed the custom `Grep` behavior, corrected bilingual manual/runtime promises, expanded the existing tests across search on/off and JSON/CSV/TSV/command logs with a `SearchFiles` control, and annotated the AgentScope contract. The proposed one-line conditional guard fails the expanded regression test. In the pinned network-disabled container, 24 real hook comparisons and 32 direct CLI comparisons pass: the proposed guard with search disabled reduces 100 CSV matches to 32 while preserving `numLines=101` and adding Stash; both the merge-base hook and the retained implementation preserve all 100. The rebuilt production CLI is byte-identical to `5e65f70a`; this update changes documentation, tests, and a contract comment only. Full Rust tests remain 788 passed / 3 ignored, and the 10 isolated AgentScope middleware tests pass. Non-blocking suggestions are deferred.
- Current revision: `cargo fmt --all -- --check`; `cargo test --locked --workspace -- --test-threads=1` (788 passed, 3 existing ignored); `cargo clippy --locked --workspace --all-targets -- -D warnings`; `cargo doc --locked --workspace --no-deps`; locked release CLI build.
- 29 Runtime/SDK tests against a newly built and installed wheel including packaged RTK; additional native Runtime checks confirm omitted configuration compresses and explicit `False` preserves the original. The SDK tests cover the default and explicit opt-out. Release-probe unit test passed. Full PR range validated with repository Commitlint.
- Pinned local Claude container, network disabled: 16 real hook-to-CLI switch/input/origin checks. Unset enables; `0` disables; truthy, empty, and other values match the documented contract. Enabled results reconstruct byte-for-byte with unchanged metadata. Malformed arguments, file reads, and Bash without RTK keep their existing behavior. The actual release Core probe passed all 20 checks, including search path sharing without an opt-in environment variable, JSON/table/log/retrieval behavior, and RTK bypass.
- Prior revision validation: 165 Python hook/adapter tests across 14 isolated files and 21 baseline/original/fixed container comparisons covered CSV/TSV/JSON protection and four supported search cases. Those adapter/compressor implementations are unchanged by the default update.
- Live factorial study on `bf85d035` with the same algorithm and explicit search settings: Claude Code 2.1.259 / DeepSeek `deepseek-v4-flash-0731`, two fixed tasks × search on/off × RTK on/off × six randomized blocks = 48 runs. All 48 answers and control checks passed; all 24 search replacements reconstructed byte-for-byte; no RTK-owned result was compressed again. No transport errors; three tool errors and their costs were retained without exclusions or reruns.
- The locate task used two tool calls throughout. Across RTK strata, mean aggregate request-body `o200k_base` estimates fell 14,287 → 13,675 (4.3%); provider input plus output, including cache input, fell 5.3%. All 12 paired locate comparisons favored search sharing. This task made no actual RTK rewrites, so the RTK-stratum difference is not evidence of an RTK effect.
- Enumeration remained uncertain: search sharing changed mean request-body estimates by -9.5% with RTK off and +19.7% with RTK on; exploratory paired bootstrap intervals crossed zero in both strata. These are two fixed tasks on one repository/model, not a universal savings claim. Request estimates and aggregate provider token counts are not billing. The latest container checks verify default wiring; the 48 live runs were not repeated for this default-only update.

## Documentation and rollback

Updated bilingual README, user manuals and runtime design, plus protocol/SDK contracts. Set `TOKENLESS_SEARCH_PATH_SHARING_ENABLED=0`, Python `search_path_sharing_enabled=False`, or Rust `search_path_sharing_enabled: false` to disable this domain while retaining other compressors for tool names other than `Grep`. Revert the commit to remove the feature. No stored-data migration is required. Local evaluation and evolution documents are excluded from this PR.
