### PR TITLE
feat(cosh-ng): [shell] define prompt contract

### DIFF
--- a/docs/user-guide/en/user-entrypoint/cosh-ng/shell/overview.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/shell/overview.md
@@ -44,6 +44,34 @@ Approved Shell commands in enhanced integration stay in the foreground Shell,
 so prompts, output, job control, and `Ctrl+C` remain usable. See
 [Tool approval](approval.md) for the safety rules.
 
+## Bash prompt compatibility
+
+Enhanced combines user `PROMPT_COMMAND` hooks with Cosh's prompt hooks. User
+hooks configured before integration keep their execution order under the
+selected Bash version. Both Assisted and Shell-only use this integration.
+
+The variable's representation and child environment have these limits:
+
+- Bash 5.1 and newer use an array. An existing export attribute is retained,
+  but Bash does not export array values. A previously exported scalar
+  `PROMPT_COMMAND` therefore no longer reaches child processes, including
+  when its original value was an empty string.
+- Bash 4.3–5.0 use a combined scalar without the export attribute. This keeps
+  Cosh's internal hook text out of child processes; the original user scalar
+  is not exported either.
+
+Configure prompt hooks in each interactive shell's startup files when child
+shells should initialize them independently. Choose Native at startup when
+the session must preserve Bash's own prompt-variable representation and
+environment behavior. Native provides no Cosh hooks, observation, or insights;
+switching Enhanced to Shell-only does not remove the limits above.
+
+`--resume` always selects Enhanced, even with `COSH_SHELL_INTEGRATION=native`
+or `shell.integration = "native"`. Omit `--resume` when Native behavior is required.
+
+These limits apply to Bash `PROMPT_COMMAND`, not ordinary environment variables
+or the interactive continuation prompt `PS2`.
+
 ## Sessions and proactive help
 
 - Enhanced sessions are persisted by cosh-core and scoped to the workspace

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/shell/overview.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/shell/overview.md
@@ -43,6 +43,29 @@ Native。切换集成需要重新启动 `cosh`，`Shift+Tab` 只切换 Enhanced 
 增强集成中获批的 Shell 命令仍在前台 Shell 执行，prompt、输出、任务控制和
 `Ctrl+C` 都可用。安全规则见[工具审批](approval.md)。
 
+## Bash prompt 兼容边界
+
+Enhanced 将用户的 `PROMPT_COMMAND` Hook 与 Cosh prompt Hook 组合执行。
+集成启动前配置的用户 Hook 按所选 Bash 版本的规则保留执行顺序。
+Assisted 和 Shell-only 均使用这套集成。
+
+变量表示和子进程环境存在以下限制：
+
+- Bash 5.1 及以上版本使用数组，保留原有 export 属性，但 Bash 不会导出数组值。
+  因此，原先导出的 scalar `PROMPT_COMMAND` 不再传入子进程，原值为空字符串时也如此。
+- Bash 4.3–5.0 使用不带 export 属性的组合 scalar，避免 Cosh 内部 Hook 文本
+  进入子进程；用户原有的 scalar 同样不会被导出。
+
+如果子 Shell 需要独立初始化 prompt Hook，请在各交互 Shell 的启动文件中配置。
+如果会话必须保留 Bash 自身的 prompt 变量表示和环境行为，请在启动时选择 Native。
+Native 不加载 Cosh Hook、不观察也不提供洞察；将 Enhanced 切换到 Shell-only
+不会消除上述限制。
+
+`--resume` 始终选择 Enhanced，即使设置了 `COSH_SHELL_INTEGRATION=native`
+或 `shell.integration = "native"`。需要 Native 行为时，请勿使用 `--resume`。
+
+这些限制仅适用于 Bash 的 `PROMPT_COMMAND`，不涉及普通环境变量或交互续行提示符 `PS2`。
+
 ## 会话与主动帮助
 
 - 增强会话由 cosh-core 保存，并按启动 cosh 时所在工作空间隔离。恢复会话只

--- a/src/cosh-ng/README.md
+++ b/src/cosh-ng/README.md
@@ -97,6 +97,10 @@ or insights:
 COSH_SHELL_INTEGRATION=native cosh
 ```
 
+Enhanced does not preserve exported Bash `PROMPT_COMMAND` values in child
+processes. See [Bash prompt compatibility](../../docs/user-guide/en/user-entrypoint/cosh-ng/shell/overview.md#bash-prompt-compatibility)
+for the version-specific attribute limits and Native alternative.
+
 ```text
 $ hello
 bash: hello: command not found

