### PR TITLE
fix(memory): align corpus supplement with host contract

### DIFF
--- a/src/agent-memory/adapters/agent-memory/openclaw/src/corpus.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/src/corpus.ts
@@ -1,0 +1,67 @@
+/**
+ * Line-window slicing for the memory corpus supplement.
+ *
+ * OpenClaw's `MemoryCorpusGetResult` (plugin-sdk `plugins/memory-state`)
+ * requires a supplement to report the window it actually returned: `fromLine`
+ * is the 1-based first line and `lineCount` the number of lines in `content`.
+ * The host spreads that result straight into the `memory_read` response, so
+ * these two fields are what the model sees — and the host's builtin reader
+ * (`buildMemoryReadResult`) clamps the same two inputs, which means a
+ * supplement that echoes the *requested* window instead of the *returned* one
+ * makes the two corpora disagree about what "from line 0, 10 lines" produced.
+ *
+ * Pure and standalone on purpose: the supplement itself needs a live plugin
+ * API and MCP client, this does not, so the window arithmetic is testable.
+ */
+
+export type CorpusWindow = {
+  /** The selected lines, joined with "\n". */
+  content: string;
+  /** 1-based first line of `content`; always >= 1. */
+  fromLine: number;
+  /** Number of lines in `content`; 0 when the window starts past the end. */
+  lineCount: number;
+};
+
+/** 1-based start line, clamped exactly like the host's builtin reader.
+ *  Without the clamp a 0 or negative request reaches `Array.slice` as a
+ *  negative index and silently returns the document's *tail*, and a non-finite
+ *  value propagates NaN into the reported window. */
+function normalizeFromLine(fromLine?: number): number {
+  if (fromLine === undefined || !Number.isFinite(fromLine)) return 1;
+  return Math.max(1, Math.trunc(fromLine));
+}
+
+/** Requested line count, or undefined for "to the end of the document".
+ *  Clamped to >= 1 for the same reason: to the host's builtin reader a
+ *  non-positive count means one line, not the whole file — and this plugin's
+ *  entire job is keeping payloads out of the context window. */
+function normalizeLineCount(lineCount?: number): number | undefined {
+  if (lineCount === undefined || !Number.isFinite(lineCount)) return undefined;
+  return Math.max(1, Math.trunc(lineCount));
+}
+
+/**
+ * Select a line window from a document body.
+ *
+ * `text` is split on "\n" and the selected lines are re-joined, so a document
+ * ending in a newline carries one trailing empty line — the same accounting the
+ * host's builtin reader uses, which keeps `fromLine + lineCount` pagination
+ * consistent across corpora.
+ */
+export function sliceCorpusWindow(
+  text: string,
+  fromLine?: number,
+  lineCount?: number,
+): CorpusWindow {
+  const lines = text.split("\n");
+  const start = normalizeFromLine(fromLine);
+  const requested = normalizeLineCount(lineCount);
+  const end = requested === undefined ? lines.length : start - 1 + requested;
+  const selected = lines.slice(start - 1, end);
+  return {
+    content: selected.join("\n"),
+    fromLine: start,
+    lineCount: selected.length,
+  };
+}

