### PR TITLE
feat(cosh-ng): [shell] pin terminal behavior

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/passthrough.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/passthrough.rs
@@ -1330,3 +1330,153 @@ fn raw_cli_interactive_dash_c_passthrough_transports_env_ps1() {
         "stdout={stdout}\nstderr={stderr}"
     );
 }
+
+struct InteractivePtyChild(std::process::Child);
+
+impl Drop for InteractivePtyChild {
+    fn drop(&mut self) {
+        if !matches!(self.0.try_wait(), Ok(Some(_))) {
+            unsafe { nix::libc::kill(-(self.0.id() as i32), nix::libc::SIGKILL) };
+            self.0.wait().expect("reap explicit interactive shell");
+        }
+    }
+}
+
+fn interactive_pty_probe(
+    program: &str,
+    args: &[&str],
+    home: &Path,
+    ready: &str,
+    done: &str,
+) -> String {
+    use std::fs::File;
+    use std::io::{self, Read};
+    use std::os::fd::AsRawFd;
+    use std::time::Instant;
+
+    use nix::libc;
+
+    let pty = nix::pty::openpty(None, None).expect("open explicit interactive PTY");
+    let mut master = File::from(pty.master);
+    let slave = File::from(pty.slave);
+    let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
+    assert!(flags >= 0, "read PTY flags");
+    assert_eq!(
+        unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) },
+        0,
+        "make PTY reads nonblocking"
+    );
+    let mut command = Command::new(program);
+    command
+        .arg0("cosh")
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin")
+        .env("HOME", home)
+        .env("TMPDIR", home)
+        .env("PS1", "__ENV_READY__ ")
+        .env("INPUTRC", "/dev/null")
+        .env("HISTFILE", "/dev/null")
+        .env("TERM", "xterm-256color")
+        .env("COSH_SHELL_BOOTSTRAP_PATH", "0")
+        .env("COSH_SHELL_STARTUP_BANNER", "0")
+        .env("COSH_SHELL_HEALTH_SCAN", "disabled")
+        .env("COSH_RECOMMENDATIONS_ENABLED", "0")
+        .env("LC_ALL", "C")
+        .env("COSH_SHELL_DEFAULT_SHELL", "bash")
+        .current_dir(home)
+        .stdin(Stdio::from(slave.try_clone().expect("clone PTY stdin")))
+        .stdout(Stdio::from(slave.try_clone().expect("clone PTY stdout")))
+        .stderr(Stdio::from(slave));
+    command.args(args);
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY as _, 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = InteractivePtyChild(command.spawn().expect("spawn interactive shell"));
+    let mut output = Vec::new();
+    let mut wait_for = |master: &mut File, marker: &str| {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !String::from_utf8_lossy(&output).contains(marker) {
+            assert!(
+                Instant::now() < deadline,
+                "{program}, args={args:?}: timed out before {marker:?}: {output:?}"
+            );
+            let mut bytes = [0; 4096];
+            match master.read(&mut bytes) {
+                Ok(0) => panic!("PTY closed before {marker:?}: {output:?}"),
+                Ok(count) => output.extend_from_slice(&bytes[..count]),
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("PTY read before {marker:?}: {error}; {output:?}"),
+            }
+        }
+    };
+    wait_for(&mut master, ready);
+    // The command is delivered only after Bash actually renders its first PS1.
+    master
+        .write_all(b"printf '__DONE__<%s>\\n' \"${COSH_RC_PROBE-unset}\"\nexit\n")
+        .expect("write prompt-gated probe");
+    wait_for(&mut master, done);
+    let status = child
+        .0
+        .wait_timeout(Duration::from_secs(10))
+        .expect("wait interactive shell")
+        .expect("interactive shell exit timeout");
+    assert!(status.success(), "{program}, args={args:?}: {status:?}");
+    String::from_utf8_lossy(&output).into_owned()
+}
+
+#[test]
+fn raw_cli_explicit_interactive_norc_preserves_prompt_readiness() {
+    for program in ["bash", env!("CARGO_BIN_EXE_cosh-shell")] {
+        for norc in [false, true] {
+            let home = tempfile::Builder::new()
+                .prefix("cosh-explicit-interactive-")
+                .tempdir()
+                .expect("isolated interactive HOME");
+            fs::write(
+                home.path().join(".bashrc"),
+                "printf '__RC_READ__\\n'\nCOSH_RC_PROBE=loaded\nPS1='__RC_READY__ '\n",
+            )
+            .expect("write startup sentinel");
+            let (args, ready, done): (&[&str], _, _) = if norc {
+                (&["--norc", "-i"], "__ENV_READY__ ", "__DONE__<unset>")
+            } else {
+                (&["-i"], "__RC_READY__ ", "__DONE__<loaded>")
+            };
+            let output = interactive_pty_probe(program, args, home.path(), ready, done);
+            assert_eq!(output.contains("__RC_READ__"), !norc, "{output}");
+            assert_eq!(output.contains("__RC_READY__"), !norc, "{output}");
+            assert_eq!(output.contains("__ENV_READY__"), norc, "{output}");
+        }
+    }
+}
+
+#[test]
+fn raw_cli_cosh_entry_default_enhanced_reaches_user_prompt() {
+    let home = tempfile::Builder::new()
+        .prefix("cosh-default-interactive-")
+        .tempdir()
+        .expect("isolated default interactive HOME");
+    write_cosh_config(home.path(), "[shell]\nadapter_default = 'fake'\n");
+    fs::write(
+        home.path().join(".bashrc"),
+        "COSH_RC_PROBE=loaded\nPS1='__RC_READY__ '\n",
+    )
+    .expect("write user prompt");
+    let output = interactive_pty_probe(
+        env!("CARGO_BIN_EXE_cosh-shell"),
+        &[],
+        home.path(),
+        "__RC_READY__ ",
+        "__DONE__<loaded>",
+    );
+    let visible = strip_ansi_escape(&output);
+    assert!(visible.contains("◇ __RC_READY__ "), "{output}");
+    assert_ordered(&visible, &["__RC_READY__ ", "__DONE__<loaded>"]);
+}

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/native.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/native.rs
@@ -1,5 +1,106 @@
 use super::*;
 