--- a/src/cosh-ng/README_zh.md
+++ b/src/cosh-ng/README_zh.md
@@ -92,6 +92,10 @@ Enhanced Assisted 是默认模式。`◇ ` 前缀表示 Cosh 可能在前台 She
 COSH_SHELL_INTEGRATION=native cosh
 ```
 
+Enhanced 不会向子进程保留已导出的 Bash `PROMPT_COMMAND` 值。
+各版本的属性限制及 Native 替代方式见
+[Bash prompt 兼容边界](../../docs/user-guide/zh/user-entrypoint/cosh-ng/shell/overview.md#bash-prompt-兼容边界)。
+
 ```text
 $ hello
 bash: hello: command not found

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/parity.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/parity.rs
@@ -275,56 +275,150 @@ fn enhanced_bash_preserves_last_argument_across_prompt_boundary() {
 }
 
 #[test]
-fn enhanced_bash_keeps_internal_prompt_hooks_out_of_child_env() {
+fn bash_prompt_command_attributes_and_child_environment_follow_integration_contract() {
     if !bash_available() {
         return;
     }
 
-    let work_dir = std::env::temp_dir().join(format!(
-        "cosh-shell-prompt-command-env-{}-{}",
-        std::process::id(),
-        unique_suffix()
-    ));
-    let config = ShellHostConfig::new("prompt-command-env", &work_dir)
-        .with_integration(ShellIntegration::Enhanced)
-        .with_env("PROMPT_COMMAND", "printf ''")
-        .with_env("LANG", "C.UTF-8")
-        .with_env("LC_ALL", "C.UTF-8");
-    let output = run_scripted_bash(
-        &config,
-        &[ScriptedInput::command(
-            "printf '__PROMPT_COMMAND__=%s\\n' \"$(declare -p PROMPT_COMMAND)\"; \
-             if env | grep -q '^PROMPT_COMMAND='; then \
-               printf '__CHILD_PROMPT_COMMAND__=present\\n'; \
-             else \
-               printf '__CHILD_PROMPT_COMMAND__=absent\\n'; \
-             fi; \
-             (PROMPT_COMMAND=('printf p1' 'printf p2'); \
-             printf '__REASSIGNED_PROMPT_COMMAND__=%s\\n' \
-             \"$(declare -p PROMPT_COMMAND)\")",
-        )],
-    )
-    .expect("scripted bash");
+    let supports_array = bash_supports_prompt_command_array();
+    for (fixture, inherited, startup, expected_trace) in [
+        ("scalar", "USER_PROMPT_TRACE+=scalar", "", "scalar"),
+        (
+            "array",
+            "",
+            "PROMPT_COMMAND=('USER_PROMPT_TRACE+=first' 'USER_PROMPT_TRACE+=second')\n",
+            if supports_array {
+                "firstsecond"
+            } else {
+                "first"
+            },
+        ),
+        ("empty", "", "", ""),
+        (
+            "unassigned",
+            "",
+            "unset PROMPT_COMMAND; export PROMPT_COMMAND\n",
+            "",
+        ),
+    ] {
+        for login_shell in [false, true] {
+            for integration in [ShellIntegration::Native, ShellIntegration::Enhanced] {
+                let enhanced = integration == ShellIntegration::Enhanced;
+                let context = format!("{fixture}/login={login_shell}/{integration:?}");
+                let root = tempfile::Builder::new()
+                    .prefix("cosh-shell-prompt-command-")
+                    .tempdir()
+                    .expect("prompt command root");
+                let home = root.path().join("home");
+                std::fs::create_dir_all(&home).expect("home");
+                let startup_file = if login_shell {
+                    ".bash_profile"
+                } else {
+                    ".bashrc"
+                };
+                // System login profiles may rewrite PROMPT_COMMAND before this
+                // user startup file. Establish each fixture after those hooks.
+                std::fs::write(
+                    home.join(startup_file),
+                    format!(
+                        "PS1='__PROMPT_COMMAND_READY__ '\nUSER_PROMPT_TRACE=\n\
+                         unset PROMPT_COMMAND\nexport PROMPT_COMMAND='{inherited}'\n{startup}"
+                    ),
+                )
+                .expect("startup file");
+                let mut config =
+                    ShellHostConfig::new("prompt-command-env", root.path().join("work"))
+                        .with_integration(integration)
+                        .with_env("HOME", home.display().to_string())
+                        .with_env("PROMPT_COMMAND", inherited)
+                        .with_env("LANG", "C.UTF-8")
+                        .with_env("LC_ALL", "C.UTF-8");
+                config.login_shell = login_shell;
+                config.raw_action_watchdog = Duration::from_secs(2);
+                let mut rendered = Vec::new();
+                let output = run_raw_relay_bash_with_actions(
+                    &config,
+                    vec![
+                        RawRelayAction::wait(Duration::from_millis(100)),
+                        RawRelayAction::line(
+                            "printf '%s' \"$USER_PROMPT_TRACE\" > \"$HOME/hook-trace\"; \
+                             declare -p PROMPT_COMMAND > \"$HOME/declaration\"; \
+                             env | grep '^PROMPT_COMMAND=' > \"$HOME/child-env\" || :; \
+                             (PROMPT_COMMAND=('printf p1' 'printf p2'); \
+                              declare -p PROMPT_COMMAND > \"$HOME/reassigned\")",
+                        ),
+                        RawRelayAction::line("exit"),
+                    ],
+                    &mut rendered,
+                )
+                .unwrap_or_else(|error| panic!("{context}: {error}"));
+                let terminal = String::from_utf8_lossy(&rendered);
+                assert_eq!(output.exit_status, Some(0), "{context}: {terminal}");
+                let read = |name| {
+                    std::fs::read_to_string(home.join(name))
+                        .unwrap_or_else(|error| panic!("{context}/{name}: {error}: {terminal}"))
+                };
+                assert_eq!(read("hook-trace"), expected_trace, "{context}");
 
-    let terminal = String::from_utf8_lossy(&output.terminal_output);
-    let expected = if bash_supports_prompt_command_array() {
-        "__PROMPT_COMMAND__=declare -ax PROMPT_COMMAND="
-    } else {
-        "__PROMPT_COMMAND__=declare -- PROMPT_COMMAND="
-    };
-    assert!(terminal.contains(expected), "{terminal}");
-    assert!(
-        terminal.contains("__CHILD_PROMPT_COMMAND__=absent"),
-        "{terminal}"
-    );
-    let reassigned = if bash_supports_prompt_command_array() {
-        "__REASSIGNED_PROMPT_COMMAND__=declare -ax PROMPT_COMMAND="
-    } else {
-        "__REASSIGNED_PROMPT_COMMAND__=declare -a PROMPT_COMMAND="
-    };
-    assert!(terminal.contains(reassigned), "{terminal}");
+                let declaration = read("declaration");
+                let attributes = if enhanced {
+                    if supports_array {
+                        "-ax"
+                    } else {
+                        "--"
+                    }
+                } else if fixture == "array" {
+                    "-ax"
+                } else {
+                    "-x"
+                };
+                assert!(
+                    declaration.starts_with(&format!("declare {attributes} PROMPT_COMMAND")),
+                    "{context}: {declaration}"
+                );
+                assert_eq!(
+                    declaration.contains("_COSH_PROMPT_STATUS"),
+                    enhanced,
+                    "{context}"
+                );
+                assert_eq!(
+                    declaration.contains("_cosh_bounded_prompt_marker"),
+                    enhanced,
+                    "{context}"
+                );
 
-    let _ = std::fs::remove_dir_all(&work_dir);
+                // Native launches Bash without a marker rcfile. Exported scalars
+                // retain their original child value; arrays have no environment entry.
+                let child_env = read("child-env");
+                let child_value = child_env
+                    .lines()
+                    .find_map(|line| line.strip_prefix("PROMPT_COMMAND="));
+                let expected_child = if !enhanced && matches!(fixture, "scalar" | "empty") {
+                    Some(inherited)
+                } else {
+                    None
+                };
+                assert_eq!(child_value, expected_child, "{context}: {child_env}");
+                let reassigned_attributes = if enhanced && !supports_array {
+                    "-a"
+                } else {
+                    "-ax"
+                };
+                assert!(
+                    read("reassigned")
+                        .starts_with(&format!("declare {reassigned_attributes} PROMPT_COMMAND=")),
+                    "{context}: {}",
+                    read("reassigned")
+                );
+                if !enhanced {
+                    assert!(
+                        !config.work_dir.join("cosh-marker.bash").exists(),
+                        "{context}"
+                    );
+                }
+            }
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Why

Enhanced uses Bash `PROMPT_COMMAND` for bounded prompt integration, so an exported user scalar no longer reaches child processes after integration. Document this compatibility boundary explicitly and pin the behavior instead of restoring `export` on Cosh's internal hook text.

## What changed

Extend the existing prompt-environment regression to 16 real PTY sessions: exported nonempty scalar, array, empty scalar, and unassigned export, each in login/non-login Native and Enhanced shells. The user startup files establish the fixtures after system profiles run, so distro-added prompt hooks do not alter the test inputs. Check user hook execution order, variable attributes, child environment values, reassigned-array attributes, and the absence of a marker rcfile in the Native control. Add matching English/Chinese guidance and README links; production behavior is unchanged.

## Related issue

Refs #2540 and #2598; supplements #2915. This PR deliberately does not auto-close either issue: it records the agreed PROMPT_COMMAND boundary, while the original Core-107/platform acceptance still needs an explicit disposition. PS2 is independent and has existing coverage from #3024.

## User / Agent impact

| Integration | Session representation | Child environment |
| --- | --- | --- |
| Enhanced, Bash 5.1+ | Combined array; existing export attribute retained | No PROMPT_COMMAND value, including when the original exported scalar was empty |
| Enhanced, Bash 4.3–5.0 | Combined scalar without export attribute | Neither the original user scalar nor Cosh's internal hook text is exported |
| Native control | Bash's own representation and attributes | Exported scalar retains its original value; arrays are not exported by Bash |

User hooks configured before integration keep the execution order supported by the selected Bash version. Both Enhanced Assisted and Enhanced Shell-only have these limits: Shift+Tab does not remove integration. Configure hooks independently in child shells' startup files, or choose Native when Bash's own prompt-variable behavior is required; Native provides no Cosh hooks, observation, or insights. `--resume` always selects Enhanced, even when Native is configured; omit it when Native behavior is required.

This boundary concerns Bash PROMPT_COMMAND only. It does not relax PS2 behavior, ordinary environment-variable semantics, user hook execution, job control, exit status, or terminal restoration.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Migration or rollback guidance is needed

Tests and documentation only; no runtime, dependency, CLI, or configuration changes. The Native PTY control directly launches Bash without a Cosh marker rcfile; it is not an installed-package, console-login, or PAM oracle.

## Validation

Ubuntu 24.04.3, Linux aarch64, Bash 5.2.21:

```bash
cd src/cosh-ng
cargo test --locked -p cosh-shell --test shell_host parity::bash_prompt_command_attributes_and_child_environment_follow_integration_contract -- --exact --nocapture
rustfmt --edition 2021 --check crates/cosh-shell/tests/shell_host/parity.rs
```

- Exact regression: 1 test passed, all 16 PTY sessions executed, 0 failed/ignored.
- Temporarily appended `;:` to PROMPT_COMMAND at the beginning of the user startup fixture to model a system startup hook: the previous revision failed the Native scalar child-environment assertion; the corrected fixture passed all 16 PTY sessions. Temporary source changes and logs were removed.
- `bash scripts/docs-lint.sh`, changed-document relative links, bilingual parity, source verification of the resume override, and `git diff --check` passed.
- Bash 4.3–5.0 expectations are encoded but were not executed locally. The original Alibaba Cloud Linux 3 host was not rerun. No ALinux4/Core-107 rerun, dual-architecture acceptance, installed-package/PAM check, manual screenshot, or real-provider validation is claimed. Broader regression coverage remains with CI.

## Documentation and rollback

Updated both component READMEs and the English/Chinese interactive-terminal overview. Reverting this commit removes the documentation and expanded regression only; existing runtime behavior is unchanged. Users requiring the Native boundary can select `COSH_SHELL_INTEGRATION=native cosh` at startup.