--- a/src/agent-memory/adapters/agent-memory/openclaw/src/corpus.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/src/corpus.ts
@@ -1,5 +1,6 @@
 /**
- * Line-window slicing for the memory corpus supplement.
+ * Corpus identity, read handles and line-window slicing for the memory corpus
+ * supplement.
  *
  * OpenClaw's `MemoryCorpusGetResult` (plugin-sdk `plugins/memory-state`)
  * requires a supplement to report the window it actually returned: `fromLine`
@@ -10,8 +11,14 @@
  * supplement that echoes the *requested* window instead of the *returned* one
  * makes the two corpora disagree about what "from line 0, 10 lines" produced.
  *
+ * The path a search hit advertises is the other half of the same contract: the
+ * model echoes it back to `memory_get`, and whether that read ever reaches this
+ * supplement is a property of the path's *shape*, not of its corpus — see
+ * `toCorpusReadHandle`.
+ *
  * Pure and standalone on purpose: the supplement itself needs a live plugin
- * API and MCP client, this does not, so the window arithmetic is testable.
+ * API and MCP client, this does not, so the window arithmetic and the path
+ * mapping are testable.
  */
 
 export type CorpusWindow = {
@@ -63,5 +70,170 @@ export function sliceCorpusWindow(
     content: selected.join("\n"),
     fromLine: start,
     lineCount: selected.length,
+  };
+}
+
+/**
+ * Corpus id this plugin's supplement serves.
+ *
+ * The host stamps its own builtin hits with `corpus: "memory"` (memory-core
+ * `createMemorySearchTool`: `surfacedMemoryResults = memoryResults.map((r) =>
+ * ({ ...r, corpus: "memory" }))`) and its compiled-wiki supplement labels its
+ * own hits `corpus: "wiki"`, so the field is how the model tells the corpora in
+ * one merged `memory_search` response apart — and how it chooses the `corpus`
+ * argument to echo back to `memory_get`.
+ *
+ * Claiming `"memory"` did two kinds of damage at once: agent-memory hits were
+ * indistinguishable from the host's `MEMORY.md` hits, and a model echoing the
+ * label back was routed to the builtin reader (`readAgentMemoryFile`, over the
+ * workspace `MEMORY.md` + `memory/*.md`), which cannot see this store.
+ * `memory_get` consults supplements only for `corpus=wiki` and, after a failed
+ * builtin read, for `corpus=all` — so every path this supplement surfaced was
+ * unreadable through the shared tool flow.
+ *
+ * The id is ours rather than the wiki's: `memory_get` walks the registered
+ * supplements and returns the first non-null answer, so borrowing `corpus:
+ * "wiki"` would make the two corpora interchangeable to the model and let
+ * whichever registered first shadow the other.
+ */
+export const AGENT_MEMORY_CORPUS = "agent-memory";
+
+/**
+ * Read route carried on search hits.
+ *
+ * `memory_get`'s `corpus` enum is `memory | wiki | all`, so the model cannot
+ * echo `agent-memory` back; with no route it retries the default builtin read
+ * and lands in the dead end described above. `corpus=all` is the value that
+ * reaches a supplement once the builtin read has failed. The hint costs a few
+ * tokens per hit and replaces a failed read plus its retry — a net saving for a
+ * component whose job is token economy. Only search hits carry it: by the time
+ * `get()` answers, the route is already chosen.
+ *
+ * The promise holds only while the builtin read genuinely fails, which is a
+ * property of the path being read — so the paths advertised alongside this
+ * label go through `toCorpusReadHandle`. Without that, every hit whose store
+ * path landed in the host's own memory namespace advertised a route that did
+ * not exist: the builtin read answered (with the workspace file, or with an
+ * empty text when there was none) and this supplement was never called.
+ */
+export const AGENT_MEMORY_CORPUS_READ_HINT =
+  "agent-memory (read via memory_get corpus=all)";
+
+/**
+ * Whether the host's builtin reader answers this path itself, so that no
+ * supplement is ever consulted for it.
+ *
+ * `memory_get` reaches the registered supplements only *after* the builtin read
+ * has thrown: memory-core's `executeMemoryReadResult` returns the builtin
+ * result when `read()` resolves, and only its catch block calls
+ * `resolveMemoryReadFailureResult`, which walks the supplements — and only for
+ * `corpus=all`. The builtin reader (memory-host-sdk `readMemoryFile`) resolves
+ * the requested path against the agent workspace and resolves successfully for
+ * exactly the shapes its `isMemoryPath` admits, returning `{text: "", path}`
+ * when the workspace has no such file and the workspace file's own content when
+ * it does. Neither answer throws, so neither ever reaches a supplement. Every
+ * other shape it rejects with "path required", and that throw is this plugin's
+ * only door in.
+ *
+ * Mirrored rather than imported because no plugin-sdk entry point exports
+ * `isMemoryPath`; `tests/unit/corpus-routing-test.ts` pins the mirror against
+ * the host's real `readMemoryFile`. `memory_get` picks its reader by backend —
+ * the builtin one, a manager that delegates to it, or qmd's, which rejects a
+ * foreign path the same way — so the shape test is the same one whichever
+ * serves the read.
+ *
+ * The mirror is deliberately over-eager, because that is the cheap direction:
+ * namespacing a path the host would have rejected anyway costs one prefix and
+ * still routes here, while missing one silently swallows the read. It cannot be
+ * exact in any case — the host also answers paths an operator lists under
+ * `extraPaths` or inside a qmd collection root, neither of which a plugin can
+ * see.
+ */
+export function isHostBuiltinMemoryPath(storePath: string): boolean {
+  // The host normalises before testing: trim, drop leading "." and "/"
+  // characters, and accept "\" as a separator.
+  const normalized = storePath.trim().replace(/^[./]+/, "").replace(/\\/g, "/");
+  if (!normalized) return false;
+  if (normalized === "MEMORY.md") return true;
+  if (normalized.toLowerCase() === "dreams.md") return true;
+  return normalized.startsWith("memory/");
+}
+
+/**
+ * Namespace put in front of a store path the host would otherwise answer
+ * itself.
+ *
+ * Any prefix outside the host's namespace works — `isMemoryPath` tests the
+ * whole relative path, so `agent-memory/MEMORY.md` is not a memory path and the
+ * builtin read throws, which is what routes `corpus=all` to a supplement. This
+ * plugin's own name keeps the handle self-describing in a merged search
+ * response, where a store path can sit next to the workspace file it shadows.
+ */
+export const AGENT_MEMORY_READ_NAMESPACE = "agent-memory/";
+
+/**
+ * The path a search hit advertises — the one the model echoes back to
+ * `memory_get`.
+ *
+ * Store paths the host answers itself are namespaced so that the builtin read
+ * fails and `corpus=all` falls through to this supplement. Every other path is
+ * advertised unchanged: it already reaches the supplement, and re-labelling it
+ * would spend tokens on a route that works.
+ *
+ * A store path that already begins with the namespace is namespaced as well.
+ * Without that, the store's own `agent-memory/notes.md` and a namespaced
+ * `notes.md` would advertise the same handle, and `fromCorpusReadHandle` could
+ * not tell them apart — one would read the other's file.
+ */
+export function toCorpusReadHandle(storePath: string): string {
+  if (isHostBuiltinMemoryPath(storePath)) {
+    return AGENT_MEMORY_READ_NAMESPACE + storePath;
+  }
+  if (storePath.startsWith(AGENT_MEMORY_READ_NAMESPACE)) {
+    return AGENT_MEMORY_READ_NAMESPACE + storePath;
+  }
+  return storePath;
+}
+
+/**
+ * Inverse of `toCorpusReadHandle`: the store path a `memory_get` lookup names.
+ *
+ * Exact for every handle this plugin advertises and the identity for anything
+ * else, so a lookup that arrives un-namespaced still resolves — a model quoting
+ * a path it saw elsewhere, or a `corpus=wiki` read, which skips the builtin
+ * reader entirely and reaches the supplements for any path shape.
+ */
+export function fromCorpusReadHandle(lookup: string): string {
+  return lookup.startsWith(AGENT_MEMORY_READ_NAMESPACE)
+    ? lookup.slice(AGENT_MEMORY_READ_NAMESPACE.length)
+    : lookup;
+}
+
+/** A hit exactly as this plugin's MCP `memory_search` reports it. */
+export type CorpusSearchHit = {
+  path: string;
+  snippet: string;
+  score: number;
+};
+
+/**
+ * Label one MCP search hit as belonging to this plugin's corpus, advertising
+ * the path that actually routes back to it.
+ */
+export function toCorpusSearchResult(
+  hit: CorpusSearchHit,
+): {
+  corpus: string;
+  path: string;
+  snippet: string;
+  score: number;
+  provenanceLabel: string;
+} {
+  return {
+    corpus: AGENT_MEMORY_CORPUS,
+    path: toCorpusReadHandle(hit.path),
+    snippet: hit.snippet,
+    score: hit.score,
+    provenanceLabel: AGENT_MEMORY_CORPUS_READ_HINT,
   };
 }

--- a/src/agent-memory/adapters/agent-memory/openclaw/src/index.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/src/index.ts
@@ -15,6 +15,7 @@ import { McpStdioClient } from "./mcp-client.js";
 import { resolveConfig, type AgentMemoryConfig } from "./config.js";
 import { looksLikePromptInjection, wrapMemoryResultsForPrompt } from "./safety.js";
 import { buildRecallQueries, MAX_RESULTS, RRF_K } from "./keyword-extract.js";