+#[test]
+fn bash_startup_files_reach_user_prompt_in_native_and_enhanced_sessions() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        eprintln!("SKIP: bash is unavailable");
+        return;
+    }
+
+    for (case, login, first_profile, syntax_error, expected_trace) in [
+        ("bashrc", false, 0, false, "rc"),
+        ("bash-profile", true, 0, false, "profile:rc"),
+        ("bash-login", true, 1, false, "login:rc"),
+        ("profile", true, 2, false, "fallback:rc"),
+        ("bashrc-error", false, 0, true, "rc"),
+        ("profile-error", true, 0, true, "profile:rc"),
+    ] {
+        for integration in [ShellIntegration::Native, ShellIntegration::Enhanced] {
+            let context = format!("{case}/{integration:?}");
+            let root = tempfile::Builder::new()
+                .prefix("cosh-shell-startup-readiness-")
+                .tempdir()
+                .expect("startup readiness root");
+            let home = root.path().join("home");
+            std::fs::create_dir_all(&home).expect("home");
+            let mut rc = "STARTUP_TRACE+=rc\nPS1='__STARTUP_READY__ '\n".to_string();
+            if syntax_error && !login {
+                rc.push_str("if ; then\n");
+            }
+            std::fs::write(home.join(".bashrc"), rc).expect("bashrc");
+            for (index, (file, tag)) in [
+                (".bash_profile", "profile"),
+                (".bash_login", "login"),
+                (".profile", "fallback"),
+            ]
+            .into_iter()
+            .enumerate()
+            .skip(first_profile)
+            {
+                let mut profile = format!("STARTUP_TRACE+={tag}:\nsource \"$HOME/.bashrc\"\n");
+                if syntax_error && login && index == first_profile {
+                    profile.push_str("if ; then\n");
+                }
+                std::fs::write(home.join(file), profile).expect("profile");
+            }
+
+            let mut config = ShellHostConfig::new("startup-readiness", root.path().join("work"))
+                .with_integration(integration)
+                .with_env("HOME", home.display().to_string())
+                .with_env("STARTUP_TRACE", "")
+                .with_env("LANG", "C")
+                .with_env("LC_ALL", "C");
+            config.login_shell = login;
+            config.raw_action_watchdog = Duration::from_secs(2);
+            let mut rendered = Vec::new();
+            let output = run_raw_relay_bash_with_actions(
+                &config,
+                vec![
+                    RawRelayAction::wait(Duration::from_millis(100)),
+                    RawRelayAction::line(
+                        "printf '%s' \"$STARTUP_TRACE\" > \"$HOME/startup-observed\"; \
+                         printf '__READY_%s__=%s\\n' RESULT \"$STARTUP_TRACE\"",
+                    ),
+                    RawRelayAction::line("exit"),
+                ],
+                &mut rendered,
+            )
+            .unwrap_or_else(|error| panic!("{context}: {error}"));
+            let terminal = without_readline_mode_controls(&String::from_utf8_lossy(&rendered));
+            assert_eq!(output.exit_status, Some(0), "{context}: {terminal}");
+            assert_eq!(
+                std::fs::read_to_string(home.join("startup-observed"))
+                    .unwrap_or_else(|error| panic!("{context}: {error}: {terminal}")),
+                expected_trace,
+                "{context}"
+            );
+            let prompts = terminal
+                .match_indices("__STARTUP_READY__ ")
+                .map(|(index, _)| index)
+                .collect::<Vec<_>>();
+            let result = terminal
+                .find(&format!("__READY_RESULT__={expected_trace}"))
+                .unwrap_or_else(|| panic!("{context}: missing command output: {terminal}"));
+            assert_eq!(prompts.len(), 2, "{context}: {terminal}");
+            assert!(
+                prompts[0] < result && result < prompts[1],
+                "{context}: {terminal}"
+            );
+            assert_eq!(
+                terminal.contains("syntax error"),
+                syntax_error,
+                "{context}: {terminal}"
+            );
+            if syntax_error {
+                assert!(
+                    terminal.find("syntax error").expect("syntax diagnostic") < prompts[0],
+                    "{context}: {terminal}"
+                );
+            }
+        }
+    }
+}
+
 fn assert_debug_log_has_only_bounded_cosh_capture(debug_log: &str) {
     for line in debug_log
         .lines()

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
@@ -1982,6 +1982,70 @@ fn routing_c3_typed_passthrough_keeps_cjk_shell_owned() {
 }
 
 #[test]
+fn raw_relay_bash_ctrl_u_and_multiline_paste_execute_only_retained_input() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        eprintln!("SKIP: bash is unavailable");
+        return;
+    }
+
+    for integration in [ShellIntegration::Native, ShellIntegration::Enhanced] {
+        let root = tempfile::Builder::new()
+            .prefix("cosh-shell-edit-paste-")
+            .tempdir()
+            .expect("editing root");
+        let home = root.path().join("home");
+        std::fs::create_dir_all(&home).expect("home");
+        std::fs::write(home.join(".bashrc"), "PS1='editing$ '\n").expect("bashrc");
+        let config = ShellHostConfig::new("edit-paste", root.path().join("work"))
+            .with_integration(integration)
+            .with_env("HOME", home.display().to_string())
+            .with_env("LANG", "C.UTF-8")
+            .with_env("LC_ALL", "C.UTF-8");
+        let mut config = with_bracketed_paste_readline(config, true);
+        config.raw_action_watchdog = Duration::from_secs(2);
+        let mut rendered = Vec::new();
+        let output = run_raw_relay_bash_with_actions(
+            &config,
+            vec![
+                RawRelayAction::wait(Duration::from_millis(100)),
+                RawRelayAction::write(b"touch \"$HOME/discarded-command\"".to_vec()),
+                RawRelayAction::write(vec![0x15]),
+                RawRelayAction::line("printf 'retained\\n' > \"$HOME/edit-result\""),
+                RawRelayAction::wait(Duration::from_millis(100)),
+                RawRelayAction::write(
+                    "\x1b[200~printf '第一行\\n' >> \"$HOME/edit-result\"\nprintf '第二行\\n' >> \"$HOME/edit-result\"\x1b[201~"
+                        .as_bytes()
+                        .to_vec(),
+                ),
+                RawRelayAction::line(""),
+                RawRelayAction::line("exit"),
+            ],
+            &mut rendered,
+        )
+        .unwrap_or_else(|error| panic!("{integration:?}: {error}"));
+        let terminal = String::from_utf8_lossy(&rendered);
+        assert_eq!(output.exit_status, Some(0), "{integration:?}: {terminal}");
+        assert!(
+            !home.join("discarded-command").exists(),
+            "{integration:?}: {terminal}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(home.join("edit-result"))
+                .unwrap_or_else(|error| panic!("{integration:?}: {error}: {terminal}")),
+            "retained\n第一行\n第二行\n",
+            "{integration:?}: {terminal}"
+        );
+        assert!(
+            !output.events.iter().any(|event| {
+                event.kind == ShellEventKind::UserInputIntercepted
+                    && event.component.as_deref() == Some("natural_language")
+            }),
+            "{integration:?}: {terminal}"
+        );
+    }
+}
+
+#[test]
 fn routing_c3_wrapped_paste_stays_shell_owned() {
     let work_dir = std::env::temp_dir().join(format!(
         "cosh-shell-c3-wrapped-{}-{}",


### PR DESCRIPTION
## Why

The original #2537 prompt-readiness failure prevented downstream startup and editing checks from running. The runtime fixes are already on main, but real `cosh` entry readiness, `--norc` startup exclusion, and interactive startup-file behavior need executable regression evidence.

## What changed

Add four scoped tests with 19 real PTY scenarios:

- A shared local PTY fixture waits for the first user prompt before sending a command. Compare Bash and `argv0=cosh` with `-i` and `--norc -i`; assert both the startup-file sentinel and the actual command result.
- Exercise `argv0=cosh` with no arguments and default Enhanced integration, using a fake adapter and disabling unrelated startup workers. Assert the decorated user PS1 precedes successful command output. This is the real entry classifier, not the `raw fake` CLI surface.
- Pair Native and Enhanced across `.bashrc`, the three login-profile precedence cases, and login/non-login startup syntax errors. Check the complete source trace and initial prompt → command output → next prompt ordering, with syntax diagnostics before readiness.
- Check ordinary Bash Ctrl-U and multiline bracketed paste in Native and Enhanced. A discarded command must leave no file; the retained command and both Chinese paste lines must produce exactly the expected file bytes, independently of terminal echo.

## Related issue

Refs #2537, #2597, and #2598. This PR adds current regression evidence. Issue #2537 remains open pending the outstanding acceptance decisions; the historical 25-family matrix has not been rerun.

## User / Agent impact

No production behavior changes. The tests keep default Enhanced entry, explicit interactive passthrough, and Native host controls distinct. A regression that loses the user prompt, reads `.bashrc` under `--norc`, changes profile precedence, executes erased input, or loses/duplicates pasted lines now has a direct assertion.

## Risk and compatibility

Test-only changes with bounded PTY reads, process waits, and isolated temporary HOME directories. The entry fixture clears inherited environment and uses a fake adapter; it does not contact a real provider or change the host login shell, PAM, packages, or services.

The evidence has explicit limits:

- Native host controls are direct Bash sessions, not an installed-package or `/usr/bin/login`/PAM oracle.
- Startup tests cover user profile selection and explicit profile-to-bashrc sourcing; they do not replace the ALinux4 system-profile acceptance. Syntax-error fixtures set the trace and PS1 before the malformed statement, then check diagnostic ordering and continued readiness.
- File assertions verify retained input execution and Unicode bytes, not Unicode cell-width rendering or the exact moment a paste becomes executable before Enter.
- Existing resize checks cover winsize propagation and a separate fixed narrow ASCII screen; they do not prove the final screen after a dynamic resize.
- The historical family definitions/fixtures, dual-architecture ALinux4 matrix, and console login chain remain outstanding. SIGKILL recovery remains #2555's separate responsibility.

## Validation

Ubuntu 24.04.3, Linux aarch64; Bash 5.2.21 and Zsh 5.9 are installed.

```bash
cd src/cosh-ng
cargo test --locked -p cosh-shell --test raw_cli passthrough::raw_cli_explicit_interactive_norc_preserves_prompt_readiness -- --exact --nocapture
cargo test --locked -p cosh-shell --test raw_cli passthrough::raw_cli_cosh_entry_default_enhanced_reaches_user_prompt -- --exact --nocapture
cargo test --locked -p cosh-shell --test shell_host native::bash_startup_files_reach_user_prompt_in_native_and_enhanced_sessions -- --exact --nocapture
cargo test --locked -p cosh-shell --test shell_host relay::raw_relay_bash_ctrl_u_and_multiline_paste_execute_only_retained_input -- --exact --nocapture
```

All four passed: 4 + 1 + 12 + 2 PTY scenarios, with no failed or ignored tests. The following seven existing regressions also passed individually with `--exact --nocapture`:

| Target | Filter |
| --- | --- |
| raw_cli | native::raw_cli_enhanced_decorates_zsh_prompt_without_mutating_prompt |
| raw_cli | prompt_replay::raw_cli_bash_recall_walks_distinct_natural_language_history_entries |
| raw_cli | agent_input::raw_cli_non_ascii_shell_input_supports_backspace |
| raw_cli | cancellation::raw_cli_ctrl_c_interrupts_foreground_command_without_agent_cancel |
| shell_host | relay::routing_c4_zsh_rust_route_uses_shared_event_contract |
| shell_host | foreground::raw_relay_host_applies_resize_actions |
| shell_host | relay::raw_relay_bash_renders_wrapped_ascii_slash_submission_exactly_once |

The existing Ctrl-C case checks session continuation and avoids Agent cancellation; it does not independently assert foreground exit 130. History traversal exercises natural-language history entries, not the whole native-history/privacy contract.

`rustfmt --edition 2021 --check` on the three changed files and `git diff --check` passed. No full local gate, old Bash, ALinux4/Core-107, manual screenshot, or real-provider acceptance was run; broader regression coverage remains with CI.

CI passed for `719d6a982c5824b34095db64719a1c52a3b3b9db` on [Components attempt 2](https://github.com/alibaba/anolisa/actions/runs/34300063065). Attempt 1 failed in the unchanged `session::raw_cli_session_new_detaches_active_without_deleting_or_forcing_resume` test: `/session new` arrived while the prior Agent request was still active. The successful retry used the same head; this does not establish that the existing fixed-delay test is stable.

## Documentation and rollback

No user-facing behavior or command changes require documentation updates. Coverage and outstanding acceptance limits are recorded above. Revert this test-only commit to remove the additional cases; runtime behavior is unaffected.
