### PR TITLE
fix(sight): reconcile idle pending snapshots

### DIFF
--- a/src/agentsight/src/storage/sqlite/genai/pending.rs
+++ b/src/agentsight/src/storage/sqlite/genai/pending.rs
@@ -1,6 +1,6 @@
 //! Pending-call lifecycle methods for GenAI SQLite store.
 
-use rusqlite::params;
+use rusqlite::{TransactionBehavior, params};
 
 use super::GenAISqliteStore;
 use crate::genai::semantic::GenAISemanticEvent;
@@ -90,7 +90,9 @@ impl GenAISqliteStore {
     ///
     /// The record is later promoted to 'complete' via [`complete_pending`] once
     /// the full response arrives, or marked 'interrupted' by the stale-scan thread
-    /// if the agent crashes before the response is received.
+    /// if the agent crashes before the response is received. A request capture adopts
+    /// a unique unfinished idle snapshot with the same match key; replaying an
+    /// existing call ID leaves its row unchanged.
     pub fn insert_pending(&self, info: &PendingCallInfo) -> Result<(), Box<dyn std::error::Error>> {
         // Enforce size limit before creating a new row. Best-effort: if
         // pruning fails (e.g. VACUUM error), proceed with the INSERT — a
@@ -99,9 +101,67 @@ impl GenAISqliteStore {
             log::warn!("Pre-insert size check failed: {e}");
         }
 
-        let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
+        // Cold instance-ID resolution may perform I/O; keep it outside the writer lock.
         let instance = crate::genai::instance_id::get_instance_id();
-        conn.execute(
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| format!("GenAI pending insert mutex poisoned: {e}"))?;
+        // Reserve the writer before checking, including across store connections.
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let exists: bool = tx.query_row(
+            "SELECT EXISTS(SELECT 1 FROM genai_events
+             WHERE event_type = 'llm_call' AND call_id = ?1)",
+            params![info.call_id],
+            |row| row.get(0),
+        )?;
+        if exists {
+            tx.commit()?;
+            return Ok(());
+        }
+
+        if info.pending_origin == PendingOrigin::RequestCapture {
+            if let Some(match_key) = info.pending_match_key.as_deref() {
+                let candidates = {
+                    let mut stmt = tx.prepare(
+                        "SELECT id FROM genai_events
+                         WHERE event_type = 'llm_call'
+                           AND status IN ('pending', 'interrupted')
+                           AND pending_origin = 'idle_drain'
+                           AND pending_match_key = ?1
+                         LIMIT 2",
+                    )?;
+                    stmt.query_map(params![match_key], |row| row.get::<_, i64>(0))?
+                        .collect::<Result<Vec<_>, _>>()?
+                };
+                if let [id] = candidates.as_slice() {
+                    // Keep request evidence and row identity; RequestCapture also
+                    // keeps deferred calls visible to crash recovery.
+                    tx.execute(
+                        "UPDATE genai_events SET
+                            call_id = ?1, trace_id = ?2, conversation_id = ?3,
+                            session_id = ?4, pending_origin = 'request_capture'
+                         WHERE id = ?5",
+                        params![
+                            info.call_id,
+                            info.trace_id,
+                            info.conversation_id,
+                            info.session_id,
+                            id,
+                        ],
+                    )?;
+                    tx.commit()?;
+                    return Ok(());
+                }
+                if candidates.len() > 1 {
+                    log::warn!(
+                        "Ambiguous idle snapshots for pending call {}; preserving snapshots",
+                        info.call_id
+                    );
+                }
+            }
+        }
+        tx.execute(
             "INSERT INTO genai_events (
                 event_type, status, call_id, trace_id, conversation_id, session_id, instance,
                 start_timestamp_ns, pid, process_name, agent_name,
@@ -140,6 +200,7 @@ impl GenAISqliteStore {
                 info.pending_match_key,
             ],
         )?;
+        tx.commit()?;
         Ok(())
     }
 