+import { sliceCorpusWindow } from "./corpus.js";
 
 // Module-scoped singleton client. OpenClaw may call register() again
 // during a plugin hot-reload without firing gateway_stop for the old
@@ -521,16 +522,16 @@ export default definePluginEntry({
           const text = await client.callTool("memory_get", {
             path: input.lookup,
           });
-          const lines = text.split("\n");
-          const start = (input.fromLine ?? 1) - 1;
-          const end = input.lineCount
-            ? start + input.lineCount
-            : lines.length;
+          // MemoryCorpusGetResult requires the window actually returned, not
+          // the one requested — clamping and accounting live in corpus.ts.
+          const slice = sliceCorpusWindow(text, input.fromLine, input.lineCount);
           return {
             corpus: "memory",
             path: input.lookup,
             title: input.lookup,
-            content: lines.slice(start, end).join("\n"),
+            content: slice.content,
+            fromLine: slice.fromLine,
+            lineCount: slice.lineCount,
           };
         } catch {
           return null;

--- a/src/agent-memory/adapters/agent-memory/openclaw/src/index.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/src/index.ts
@@ -15,7 +15,13 @@ import { McpStdioClient } from "./mcp-client.js";
 import { resolveConfig, type AgentMemoryConfig } from "./config.js";
 import { looksLikePromptInjection, wrapMemoryResultsForPrompt } from "./safety.js";
 import { buildRecallQueries, MAX_RESULTS, RRF_K } from "./keyword-extract.js";
-import { sliceCorpusWindow } from "./corpus.js";
+import {
+  AGENT_MEMORY_CORPUS,
+  fromCorpusReadHandle,
+  sliceCorpusWindow,
+  toCorpusSearchResult,
+  type CorpusSearchHit,
+} from "./corpus.js";
 
 // Module-scoped singleton client. OpenClaw may call register() again
 // during a plugin hot-reload without firing gateway_stop for the old
@@ -498,17 +504,14 @@ export default definePluginEntry({
             top_k: input.maxResults ?? 5,
             mode: "hybrid",
           });
-          const hits = JSON.parse(text) as Array<{
-            path: string;
-            snippet: string;
-            score: number;
-          }>;
-          return hits.map((h) => ({
-            corpus: "memory",
-            path: h.path,
-            snippet: h.snippet,
-            score: h.score,
-          }));
+          const hits = JSON.parse(text) as CorpusSearchHit[];
+          // Labelled with this plugin's own corpus id, never the host's
+          // "memory": the label is what the model echoes back to memory_get,
+          // and only a supplement corpus routes there. The path each hit
+          // advertises is namespaced when the host's builtin reader would
+          // otherwise answer it itself, so that the echoed read really does
+          // fall through to get() below (see corpus.ts).
+          return hits.map(toCorpusSearchResult);
         } catch {
           return [];
         }
@@ -518,15 +521,23 @@ export default definePluginEntry({
         fromLine?: number;
         lineCount?: number;
       }) {
+        // The lookup is the read handle search() advertised; the store is
+        // addressed by the path underneath it. Identity for a lookup that
+        // arrives un-namespaced (see corpus.ts).
+        const storePath = fromCorpusReadHandle(input.lookup);
         try {
           const text = await client.callTool("memory_get", {
-            path: input.lookup,
+            path: storePath,
           });
           // MemoryCorpusGetResult requires the window actually returned, not
           // the one requested — clamping and accounting live in corpus.ts.
           const slice = sliceCorpusWindow(text, input.fromLine, input.lineCount);
           return {
-            corpus: "memory",
+            corpus: AGENT_MEMORY_CORPUS,
+            // Echo the handle rather than the store path: the handle is what
+            // routes here, so it is what a follow-up windowed read must keep
+            // using. Answering with the bare store path would hand the model a
+            // path whose next read the host answers itself.
             path: input.lookup,
             title: input.lookup,
             content: slice.content,

--- a/src/agent-memory/adapters/agent-memory/openclaw/tests/smoke-test.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/tests/smoke-test.ts
@@ -9,6 +9,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { execSync } from "node:child_process";
 import { McpStdioClient } from "../src/mcp-client.js";
 
@@ -47,6 +49,14 @@ const binaryPath = findBinary();
 // Skip entire suite if binary is not available.
 const skip = binaryPath === null;
 
+// The client forwards both as MEMORY_SESSION_ID / MEMORY_SESSION_DIR on every
+// spawn. A throwaway dir keeps the smoke test hermetic: the production default
+// /run/anolisa/sessions is root-owned 0700 via tmpfiles.d and need not exist
+// on a dev host. Only created when the suite will actually run.
+const sessionDir = skip
+  ? path.join(os.tmpdir(), "agent-memory-smoke-skipped")
+  : fs.mkdtempSync(path.join(os.tmpdir(), "agent-memory-smoke-"));
+
 describe("agent-memory MCP smoke test", { skip }, () => {
   const client = new McpStdioClient({
     binaryPath: binaryPath!,
@@ -54,6 +64,8 @@ describe("agent-memory MCP smoke test", { skip }, () => {
     profile: "advanced",
     maxReadBytes: 1_048_576,
     maxWriteBytes: 16_777_216,
+    sessionId: `ses_smoke_${process.pid}`,
+    sessionDir,
   });
 
   it("calls memory_search and returns a result", async () => {

--- a/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/corpus-routing-test.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/corpus-routing-test.ts
@@ -1,0 +1,218 @@
+/**
+ * Routing tests for the corpus read handle: does the path a search hit
+ * advertises actually reach this plugin's supplement through the host's
+ * `memory_get`?
+ *
+ * `corpus-test.ts` checks the handle as a pure mapping. This file checks the
+ * claim the handle exists to make, against the pinned host's own reader — a
+ * hit is only readable if the model can follow `provenanceLabel` and land on
+ * `get()`, and for a store path inside the host's builtin memory namespace
+ * (`MEMORY.md`, `dreams.md`, `memory/**`) it could not: the builtin read
+ * *succeeds* there, with the workspace file's content or with an empty text
+ * when the workspace has no such file, and `memory_get` consults supplements
+ * only after that read has thrown.
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { readMemoryFile } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import {
+  AGENT_MEMORY_CORPUS,
+  fromCorpusReadHandle,
+  sliceCorpusWindow,
+  toCorpusReadHandle,
+  toCorpusSearchResult,
+} from "../../src/corpus.js";
+
+/** What this plugin's MCP store holds, keyed by store-relative path. */
+const STORE = new Map<string, string>([
+  ["MEMORY.md", "store one\nstore two"],
+  ["dreams.md", "store dream one\nstore dream two"],
+  ["memory/sample.md", "store mem one\nstore mem two"],
+  ["notes/observed/sample.md", "note one\nnote two"],
+  ["agent-memory/notes.md", "namespaced one\nnamespaced two"],
+]);
+
+/** Paths the workspace's own builtin memory holds — same shapes, different
+ *  content, so a read served by the wrong store is unmistakable. */
+const WORKSPACE_FILES = new Map<string, string>([
+  ["MEMORY.md", "builtin one\nbuiltin two"],
+  ["memory/sample.md", "builtin mem one\nbuiltin mem two"],
+]);
+
+type ReadRoute =
+  | { via: "builtin"; text: string }
+  | { via: "supplement"; text: string }
+  | { via: "none" };
+
+/**
+ * The host's `memory_get` read path (memory-core `tools.ts`, OpenClaw
+ * 2026.5.7), reduced to the part that decides whether a supplement is
+ * consulted:
+ *
+ *   executeMemoryReadResult        builtin read resolves → return it;
+ *                                  builtin read throws → resolveMemoryReadFailureResult,
+ *                                  which for `corpus=all` walks the registered
+ *                                  supplements and returns the first non-null
+ *                                  answer.
+ *
+ * The builtin read is the host's own exported `readMemoryFile` over a real
+ * workspace directory, so what decides the route here is the host's real
+ * behaviour rather than a restatement of it.
+ */
+async function hostMemoryGet(params: {
+  workspaceDir: string;
+  relPath: string;
+  store: Map<string, string>;
+}): Promise<ReadRoute> {
+  // This plugin's supplement, as src/index.ts registers it.
+  const supplementGet = async (lookup: string) => {
+    const text = params.store.get(fromCorpusReadHandle(lookup));
+    if (text === undefined) return null; // index.ts: MCP error → null
+    const slice = sliceCorpusWindow(text);
+    return { corpus: AGENT_MEMORY_CORPUS, path: lookup, content: slice.content };
+  };
+
+  try {
+    const builtin = await readMemoryFile({
+      workspaceDir: params.workspaceDir,
+      relPath: params.relPath,
+    });
+    return { via: "builtin", text: builtin.text };
+  } catch {
+    const result = await supplementGet(params.relPath);
+    return result ? { via: "supplement", text: result.content } : { via: "none" };
+  }
+}
+
+/** Read the path a search hit advertises, the way a model following
+ *  `provenanceLabel` would. */
+async function readAdvertisedHit(params: {
+  workspaceDir: string;
+  storePath: string;
+  store: Map<string, string>;
+}): Promise<ReadRoute> {
+  const hit = toCorpusSearchResult({
+    path: params.storePath,
+    snippet: "…",
+    score: -1,
+  });
+  return await hostMemoryGet({
+    workspaceDir: params.workspaceDir,
+    relPath: hit.path,
+    store: params.store,
+  });
+}
+
+describe("memory_get routing through the pinned host", () => {
+  let bareWorkspace = ""; // no builtin memory files at all
+  let shadowingWorkspace = ""; // builtin MEMORY.md + memory/sample.md present
+
+  before(async () => {
+    bareWorkspace = await fs.mkdtemp(path.join(os.tmpdir(), "am-corpus-bare-"));
+    shadowingWorkspace = await fs.mkdtemp(
+      path.join(os.tmpdir(), "am-corpus-shadow-"),
+    );
+    for (const [relPath, content] of WORKSPACE_FILES) {
+      const abs = path.join(shadowingWorkspace, relPath);
+      await fs.mkdir(path.dirname(abs), { recursive: true });
+      await fs.writeFile(abs, `${content}\n`, "utf-8");
+    }
+  });
+
+  after(async () => {
+    for (const dir of [bareWorkspace, shadowingWorkspace]) {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  for (const workspace of ["bare", "shadowing"] as const) {
+    const dir = () => (workspace === "bare" ? bareWorkspace : shadowingWorkspace);
+
+    describe(`workspace ${workspace}`, () => {
+      it("routes every advertised hit to this supplement", async () => {
+        for (const storePath of STORE.keys()) {
+          const route = await readAdvertisedHit({
+            workspaceDir: dir(),
+            storePath,
+            store: STORE,
+          });
+          assert.equal(route.via, "supplement", storePath);
+          assert.equal(route.text, STORE.get(storePath), storePath);
+        }
+      });
+
+      it("reads the store, not the workspace file it shadows", async () => {
+        // The reviewer's repro: with a workspace MEMORY.md present, a bare
+        // read of the same shape returned "builtin two" and never called the
+        // supplement.
+        for (const storePath of ["MEMORY.md", "memory/sample.md", "dreams.md"]) {
+          const route = await readAdvertisedHit({
+            workspaceDir: dir(),
+            storePath,
+            store: STORE,
+          });
+          assert.equal(route.via, "supplement", storePath);
+          assert.match(route.text, /^store /, storePath);
+        }
+      });
+
+      it("advertises only handles the host's builtin reader rejects", async () => {
+        // A handle the builtin reader answers is a handle that never reaches
+        // get(), whatever the workspace holds.
+        for (const storePath of STORE.keys()) {
+          await assert.rejects(
+            readMemoryFile({
+              workspaceDir: dir(),
+              relPath: toCorpusReadHandle(storePath),
+            }),
+            /path required/,
+            storePath,
+          );
+        }
+      });
+    });
+  }
+
+  describe("the bare store path it replaces", () => {
+    it("is answered by the workspace file when one exists", async () => {
+      const route = await hostMemoryGet({
+        workspaceDir: shadowingWorkspace,
+        relPath: "MEMORY.md",
+        store: STORE,
+      });
+      assert.deepEqual(route, {
+        via: "builtin",
+        text: "builtin one\nbuiltin two\n",
+      });
+    });
+
+    it("is answered with empty text when no workspace file exists", async () => {
+      // Neither answer throws, so neither ever reaches a supplement: this is
+      // the dead end the handle exists to avoid.
+      for (const relPath of ["MEMORY.md", "memory/sample.md", "dreams.md"]) {
+        const route = await hostMemoryGet({
+          workspaceDir: bareWorkspace,
+          relPath,
+          store: STORE,
+        });
+        assert.deepEqual(route, { via: "builtin", text: "" }, relPath);
+      }
+    });
+
+    it("still reaches the supplement for a path outside the namespace", async () => {
+      // Why only shadowed paths are namespaced: this one already worked, and
+      // re-labelling it would spend tokens on a route that needs no repair.
+      const route = await hostMemoryGet({
+        workspaceDir: shadowingWorkspace,
+        relPath: "notes/observed/sample.md",
+        store: STORE,
+      });
+      assert.equal(route.via, "supplement");
+      assert.equal(route.text, "note one\nnote two");
+    });
+  });
+});

--- a/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/corpus-test.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/corpus-test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for the corpus-get line window (src/corpus.ts).
+ *
+ * The window the memory corpus supplement reports back to OpenClaw has to
+ * match the host's own builtin reader: `MemoryCorpusGetResult` requires
+ * `fromLine` / `lineCount`, and the host clamps both inputs, so an unclamped
+ * supplement would answer the same `memory_read` differently depending on
+ * which corpus served it.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { sliceCorpusWindow } from "../../src/corpus.js";
+
+// Five lines, no trailing newline.
+const DOC = "one\ntwo\nthree\nfour\nfive";
+
+describe("sliceCorpusWindow", () => {
+  it("returns the whole document when no window is requested", () => {
+    assert.deepEqual(sliceCorpusWindow(DOC), {
+      content: DOC,
+      fromLine: 1,
+      lineCount: 5,
+    });
+  });
+
+  it("returns the requested window and reports it", () => {
+    assert.deepEqual(sliceCorpusWindow(DOC, 2, 2), {
+      content: "two\nthree",
+      fromLine: 2,
+      lineCount: 2,
+    });
+  });
+
+  it("honours an open-ended window from a given line", () => {
+    assert.deepEqual(sliceCorpusWindow(DOC, 4), {
+      content: "four\nfive",
+      fromLine: 4,
+      lineCount: 2,
+    });
+  });
+
+  it("clamps a window that runs past the end of the document", () => {
+    assert.deepEqual(sliceCorpusWindow(DOC, 4, 10), {
+      content: "four\nfive",
+      fromLine: 4,
+      lineCount: 2,
+    });
+  });
+
+  it("reports an empty window when fromLine is past the end", () => {
+    assert.deepEqual(sliceCorpusWindow(DOC, 6, 2), {
+      content: "",
+      fromLine: 6,
+      lineCount: 0,
+    });
+  });
+
+  it("clamps fromLine 0 to the first line instead of slicing from the end", () => {
+    // Regression: (0 - 1) reached Array.slice as -1 and returned the tail.
+    assert.deepEqual(sliceCorpusWindow(DOC, 0, 2), {
+      content: "one\ntwo",
+      fromLine: 1,
+      lineCount: 2,
+    });
+  });
+
+  it("clamps a negative fromLine the same way", () => {
+    assert.deepEqual(sliceCorpusWindow(DOC, -3, 1), {
+      content: "one",
+      fromLine: 1,
+      lineCount: 1,
+    });
+  });
+
+  it("clamps lineCount 0 to one line, matching the builtin reader", () => {
+    // Regression: 0 is falsy, so it used to select the rest of the document.
+    assert.deepEqual(sliceCorpusWindow(DOC, 2, 0), {
+      content: "two",
+      fromLine: 2,
+      lineCount: 1,
+    });
+  });
+
+  it("clamps a negative lineCount the same way", () => {
+    assert.deepEqual(sliceCorpusWindow(DOC, 3, -5), {
+      content: "three",
+      fromLine: 3,
+      lineCount: 1,
+    });
+  });
+
+  it("truncates fractional bounds instead of reporting them", () => {
+    assert.deepEqual(sliceCorpusWindow(DOC, 2.7, 2.9), {
+      content: "two\nthree",
+      fromLine: 2,
+      lineCount: 2,
+    });
+  });
+
+  it("treats non-finite bounds as no window", () => {
+    assert.deepEqual(sliceCorpusWindow(DOC, Number.NaN, Number.POSITIVE_INFINITY), {
+      content: DOC,
+      fromLine: 1,
+      lineCount: 5,
+    });
+  });
+
+  it("counts a trailing newline as one empty line", () => {
+    assert.deepEqual(sliceCorpusWindow("a\nb\n"), {
+      content: "a\nb\n",
+      fromLine: 1,
+      lineCount: 3,
+    });
+  });
+
+  it("handles an empty document", () => {
+    assert.deepEqual(sliceCorpusWindow(""), {
+      content: "",
+      fromLine: 1,
+      lineCount: 1,
+    });
+  });
+});

--- a/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/corpus-test.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/corpus-test.ts
@@ -1,16 +1,33 @@
 /**
- * Unit tests for the corpus-get line window (src/corpus.ts).
+ * Unit tests for the corpus supplement contract helpers (src/corpus.ts):
+ * the line window a `memory_read` reports, the corpus identity the
+ * supplement's results carry, and the read handle each hit advertises.
  *
  * The window the memory corpus supplement reports back to OpenClaw has to
  * match the host's own builtin reader: `MemoryCorpusGetResult` requires
  * `fromLine` / `lineCount`, and the host clamps both inputs, so an unclamped
  * supplement would answer the same `memory_read` differently depending on
  * which corpus served it.
+ *
+ * The handle is checked here as a pure mapping; whether it actually routes a
+ * read back to the supplement is `corpus-routing-test.ts`, which drives the
+ * host's own reader.
  */
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { sliceCorpusWindow } from "../../src/corpus.js";
+import {
+  AGENT_MEMORY_CORPUS,
+  AGENT_MEMORY_CORPUS_READ_HINT,
+  AGENT_MEMORY_READ_NAMESPACE,
+  fromCorpusReadHandle,
+  isHostBuiltinMemoryPath,
+  sliceCorpusWindow,
+  toCorpusReadHandle,
+  toCorpusSearchResult,
+} from "../../src/corpus.js";
+
+type CorpusHit = Parameters<typeof toCorpusSearchResult>[0];
 
 // Five lines, no trailing newline.
 const DOC = "one\ntwo\nthree\nfour\nfive";
@@ -120,5 +137,182 @@ describe("sliceCorpusWindow", () => {
       fromLine: 1,
       lineCount: 1,
     });
+  });
+});
+
+/** Store paths this plugin's MCP server can legitimately report: the ones the
+ *  host's builtin namespace shadows, the ones it does not, and the one that
+ *  collides with the namespace this plugin prefixes with. */
+const STORE_PATHS = [
+  "MEMORY.md",
+  "dreams.md",
+  "memory/sample.md",
+  "memory/nested/deep.md",
+  "notes/observed/01J.md",
+  "observations.md",
+  "strategies/rebase.md",
+  "agent-memory/notes.md",
+];
+
+describe("host builtin namespace", () => {
+  it("names the shapes the host's builtin reader answers itself", () => {
+    // memory-core's memory_get only consults supplements after the builtin
+    // read throws, and the host's isMemoryPath admits exactly these.
+    for (const p of [
+      "MEMORY.md",
+      "dreams.md",
+      "memory/sample.md",
+      "memory/nested/deep.md",
+    ]) {
+      assert.equal(isHostBuiltinMemoryPath(p), true, p);
+    }
+  });
+
+  it("normalises before testing, the way the host normalises", () => {
+    for (const p of [
+      "./MEMORY.md",
+      "  MEMORY.md  ",
+      "memory\\sample.md",
+      ".//memory/sample.md",
+    ]) {
+      assert.equal(isHostBuiltinMemoryPath(p), true, p);
+    }
+  });
+
+  it("matches dreams.md case-insensitively, like the host", () => {
+    assert.equal(isHostBuiltinMemoryPath("Dreams.md"), true);
+    assert.equal(isHostBuiltinMemoryPath("DREAMS.MD"), true);
+    assert.equal(isHostBuiltinMemoryPath("MEMORY.MD"), false);
+  });
+
+  it("leaves every other store path alone", () => {
+    // Near-misses matter as much as the hits: over-claiming here namespaces
+    // paths that already reach the supplement and costs tokens for nothing.
+    for (const p of [
+      "notes/observed/01J.md",
+      "observations.md",
+      "memory",
+      "memoryx/foo.md",
+      "MEMORY.md.bak",
+      "dreams.md.bak",
+      "notes/memory/sample.md",
+      "",
+    ]) {
+      assert.equal(isHostBuiltinMemoryPath(p), false, p);
+    }
+  });
+});
+
+describe("corpus read handle", () => {
+  it("namespaces a store path the host would answer itself", () => {
+    assert.equal(toCorpusReadHandle("MEMORY.md"), "agent-memory/MEMORY.md");
+    assert.equal(
+      toCorpusReadHandle("memory/sample.md"),
+      "agent-memory/memory/sample.md",
+    );
+    assert.equal(toCorpusReadHandle("dreams.md"), "agent-memory/dreams.md");
+  });
+
+  it("leaves a path that already reaches the supplement unchanged", () => {
+    assert.equal(toCorpusReadHandle("notes/observed/01J.md"), "notes/observed/01J.md");
+    assert.equal(toCorpusReadHandle("observations.md"), "observations.md");
+  });
+
+  it("namespaces a store path that already begins with the namespace", () => {
+    // Otherwise the store's own agent-memory/notes.md and a namespaced
+    // notes.md would advertise the same handle, and one would read the
+    // other's file.
+    assert.equal(
+      toCorpusReadHandle("agent-memory/notes.md"),
+      "agent-memory/agent-memory/notes.md",
+    );
+  });
+
+  it("never advertises a handle inside the host's builtin namespace", () => {
+    for (const p of STORE_PATHS) {
+      assert.equal(isHostBuiltinMemoryPath(toCorpusReadHandle(p)), false, p);
+    }
+  });
+
+  it("round-trips every store path", () => {
+    for (const p of STORE_PATHS) {
+      assert.equal(fromCorpusReadHandle(toCorpusReadHandle(p)), p, p);
+    }
+  });
+
+  it("resolves an un-namespaced lookup to itself", () => {
+    // A model quoting a path it saw elsewhere, or a corpus=wiki read, which
+    // skips the builtin reader and reaches supplements for any path shape.
+    assert.equal(fromCorpusReadHandle("MEMORY.md"), "MEMORY.md");
+    assert.equal(
+      fromCorpusReadHandle("notes/observed/01J.md"),
+      "notes/observed/01J.md",
+    );
+  });
+
+  it("advertises the handle, not the store path, on a search hit", () => {
+    const shadowed: CorpusHit = { path: "MEMORY.md", snippet: "…decided…", score: -1 };
+    assert.equal(toCorpusSearchResult(shadowed).path, "agent-memory/MEMORY.md");
+    const reachable: CorpusHit = {
+      path: "notes/observed/01J.md",
+      snippet: "…",
+      score: -1,
+    };
+    assert.equal(toCorpusSearchResult(reachable).path, "notes/observed/01J.md");
+  });
+
+  it("namespaces with this plugin's own corpus id", () => {
+    // The handle has to stay self-describing in a merged search response,
+    // where a store path can sit next to the workspace file it shadows.
+    assert.equal(AGENT_MEMORY_READ_NAMESPACE, `${AGENT_MEMORY_CORPUS}/`);
+  });
+});
+
+describe("corpus identity", () => {
+  const HIT: CorpusHit = {
+    path: "notes/observed/01J.md",
+    snippet: "…decided…",
+    score: -3.25,
+  };
+
+  it("labels a search hit with this plugin's own corpus id", () => {
+    assert.deepEqual(toCorpusSearchResult(HIT), {
+      corpus: "agent-memory",
+      path: HIT.path,
+      snippet: HIT.snippet,
+      score: HIT.score,
+      provenanceLabel: "agent-memory (read via memory_get corpus=all)",
+    });
+  });
+
+  it("never claims a corpus id the host resolves without a supplement", () => {
+    // The host stamps its own builtin hits "memory" (and filters "sessions"
+    // from the same index); memory_get's corpus enum is memory | wiki | all,
+    // and only "wiki" and "all" ever reach a supplement. Claiming one of those
+    // ids sends the model's read to a reader that cannot see this store.
+    const hostResolved = ["memory", "sessions", "wiki", "all"];
+    assert.equal(hostResolved.includes(AGENT_MEMORY_CORPUS), false);
+  });
+
+  it("carries the read route that does reach a supplement", () => {
+    // memory_get falls back to the registered supplements only when the builtin
+    // read failed *and* corpus=all was requested, so that is the route to name.
+    assert.match(AGENT_MEMORY_CORPUS_READ_HINT, /corpus=all/);
+    assert.equal(
+      toCorpusSearchResult(HIT).provenanceLabel,
+      AGENT_MEMORY_CORPUS_READ_HINT,
+    );
+  });
+
+  it("passes the MCP score through unrescaled", () => {
+    // Ranking across corpora is the host's merge step; this mapper only labels.
+    const hits = [
+      { path: "a.md", snippet: "a", score: -0.5 },
+      { path: "b.md", snippet: "b", score: -4 },
+    ];
+    assert.deepEqual(
+      hits.map(toCorpusSearchResult).map((r) => r.score),
+      [-0.5, -4],
+    );
   });
 });

--- a/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/mcp-client-test.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/mcp-client-test.ts
@@ -92,6 +92,10 @@ describe("McpStdioClient", () => {
     profile: "advanced" as const,
     maxReadBytes: 1_048_576,
     maxWriteBytes: 16_777_216,
+    // Inert here — the binary never spawns — but part of AgentMemoryConfig,
+    // which the client forwards as MEMORY_SESSION_ID / MEMORY_SESSION_DIR.
+    sessionId: "ses_test",
+    sessionDir: "/nonexistent/agent-memory-session-dir",
   };
 
   it("stop() is safe when the process was never started", async () => {


### PR DESCRIPTION
## Why

Three defects in the agent-memory OpenClaw adapter's corpus supplement and its test fixtures, all invisible to CI: `Test agent-memory` runs `cargo fmt` / `clippy` / `test` only, so nothing typechecks or runs the adapter's Node side. `npm run build:check` (`tsc --project tsconfig.json --noEmit`) fails on a clean `main` checkout with **4 errors** and has been red since 2026-05-26; two of the three defects below are contract bugs rather than stale annotations.

**1. The corpus supplement never reported the window it returned** (`src/index.ts:515`)

`api.registerMemoryCorpusSupplement({... get()})` answered with `{corpus, path, title, content}`. The host contract — the plugin SDK's `MemoryCorpusGetResult` (`plugins/memory-state.d.ts:25`) — also requires `fromLine` and `lineCount`, and the host spreads the supplement's result straight into the JSON it hands the model:

```js
const { content, ...rest } = supplement;
return { ...rest, text: content };
```

So a windowed `memory_read` served by this corpus came back without saying *which* window it contained, while the identical request served by the host's builtin reader does report `from` / `lines` (`buildMemoryReadResult`). Two corpora, two response shapes, and the model has no way to paginate this one.

Reading the host's builtin reader also exposed two live bugs in our own slicing:

| input | before | host builtin | after |
|---|---|---|---|
| `fromLine: 0` | `start = -1` → `Array.slice(-1, n)` → the document's **last line**, reported as nothing | `Math.max(1, from ?? 1)` → line 1 | line 1, reported |
| `fromLine: -3` | third line **from the end** | line 1 | line 1, reported |
| `lineCount: 0` | falsy → **the rest of the document** | `Math.max(1, lines ?? …)` → 1 line | 1 line, reported |

The last one matters for a token-saving component: the request that should have returned nothing returned everything.

**2. The supplement claimed the host's own corpus id, and then advertised a read route that did not exist** (`src/index.ts:497,529`)

Every result was stamped `corpus: "memory"` — the id the host stamps on its *builtin* hits (`createMemorySearchTool`: `surfacedMemoryResults = memoryResults.map((r) => ({ ...r, corpus: "memory" }))`), while the host's compiled-wiki supplement labels its own hits `corpus: "wiki"` (`toWikiSearchResult`). The field is how the model tells corpora apart inside one merged `memory_search` response, and how it picks the `corpus` argument to echo back to `memory_get`. Claiming the host's id broke both directions:

- agent-memory hits were indistinguishable from `MEMORY.md` hits in a `corpus=all` merge;
- a model echoing the label back was routed to the builtin reader (`readAgentMemoryFile`, over the workspace `MEMORY.md` + `memory/*.md`), which cannot see this store. `memory_get` consults supplements only for `corpus=wiki` and, after a failed builtin read, for `corpus=all` — and its `corpus` enum is `memory | wiki | all`. So **every path this supplement surfaced was a dead end** in the shared tool flow: search returned it, read could not.

Fixing the id alone was not enough, as @ikunkun-sys found in review: `memory_get` consults supplements only *after* the builtin read has **thrown** (`executeMemoryReadResult` → `resolveMemoryReadFailureResult`), and the host's `readMemoryFile` does not throw inside its own namespace. For every shape its `isMemoryPath` admits — `MEMORY.md`, `dreams.md`, anything under `memory/` — it *resolves*: with the workspace file's content when one exists, and with `{text: "", path}` when none does. So a hit this store held at `memory/sample.md` came back correctly labelled, advertised `corpus=all`, and still never reached `get()`; the model got empty text, or another store's file. The route the label promised was a property of the **path**, not of the corpus.

**3. Both test fixtures predate `AgentMemoryConfig.sessionId` / `.sessionDir`** (`tests/smoke-test.ts:51`, `tests/unit/mcp-client-test.ts:98,103`)

`McpStdioClient` takes `AgentMemoryConfig`, which has carried both fields since `bc00bbe5`, but each fixture was written with only the five fields that existed on paper — TS2345 ×3.

## What changed

- **`src/corpus.ts` (new)** — the supplement's host-contract helpers as pure functions, testable without a live plugin API or MCP client (the same shape `safety.ts` and `keyword-extract.ts` already use):
  - `sliceCorpusWindow(text, fromLine?, lineCount?)` → `{content, fromLine, lineCount}`: the window *actually returned*, with inputs clamped the way the host's builtin reader clamps them.
  - `AGENT_MEMORY_CORPUS` / `toCorpusSearchResult()` / `AGENT_MEMORY_CORPUS_READ_HINT`: the corpus identity. The id is this plugin's own (`agent-memory`) rather than the wiki's, because `memory_get` walks the registered supplements and returns the first non-null answer — borrowing `corpus: "wiki"` would make the two corpora interchangeable to the model and let whichever registered first shadow the other. Since the enum has no value naming our corpus, each search hit also carries the route that *does* reach a supplement as its `provenanceLabel` (`"agent-memory (read via memory_get corpus=all)"`); `get()` omits the hint because the route is chosen by then.
  - `isHostBuiltinMemoryPath()` / `AGENT_MEMORY_READ_NAMESPACE` / `toCorpusReadHandle()` / `fromCorpusReadHandle()`: the read handle that makes that label true. A hit whose store path lands in the host's builtin namespace is advertised as `agent-memory/<path>` — `isMemoryPath` tests the whole relative path, so the handle is foreign to the builtin reader, the read throws, and `corpus=all` falls through to this supplement. Paths outside that namespace are advertised unchanged: they already reach the supplement, and namespacing them too would spend tokens on a route that needs no repair. A store path that already begins with the namespace is prefixed as well, so the mapping stays injective and the store's own `agent-memory/notes.md` cannot be confused with a namespaced `notes.md`. The host's predicate is mirrored rather than imported (no plugin-sdk entry point exports `isMemoryPath`) and deliberately over-eager — an unnecessary prefix still routes here, a missed one silently swallows the read.
- **`src/index.ts`** — `get()` delegates the window and reports the two required fields, resolves the read handle to a store path before addressing MCP, and echoes the handle back so a follow-up windowed read keeps routing here; both `search()` and `get()` label results with the plugin's own corpus id. No other behaviour change.
- **`tests/unit/corpus-test.ts` (new)** — 29 cases: the window (whole document, explicit window, open-ended window, window past EOF, `fromLine` 0 / negative, `lineCount` 0 / negative, fractional bounds, non-finite bounds, trailing-newline accounting, empty document); the corpus identity (own id, never one the host resolves without a supplement, read hint names `corpus=all`, MCP score passed through unrescaled); and the handle as a pure mapping (builtin-namespace shapes incl. the host's normalisation and case-insensitive `dreams.md`, near-misses that must *not* be namespaced, handle round-trip, injectivity on a path that already starts with the namespace).
- **`tests/unit/corpus-routing-test.ts` (new)** — 9 cases that pin the reviewer's repro against the pinned host's **own** exported `readMemoryFile` (`openclaw/plugin-sdk/memory-core-host-engine-storage`), not a restatement of its logic, over two workspaces — one bare, one holding a `MEMORY.md` and a `memory/sample.md` whose content differs from the store's: every advertised hit routes to the supplement and returns store content; every advertised handle makes the host's reader throw `path required`; the *bare* store path is answered by the host itself (`"builtin one\nbuiltin two"` when the file exists, `{text: ""}` when it does not) with zero supplement calls; and `notes/observed/sample.md` still routes un-namespaced. With `toCorpusReadHandle` reduced to the identity this suite fails 6 of 9.
- **`tests/smoke-test.ts` / `tests/unit/mcp-client-test.ts`** — fixtures name `sessionId` / `sessionDir`. The smoke test points its child at a throwaway dir created only when the suite will actually run, rather than at `/run/anolisa/sessions` (root-owned 0700 via the tmpfiles.d snippet, and not guaranteed to exist on a dev host); the unit-test one stays inert because that binary path never spawns.

An absent `lineCount` still means "to the end of the document", exactly as before. The host applies its char budget only on the builtin path, so capping here would silently change what operators get back from a plugin whose reads are already bounded by `maxReadBytes` — a separate decision, deliberately not folded into a contract fix.

Commits are independent: the window fix, the corpus-id-and-routing fix and the fixture repair can each be reviewed (or dropped) on their own.

## Verification

Node v22.21.1, dependencies installed per `src/agent-memory/Makefile` `test-openclaw-plugin`; branch rebased onto current `main`, which now carries `48d1002` (#3155):

- `npm run build:check` — main: **4 errors**; this branch: **0**
- `npm test` — **126 tests / 0 fail** (`sliceCorpusWindow` 13/13, `corpus identity` 4/4, `host builtin namespace` 4/4, `corpus read handle` 8/8, `memory_get routing through the pinned host` 9/9). The 5 `resolveConfig` failures this branch reported earlier were the evaluation-order defect #3155 fixes; the rebase picks that fix up, so the suite is green end to end.
- `npm run build` — esbuild bundles the change (`dist/index.js` 239.0kb)
- `npm run smoke` — skips cleanly with no binary present, and creates no temp dir when skipped

Host-side claims were read off the pinned `openclaw@2026.5.7` artifact (`dist/tools-B3jFTrn6.js`, `dist/read-file-D9O26XT9.js`, `dist/internal-DcS7JcH6.js`, `dist/cli-D-ubyXOM.js`, `dist/plugin-sdk/src/plugins/memory-state.d.ts`) and, for the routing suite, executed against it — not assumed from the docs.

## Notes

- No docs update: `specs/documentation-standard.md` §5 triggers on new/modified CLI flags, config options, install method, architecture/protocol changes and new components. This is none of those — it complies with protocols the SDK already defines — and no agent-memory doc mentions the corpus supplement. The read handle is internal to the supplement's own results: not a path an operator configures, not a file the store grows. CHANGELOG is release-PR-only per the same section.
- **Residual limitation, host-side**: the model still has to choose `corpus=all` or `corpus=wiki` to read one of our hits, because `memory_get`'s enum has no value naming a third-party corpus — a read that omits `corpus` still lands on the builtin reader and fails. Closing that fully needs a host change (accept a supplement corpus id in the enum, or fall back to supplements on *any* read the builtin namespace did not claim). Worth raising with whoever owns the memory-core corpus routing.
- **Residual limitation, operator-side**: an operator who points `extraPaths` — or a qmd collection root — at a path this store also uses reintroduces the shadowing for that one path. Neither setting is visible to a plugin, so the handle cannot account for them; the same host-side fallback would close this too.
- **Follow-up, deliberately not changed here**: cross-corpus score comparability. Our BM25 path returns negative ranks (`src/index/store.rs:470` — "more negative = worse"), the LIKE fallback returns a non-negative term frequency, and hybrid returns RRF values around 1/(60+rank); the host normalises its own BM25 with `bm25RankToScore` (`relevance / (1 + relevance)` → (0,1)) and the wiki supplement emits 0..100 page scores. Merged `corpus=all` ranking therefore mixes four scales, and our hits sort last whenever the builtin side has any hit at all. `balanceCorpora` keeps them in the response, so this is a ranking defect rather than a visibility one, and one supplement cannot fix a merge policy — no rescaling is applied in this PR.

Tracked in Multica as AGE-6861, AGE-6875 and AGE-6926 (Developer autopilot scans).