--- a/src/agentsight/src/unified/response_pending_tests.rs
+++ b/src/agentsight/src/unified/response_pending_tests.rs
@@ -108,63 +108,136 @@ fn response_pending_exit_and_dead_pid_preserve_crash_evidence() {
 
 #[test]
 fn response_pending_idle_snapshot_persists_once_and_can_resume() {
-    let body = r#"{"id":"fixture","model":"gpt-4","choices":[{"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3}}"#;
+    let body = r#"{"id":"fixture","object":"chat.completion","created":0,"model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}"#;
     let response = format!(
         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
         body.len()
     );
-    for split in [26, response.len() - 1] {
-        let mut aggregator = fixture(&response.as_bytes()[..split]);
-        aggregator.http_mut().evict_idle_and_oversized();
-        let snapshots = aggregator.snapshot_idle_connections();
-        assert_eq!(snapshots.len(), 1);
-        assert!(aggregator.snapshot_idle_connections().is_empty());
-        let (id, state) = &snapshots[0];
-        let mut pending = GenAIBuilder::new()
-            .build_pending_from_request(
-                state.pending_request().expect("retained request"),
-                id,
-                &ResponseSessionMapper::new(),
-                &HashMap::new(),
-            )
-            .unwrap();
-        pending.pending_origin = PendingOrigin::IdleDrain;
-        let dir = super::tests::unique_tmp_dir("response-pending");
-        let store = GenAISqliteStore::new_with_path(&dir.join("genai.db")).unwrap();
-        store.insert_pending(&pending).unwrap();
-        // Crash-candidate queries intentionally exclude idle snapshots; inspect
-        // the stored row to verify both persistence and in-place reconciliation.
-        let db = rusqlite::Connection::open(dir.join("genai.db")).unwrap();
-        let row_state = || {
-            db.query_row(
-                "SELECT COUNT(*), MIN(status), MIN(pending_origin) FROM genai_events",
-                [],
-                |row| {
-                    Ok((
-                        row.get::<_, i64>(0)?,
-                        row.get::<_, String>(1)?,
-                        row.get::<_, String>(2)?,
-                    ))
-                },
-            )
-            .unwrap()
-        };
-        assert_eq!(row_state(), (1, "pending".into(), "idle_drain".into()));
-        aggregator.http_mut().evict_idle_and_oversized();
-        let completed = feed(&mut aggregator, 0, &response.as_bytes()[split..]);
-        assert_eq!(completed.len(), 1);
-        let analyzed = Analyzer::new().analyze_aggregated(&completed[0]);
-        let (output, _) = GenAIBuilder::new().build_with_pending(
-            &analyzed,
-            &ResponseSessionMapper::new(),
-            &HashMap::new(),
-        );
-        assert!(!output.events.is_empty());
-        for event in &output.events {
-            store.complete_pending(event).unwrap();
+    let sse_headers = b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n";
+    let sse_body = b"data: {\"id\":\"fixture\",\"object\":\"chat.completion.chunk\",\"created\":0,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"hello\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":3,\"total_tokens\":8}}\n\ndata: [DONE]\n\n";
+    for (prefix, remaining, is_sse) in [
+        (&response.as_bytes()[..0], response.as_bytes(), false),
+        (
+            &response.as_bytes()[..26],
+            &response.as_bytes()[26..],
+            false,
+        ),
+        (
+            &response.as_bytes()[..response.len() - 1],
+            &response.as_bytes()[response.len() - 1..],
+            false,
+        ),
+        (sse_headers.as_slice(), sse_body.as_slice(), true),
+    ] {
+        for deferred in [false, true] {
+            let mut aggregator = fixture(prefix);
+            aggregator.http_mut().evict_idle_and_oversized();
+            let snapshots = aggregator.snapshot_idle_connections();
+            assert_eq!(snapshots.len(), 1);
+            assert!(aggregator.snapshot_idle_connections().is_empty());
+            let (id, state) = &snapshots[0];
+            let mut pending = GenAIBuilder::new()
+                .build_pending_from_request(
+                    state.pending_request().expect("retained request"),
+                    id,
+                    &ResponseSessionMapper::new(),
+                    &HashMap::new(),
+                )
+                .unwrap();
+            pending.pending_origin = PendingOrigin::IdleDrain;
+            let dir = super::tests::unique_tmp_dir("response-pending");
+            let store = GenAISqliteStore::new_with_path(&dir.join("genai.db")).unwrap();
+            store.insert_pending(&pending).unwrap();
+            let db = rusqlite::Connection::open(dir.join("genai.db")).unwrap();
+            let snapshot_id: i64 = db
+                .query_row("SELECT id FROM genai_events", [], |r| r.get(0))
+                .unwrap();
+            let count = || {
+                db.query_row("SELECT COUNT(*) FROM genai_events", [], |r| {
+                    r.get::<_, i64>(0)
+                })
+                .unwrap()
+            };
+            aggregator.http_mut().evict_idle_and_oversized();
+            let completed = feed(&mut aggregator, 0, remaining);
+            assert_eq!(completed.len(), 1);
+            let mut mapper = ResponseSessionMapper::new();
+            let session = "11111111-1111-4111-8111-111111111111";
+            if !deferred {
+                let buf = br#"{"responseId":"fixture"}"#.to_vec();
+                mapper.process_filewrite(&crate::probes::FileWriteEvent {
+                    pid: PID,
+                    tid: PID,
+                    uid: 0,
+                    timestamp_ns: 1,
+                    write_size: buf.len() as u32,
+                    comm: "fixture".into(),
+                    filename: format!("{session}.jsonl"),
+                    cgroup_id: 0,
+                    buf,
+                });
+            }
+            let analyzed = Analyzer::new().analyze_aggregated(&completed[0]);
+            let (mut output, formal) =
+                GenAIBuilder::new().build_with_pending(&analyzed, &mapper, &HashMap::new());
+            assert_eq!(output.pending_response_id.is_some(), deferred);
+            assert!(!output.events.is_empty());
+            let formal = formal.unwrap();
+            assert_eq!(formal.pending_match_key, pending.pending_match_key);
+            // Both immediate export and deferred session resolution insert first.
+            store.insert_pending(&formal).unwrap();
+            store.insert_pending(&formal).unwrap();
+            assert_eq!(count(), 1);
+            assert_eq!(store.list_pending_for_pids(&[PID as i32]).unwrap().len(), 1);
+            for event in &mut output.events {
+                if let GenAISemanticEvent::LLMCall(call) = event {
+                    // Simulate the session resolution that precedes deferred export.
+                    call.metadata.insert("session_id".into(), session.into());
+                }
+                store.complete_pending(event).unwrap();
+                store.insert_pending(&formal).unwrap();
+                store.complete_pending(event).unwrap();
+            }
+            assert_eq!(count(), 1);
+            let (id, call_id, status, input, output, session_id, body, streamed): (
+                i64,
+                String,
+                String,
+                i64,
+                i64,
+                String,
+                String,
+                bool,
+            ) = db
+                .query_row(
+                    "SELECT id, call_id, status, input_tokens, output_tokens, session_id,
+                     output_messages, is_sse FROM genai_events",
+                    [],
+                    |r| {
+                        Ok((
+                            r.get(0)?,
+                            r.get(1)?,
+                            r.get(2)?,
+                            r.get(3)?,
+                            r.get(4)?,
+                            r.get(5)?,
+                            r.get(6)?,
+                            r.get(7)?,
+                        ))
+                    },
+                )
+                .unwrap();
+            assert_eq!(id, snapshot_id);
+            assert_eq!(call_id, formal.call_id);
+            assert_eq!(status, "complete");
+            assert_eq!((input, output), (5, 3));
+            assert_eq!(session_id, session);
+            assert!(body.contains("hello"));
+            assert_eq!(streamed, is_sse);
+            assert!(!aggregator.has_pending());
+            drop(db);
+            drop(store);
+            std::fs::remove_dir_all(&dir).unwrap();
         }
-        assert_eq!(row_state(), (1, "complete".into(), "idle_drain".into()));
-        assert!(!aggregator.has_pending());
-        std::fs::remove_dir_all(&dir).unwrap();
     }
 }

--- a/src/agentsight/tests/pending_reconciliation_tests.rs
+++ b/src/agentsight/tests/pending_reconciliation_tests.rs
@@ -1,0 +1,231 @@
+//! Regressions for adopting idle snapshots through the two-phase storage path.
+#![cfg(target_os = "linux")]
+
+mod common;
+
+use agentsight::genai::semantic::GenAISemanticEvent;
+use agentsight::storage::sqlite::{GenAISqliteStore, PendingCallInfo, PendingOrigin};
+use rusqlite::{Connection, params};
+use std::path::PathBuf;
+use std::sync::{Arc, Barrier};
+
+struct Fixture {
+    dir: PathBuf,
+    store: GenAISqliteStore,
+    db: Connection,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = common::temp_dir("pending-reconciliation");
+        let path = dir.join("genai.db");
+        Self {
+            store: GenAISqliteStore::new_with_path(&path).unwrap(),
+            db: Connection::open(path).unwrap(),
+            dir,
+        }
+    }
+
+    fn count(&self) -> i64 {
+        self.db
+            .query_row("SELECT COUNT(*) FROM genai_events", [], |r| r.get(0))
+            .unwrap()
+    }
+
+    fn finish(self) {
+        drop(self.db);
+        drop(self.store);
+        std::fs::remove_dir_all(self.dir).unwrap();
+    }
+}
+
+fn pending(call_id: &str, origin: PendingOrigin, key: Option<&str>) -> PendingCallInfo {
+    PendingCallInfo {
+        call_id: call_id.into(),
+        trace_id: None,
+        conversation_id: None,
+        session_id: None,
+        start_timestamp_ns: 1_000_000_000,
+        pid: 1234,
+        process_name: "fixture".into(),
+        agent_name: None,
+        http_method: Some("POST".into()),
+        http_path: Some("/v1/chat/completions".into()),
+        input_messages: Some("[]".into()),
+        system_instructions: None,
+        user_query: Some("hello".into()),
+        is_sse: false,
+        model: Some("gpt-4".into()),
+        provider: Some("openai".into()),
+        call_kind: "main".into(),
+        pending_origin: origin,
+        pending_match_key: key.map(str::to_owned),
+    }
+}
+
+fn complete_event() -> GenAISemanticEvent {
+    let mut call = common::make_test_llm_call("formal");
+    call.metadata
+        .insert("pending_match_key".into(), "match".into());
+    GenAISemanticEvent::LLMCall(call)
+}
+
+#[test]
+fn only_matching_unfinished_idle_rows_are_adopted() {
+    for (origin, status, key, adopt) in [
+        (PendingOrigin::IdleDrain, "pending", Some("match"), true),
+        (PendingOrigin::IdleDrain, "interrupted", Some("match"), true),
+        (PendingOrigin::IdleDrain, "complete", Some("match"), false),
+        (
+            PendingOrigin::RequestCapture,
+            "pending",
+            Some("match"),
+            false,
+        ),
+        (PendingOrigin::DeadPidDrain, "pending", Some("match"), false),
+        (
+            PendingOrigin::IdleDrain,
+            "pending",
+            Some("different"),
+            false,
+        ),
+        (PendingOrigin::IdleDrain, "pending", None, false),
+    ] {
+        let fixture = Fixture::new();
+        fixture
+            .store
+            .insert_pending(&pending("snapshot", origin, Some("match")))
+            .unwrap();
+        fixture
+            .db
+            .execute("UPDATE genai_events SET status = ?1", params![status])
+            .unwrap();
+        let mut formal = pending("formal", PendingOrigin::RequestCapture, key);
+        formal.trace_id = Some("response".into());
+        formal.session_id = Some("session".into());
+        formal.conversation_id = Some("conversation".into());
+        fixture.store.insert_pending(&formal).unwrap();
+        assert_eq!(
+            fixture.count(),
+            if adopt { 1 } else { 2 },
+            "{origin:?}/{status}/{key:?}"
+        );
+        let (id, trace, session, conversation, origin): (i64, String, String, String, String) = fixture.db.query_row(
+            "SELECT id, trace_id, session_id, conversation_id, pending_origin FROM genai_events WHERE call_id = 'formal'", [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?))
+        ).unwrap();
+        assert_eq!(id == 1, adopt);
+        assert_eq!(
+            (
+                trace.as_str(),
+                session.as_str(),
+                conversation.as_str(),
+                origin.as_str()
+            ),
+            ("response", "session", "conversation", "request_capture")
+        );
+        fixture.finish();
+    }
+}
+
+#[test]
+fn ambiguous_snapshots_are_preserved() {
+    let fixture = Fixture::new();
+    for id in ["idle-a", "idle-b"] {
+        fixture
+            .store
+            .insert_pending(&pending(id, PendingOrigin::IdleDrain, Some("match")))
+            .unwrap();
+    }
+    fixture
+        .store
+        .insert_pending(&pending(
+            "formal",
+            PendingOrigin::RequestCapture,
+            Some("match"),
+        ))
+        .unwrap();
+    fixture.store.complete_pending(&complete_event()).unwrap();
+    assert_eq!(fixture.count(), 3);
+    let idle_count: i64 = fixture.db.query_row(
+        "SELECT COUNT(*) FROM genai_events WHERE pending_origin = 'idle_drain' AND status = 'pending'", [], |r| r.get(0)
+    ).unwrap();
+    assert_eq!(idle_count, 2);
+    fixture.finish();
+}
+
+#[test]
+fn concurrent_connections_do_not_duplicate_formal_calls() {
+    for with_snapshot in [false, true] {
+        let fixture = Fixture::new();
+        if with_snapshot {
+            fixture
+                .store
+                .insert_pending(&pending("idle", PendingOrigin::IdleDrain, Some("match")))
+                .unwrap();
+        }
+        let stores: Vec<_> = (0..8)
+            .map(|_| GenAISqliteStore::new_with_path(&fixture.dir.join("genai.db")).unwrap())
+            .collect();
+        let barrier = Arc::new(Barrier::new(stores.len()));
+        let threads: Vec<_> = stores
+            .into_iter()
+            .map(|store| {
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    for _ in 0..3 {
+                        store
+                            .insert_pending(&pending(
+                                "formal",
+                                PendingOrigin::RequestCapture,
+                                Some("match"),
+                            ))
+                            .unwrap();
+                        store.complete_pending(&complete_event()).unwrap();
+                    }
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().unwrap();
+        }
+        assert_eq!(fixture.count(), 1);
+        let status: String = fixture
+            .db
+            .query_row("SELECT status FROM genai_events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(status, "complete");
+        fixture.finish();
+    }
+}
+
+#[test]
+fn failed_adoption_keeps_snapshot_and_allows_retry() {
+    let fixture = Fixture::new();
+    fixture
+        .store
+        .insert_pending(&pending("idle", PendingOrigin::IdleDrain, Some("match")))
+        .unwrap();
+    fixture
+        .db
+        .execute_batch(
+            "CREATE TRIGGER reject_adoption BEFORE UPDATE OF call_id ON genai_events
+        BEGIN SELECT RAISE(ABORT, 'injected failure'); END;",
+        )
+        .unwrap();
+    let formal = pending("formal", PendingOrigin::RequestCapture, Some("match"));
+    assert!(fixture.store.insert_pending(&formal).is_err());
+    let id: String = fixture
+        .db
+        .query_row("SELECT call_id FROM genai_events", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(id, "idle");
+    fixture
+        .db
+        .execute_batch("DROP TRIGGER reject_adoption")
+        .unwrap();
+    fixture.store.insert_pending(&formal).unwrap();
+    assert_eq!(fixture.count(), 1);
+    fixture.finish();
+}


### PR DESCRIPTION
## Why

Long-running LLM calls can leave an idle snapshot behind after successful completion. The normal and deferred export paths both insert a formal pending row before `complete_pending`, so completion updates that new row and never reaches the idle-snapshot fallback.

## What changed

Extend `insert_pending` to adopt a unique unfinished `idle_drain` row with the same `pending_match_key`, preserving its SQLite row ID and request evidence while assigning the formal call/trace/session/conversation IDs. An immediate transaction serializes lookup, adoption, and insertion across connections; an existing call ID makes replay a no-op. Ambiguous candidates are preserved with a warning, and cold instance-ID resolution stays outside the SQLite writer lock.

This uses the existing storage method (footprint level 1), with no new production module or schema migration.

## Related issue

Closes #3179

## User / Agent impact

A request that resumes after an idle snapshot completes as one logical call with its response and token data. Deferred calls become `request_capture` records so crash-recovery queries can still see them. Existing historical duplicates are not cleaned up by this change.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: parameterized SQL, unchanged schema and public signatures. Only a unique matching pending/interrupted idle snapshot is adopted; completed rows, other origins, missing/different keys, and ambiguous candidates are preserved. Upstream `is_sse` completion backfill remains intact.

## Validation

Linux amd64, isolated build container, Rust 1.91.1, using synthetic events and temporary SQLite databases. All three tested source files were verified against the local worktree by SHA-256. This does not constitute a deployment or live eBPF acceptance run.

- Red/green regression: the original storage code leaves two rows for one matched call and 24 rows after eight connections replay three writes each; both become one with this fix.
- Pipeline regression exercises waiting for headers, partial headers, partial JSON body, and SSE, each with immediate/deferred session resolution. It verifies stable row ID, formal ID, crash-query visibility, completion replay, response text, tokens, session, and `is_sse`.
- Storage integration tests cover matching boundaries, ambiguous candidates, eight independent SQLite connections, and injected update failure followed by successful retry.
- `cargo fmt --all -- --check`: passed.
- `python3 scripts/check-arch-boundaries.py`: passed, zero new violations.
- `cargo doc --offline --locked --workspace --no-deps`: completed with existing rustdoc warnings.

- `cargo clippy --offline --locked --workspace --exclude ebpf-ifc-engine --exclude actplane-ifc-compiler --all-targets -- -D warnings`: passed for all AgentSight-owned workspace crates.
- `cargo test --offline --locked --workspace --exclude ebpf-ifc-engine --exclude actplane-ifc-compiler -- --test-threads=8`: **2,189 passed, 0 failed, 39 ignored** across 40 test targets, including doctests.

Full workspace gates were also attempted: existing ActPlane tests fail because the vendored compiler expects the absent `test/policies` corpus; full Clippy reports existing warnings in `actplane-ifc-compiler` and `ebpf-ifc-engine`. Those source files are unchanged. The local toolchain differs from CI's pinned Rust 1.89.0; CI/coverage results must be evaluated separately.

## Documentation and rollback

Updated the method's rustdoc to describe adoption and replay behavior. No user configuration or API documentation changes are needed. Revert this commit to restore the prior behavior; no database migration or historical-data cleanup is involved.
