### PR TITLE
feat(skillfs): seed read-only skills with ledger

### DIFF
--- a/docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md
+++ b/docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md
@@ -10,6 +10,93 @@ The repository does not currently publish a dedicated SkillFS sidecar image.
 Build the image from the source revision you plan to deploy, verify it locally,
 and push it to a registry that the cluster can pull from.
 
+## Read-only installed skills with Ledger
+
+The optional `30-ledger-pod.yaml` profile copies an installed, flat skill bundle
+into `/state/source`, runs the real Ledger scanner and activation processor,
+then starts Ledger, SkillFS and Cosh in that order. It keeps
+`--security --activation-mode file`; read-only package permissions never grant
+activation. Both `.skill-meta/activation.json` and its version snapshots remain
+inside each copied skill. File activation also reads the existing xattr protocol.
+
+Use an ANOLISA RPM image containing `os-skills`, `agent-sec-core` and `cosh-ng`
+from the revision being validated, and the corresponding dedicated SkillFS
+image. The example uses the RPM Python layout and `/usr/share/anolisa/skills`.
+For a raw install, change the init command's package argument and Python runtime
+to that image's installed paths. Do not point SkillFS directly at the package.
+Run these commands from `src/skillfs`, after creating the example namespace:
+
+```bash
+export NS=skillfs-container-example
+export IMAGE=registry.example.com/anolisa/skillfs-sidecar:validated
+export ANOLISA_IMAGE=registry.example.com/anolisa/anolisa:validated
+kubectl -n "$NS" create configmap skillfs-ledger-init \
+  --from-file=ledger-init.py=container/ledger-init.py --dry-run=client -o yaml |
+  kubectl -n "$NS" apply -f -
+sed -e "s|skillfs-sidecar:dev|$IMAGE|g" \
+    -e "s|anolisa:dev|$ANOLISA_IMAGE|g" deploy/kubernetes/30-ledger-pod.yaml |
+  kubectl -n "$NS" apply -f -
+kubectl -n "$NS" logs skillfs-ledger-example -c ledger-init
+kubectl -n "$NS" wait --for=condition=Ready pod/skillfs-ledger-example --timeout=300s
+```
+
+The init container has a read-only root filesystem. The initializer normalizes
+copied permissions, refuses links, special files and package-supplied Ledger
+metadata, and publishes a complete source tree before scanning. It uses a
+dedicated Ledger configuration with explicit `managedSkillDirs`; daemon startup
+alone does not turn default discovery roots into managed skills. Scanner or
+activation errors stop initialization; policy outcomes, including hidden skills
+and Ledger's safe pending-review snapshots, are preserved without auto-approval.
+
+The Agent receives only the propagated view via its legacy user skill directory.
+`--read-only` makes the FUSE mount itself reject mutations with `EROFS`, including
+after propagation. A parent volume's `readOnly: true` alone does not protect
+submounts. Ledger retains write access to the separate physical source.
+Its home and workspace start empty; RPM/raw system skill and extension roots are
+masked. `skills.custom_paths` is additive and cannot provide this isolation.
+Custom-prefix images, extra extensions or preloaded homes require equivalent
+masking. This profile uses FUSE activation as its enforcement boundary and does
+not enable an independent Cosh Ledger hook. Adding hooks requires checking their
+path identity and daemon access separately; do not mount `/state` in the Agent.
+
+Ledger's startup probe requires a successful `daemon.health` RPC before SkillFS
+and Cosh start. Readiness uses the same RPC, and repeated liveness failures
+restart the Ledger sidecar. A stale socket or an unresponsive daemon fails the
+probe; socket existence alone is insufficient.
+
+The mount probes read virtual `skill-discover/SKILL.md`, which remains available
+when all business skills are hidden. Readiness confirms the mount, not approval
+of a required business skill. Add an application readiness condition if needed.
+The activation watcher reloads activation artifacts already published by Ledger
+without a remount. This profile does not automatically rescan arbitrary source
+edits: the JSONL event log is diagnostic and the daemon does not tail it.
+Treat seeded content as immutable; package updates require a new source volume
+and a new scan. A trusted operator changing the existing source must explicitly
+request Ledger scanning and activation before expecting the view to change.
+
+For persistence, replace the **whole** `state` emptyDir with a dedicated PVC so
+signing keys and per-skill snapshots survive together. Reusing the same package
+preserves existing state; a changed or unrecognized seed fails instead of
+overwriting it. Quiesce the old Pod before reusing its PVC, and keep the old volume
+for rollback. Never run two initializers or daemons against the same state.
+
+Validation: `python3 scripts/test-ledger-init.py` checks seeding without external
+dependencies. In a disposable privileged Linux container with `/dev/fuse`, use
+the agent-sec Python 3.11 environment and place current `skillfs`, `cosh-core`,
+`fusermount3` and `timeout` on PATH, then run
+`python scripts/test-ledger-init.py --integration`. It uses real scanners and
+snapshots, a read-only bind mount, an unprivileged Cosh process, a raw-directory
+bypass negative control, and a probe after every business skill is hidden.
+This does not replace Kubernetes mount-propagation validation on the target cluster.
+
+Delete the example Pod and ConfigMap when finished; retain any PVC until its
+state is no longer needed:
+
+```bash
+kubectl -n "$NS" delete pod skillfs-ledger-example
+kubectl -n "$NS" delete configmap skillfs-ledger-init
+```
+
 ## Prerequisites
 
 - Kubernetes 1.29 or later.

--- a/docs/user-guide/en/runtime/skillfs.md
+++ b/docs/user-guide/en/runtime/skillfs.md
@@ -746,6 +746,7 @@ shares the same file for compatibility.
 | `--decision-command <CMD>` | Use legacy external decision mode |
 | `--pid-file <PATH>` | Write a process pid file |
 | `--allow-other` | Allow other users to access the FUSE mount |
+| `--read-only` | Reject mutations through the FUSE mount with `EROFS`; the separate physical source remains writable by its owner |
 | `--config <PATH>` | Load SkillFS TOML configuration |
 | `-v`, `--verbose` | Enable debug logging |
 | `--log-file <PATH>` | Write logs to a file |

--- a/docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md
+++ b/docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md
@@ -9,6 +9,78 @@ source。
 仓库目前没有发布可直接拉取的 SkillFS Sidecar 专用镜像。请从准备部署的源码
 revision 构建镜像，完成本地验证后，再推送到集群可以访问的 registry。
 
+## 只读安装的 Skill 与 Ledger
+
+可选的 `30-ledger-pod.yaml` 将安装包中的平铺 Skill 复制到 `/state/source`，
+调用真实 Ledger 扫描与激活处理，然后依次启动 Ledger、SkillFS 和 Cosh。
+它保留 `--security --activation-mode file`，安装目录只读不会自动获得激活。
+`.skill-meta/activation.json` 及其版本快照仍位于各自 Skill 目录内。
+file 激活模式也会读取现有 xattr 协议。
+
+使用包含待验证 revision 的 `os-skills`、`agent-sec-core` 和 `cosh-ng` 的
+ANOLISA RPM 镜像，以及对应的 SkillFS 专用镜像。示例采用 RPM Python 路径和
+`/usr/share/anolisa/skills`。使用 raw 安装时，将 init 命令中的安装包参数和
+Python runtime 改为该镜像的实际安装路径。不要直接将安装包目录作为 SkillFS
+源目录。创建示例 namespace 后，从 `src/skillfs` 执行：
+
+```bash
+export NS=skillfs-container-example
+export IMAGE=registry.example.com/anolisa/skillfs-sidecar:validated
+export ANOLISA_IMAGE=registry.example.com/anolisa/anolisa:validated
+kubectl -n "$NS" create configmap skillfs-ledger-init \
+  --from-file=ledger-init.py=container/ledger-init.py --dry-run=client -o yaml |
+  kubectl -n "$NS" apply -f -
+sed -e "s|skillfs-sidecar:dev|$IMAGE|g" \
+    -e "s|anolisa:dev|$ANOLISA_IMAGE|g" deploy/kubernetes/30-ledger-pod.yaml |
+  kubectl -n "$NS" apply -f -
+kubectl -n "$NS" logs skillfs-ledger-example -c ledger-init
+kubectl -n "$NS" wait --for=condition=Ready pod/skillfs-ledger-example --timeout=300s
+```
+
+init 容器使用只读根文件系统。初始化脚本调整副本权限，拒绝链接、特殊文件和
+安装包附带的 Ledger 元数据，在发布完整源目录后执行扫描。它使用独立的 Ledger
+配置，显式设置 `managedSkillDirs`；启动 daemon 不会自动将默认发现目录纳入托管。
+扫描或激活执行错误会阻止初始化完成；策略结果，包括隐藏 Skill 和 Ledger 安全的
+待审核快照，均按原有判定保留，不自动批准。
+
+Agent 仅通过传统用户 Skill 目录读取传播后的 view。`--read-only` 使 FUSE 挂载自身
+以 `EROFS` 拒绝修改，传播后仍然生效。仅设置父卷的 `readOnly: true` 不能保护子挂载。
+Ledger 仍可写入独立的物理源目录。Agent 的 home 和 workspace 初始为空，
+RPM/raw 系统 Skill 与 extension 目录被遮蔽。`skills.custom_paths` 是追加配置，
+不能提供这种隔离。自定义 prefix 镜像、额外 extension 或预置 home 需要同等隔离。
+该示例使用 FUSE 激活判定作为执行边界，不启用独立的 Cosh Ledger hook。
+添加 hook 时应另行核对路径身份与 daemon 访问，不能将 `/state` 挂给 Agent。
+
+Ledger 的 startup probe 要求 `daemon.health` RPC 成功后才启动 SkillFS 和 Cosh。
+Readiness 使用同一 RPC，连续 liveness 失败会重启 Ledger sidecar。残留 socket 或
+daemon 无响应都会使 probe 失败；仅有 socket 文件不代表服务可用。
+
+挂载 probe 读取虚拟 `skill-discover/SKILL.md`，即使所有业务 Skill 都被隐藏也可用。
+Readiness 只确认挂载正常，不代表必需业务 Skill 已获批准；有此需求时补充应用就绪
+条件。activation watcher 会重新加载 Ledger 已发布的激活文件，无需重新挂载。
+此示例不会自动扫描任意源目录修改，JSONL 事件日志用于诊断，daemon 不会读取它。
+应将已导入内容视为不可变；安装包升级采用新源卷和重新扫描。可信操作员若修改已有
+源目录，必须显式请求 Ledger 扫描并更新激活，才能期待 view 随之变化。
+
+需要持久化时，将**整个** `state` emptyDir 替换为独立 PVC，同时保存签名密钥和各
+Skill 快照。相同安装包重跑会保留已有状态；安装包变化或来源无法识别时会报错，
+不会覆盖。复用 PVC 前先停止旧 Pod，并保留旧卷用于回退。不要让两个初始化程序或
+daemon 同时操作同一份状态。
+
+验证时，`python3 scripts/test-ledger-init.py` 无需外部依赖即可检查初始化。
+在带 `/dev/fuse` 的一次性特权 Linux 容器内，使用 agent-sec Python 3.11 环境，
+将当前 `skillfs`、`cosh-core`、`fusermount3` 和 `timeout` 放入 PATH，再运行
+`python scripts/test-ledger-init.py --integration`。它使用真实扫描器和快照、只读
+bind mount、非特权 Cosh 进程、原始目录绕过的反向验证，以及所有业务 Skill 隐藏后的
+probe 检查。这不能代替目标 Kubernetes 集群上的挂载传播验证。
+
+完成后删除示例 Pod 和 ConfigMap；PVC 应保留到不再需要其中状态时：
+
+```bash
+kubectl -n "$NS" delete pod skillfs-ledger-example
+kubectl -n "$NS" delete configmap skillfs-ledger-init
+```
+
 ## 前提条件
 
 - Kubernetes 1.29 或更高版本。

--- a/docs/user-guide/zh/runtime/skillfs.md
+++ b/docs/user-guide/zh/runtime/skillfs.md
@@ -670,6 +670,7 @@ mount-session summary 仍共享同一个文件。
 | `--decision-command <CMD>` | 使用旧 external decision 模式 |
 | `--pid-file <PATH>` | 写进程 pid file |
 | `--allow-other` | 允许其他用户访问 FUSE mount |
+| `--read-only` | FUSE 挂载以 `EROFS` 拒绝修改；独立的物理源目录仍可由其所有者写入 |
 | `--config <PATH>` | 加载 SkillFS TOML 配置 |
 | `-v`, `--verbose` | 启用 debug logging |
 | `--log-file <PATH>` | 将日志写入文件 |

--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -429,6 +429,13 @@ The sidecar supervisor detects failed FUSE reads and remounts inside the
 container. Its recovery budget is configurable through `SKILLFS_SUPERVISOR_*`;
 see the sidecar guide below for defaults and recovery limits.
 
+For read-only installed skills, the guide also provides a Ledger profile that
+seeds a private writable source, scans before mounting, and masks installed
+copies from Cosh. Missing or invalid activation remains hidden.
+The profile uses `skillfs mount --read-only` to reject FUSE writes at the kernel
+boundary while Ledger keeps writing the separate private source.
+Ledger RPC probes gate startup and readiness and restart an unresponsive daemon.
+
 ```bash
 cd src/skillfs
 IMAGE=registry.example.com/anolisa/skillfs-sidecar:$(git rev-parse --short=12 HEAD)

--- a/src/skillfs/README_zh.md
+++ b/src/skillfs/README_zh.md
@@ -388,6 +388,13 @@ Kubernetes 1.29+、`/dev/fuse`，并允许 Sidecar 使用特权模式。
 Sidecar supervisor 检测 FUSE 读取失败，并在容器内重新挂载。可通过
 `SKILLFS_SUPERVISOR_*` 配置恢复预算；默认值和恢复边界见下方 Sidecar 用户指南。
 
+对于只读安装的 Skill，指南还提供 Ledger 部署示例，将初始内容复制到私有可写
+源目录，在挂载前扫描，并对 Cosh 隔离安装包原始目录。缺失或无效的 activation
+仍保持隐藏。
+该示例通过 `skillfs mount --read-only` 在内核边界拒绝 FUSE 写入，Ledger 仍可写入
+独立的私有源目录。
+Ledger RPC 探针控制启动与就绪状态，并在 daemon 无响应时触发重启。
+
 ```bash
 cd src/skillfs
 IMAGE=registry.example.com/anolisa/skillfs-sidecar:$(git rev-parse --short=12 HEAD)

--- a/src/skillfs/container/ledger-init.py
+++ b/src/skillfs/container/ledger-init.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Seed a private source from an immutable flat skill bundle, then run Ledger."""
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import stat
+import tempfile
+from pathlib import Path
+
+
+def seed(package: Path, source: Path) -> list[Path]:
+    """Publish the complete seed once; never overwrite an existing Ledger tree."""
+    package = package.resolve(strict=True)
+    if source.is_symlink():
+        raise ValueError("source must not be a symlink")
+    source = source.resolve()
+    if source == package or source.is_relative_to(package) or package.is_relative_to(source):
+        raise ValueError("package and source must be separate trees")
+    skills = sorted(p for p in package.iterdir() if not p.name.startswith("."))
+    skills = [p for p in skills if p.is_dir() and (p / "SKILL.md").is_file()]
+    if not skills:
+        raise ValueError(f"no flat skills with SKILL.md found in {package}")
+    inventory = {}
+    for skill in skills:
+        for path in [skill, *sorted(skill.rglob("*"))]:
+            mode = path.lstat().st_mode
+            if path.is_symlink() or not (stat.S_ISDIR(mode) or stat.S_ISREG(mode)):
+                raise ValueError(f"bundle contains a link or special file: {path}")
+            if ".skill-meta" in path.relative_to(package).parts:
+                raise ValueError(f"bundle must not supply Ledger state: {path}")
+            digest = None
+            if path.is_file():
+                with path.open("rb") as stream:
+                    digest = hashlib.file_digest(stream, "sha256").hexdigest()
+            inventory[str(path.relative_to(package))] = [digest, mode & 0o111]
+
+    marker = source / ".skillfs-seed.json"
+    if source.exists() and any(source.iterdir()):
+        # ponytail: upgrades use a new volume; add migration only with a version policy.
+        if not marker.is_file() or json.loads(marker.read_text()) != inventory:
+            raise ValueError("seed differs or is unrecognized; use a new source volume and rescan")
+        if source.stat().st_uid != os.geteuid() or source.stat().st_mode & 0o077:
+            raise ValueError("existing source must be owned by this UID with mode 0700")
+    else:
+        source.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(prefix=".skillfs-seed-", dir=source.parent) as tmp:
+            staged = Path(tmp) / "source"
+            staged.mkdir(mode=0o700)
+            for relative, (digest, executable) in inventory.items():
+                target = staged / relative
+                if digest is None:
+                    target.mkdir(mode=0o755)
+                    target.chmod(0o755)
+                else:
+                    # Omit package xattrs, including stale activation on directories.
+                    shutil.copyfile(package / relative, target)
+                    target.chmod(0o644 | executable)
+            (staged / marker.name).write_text(json.dumps(inventory, sort_keys=True) + "\n")
+            if source.exists():
+                source.rmdir()
+            staged.rename(source)
+    return [source / p.name for p in skills]
+
+
+def activate(skills: list[Path]) -> None:
+    """Use the daemon's real scanner and activation policy without auto-approval."""
+    from agent_sec_cli.daemon.jobs.skill_ledger.processor import process_skill_change
+    from agent_sec_cli.daemon.jobs.skill_ledger.protocol import SkillFsChange
+    from agent_sec_cli.skill_ledger.config import load_config, save_config
+
+    config = load_config()
+    config["enableDefaultSkillDirs"] = False
+    config["managedSkillDirs"] = [str(skill) for skill in skills]
+    save_config(config)
+    for skill in skills:
+        result = process_skill_change(
+            SkillFsChange(canonical_skill_dir=skill, event_kinds={"reconcile"})
+        )
+        print(json.dumps(result), flush=True)
+        if result["status"] != "processed":
+            raise RuntimeError(f"Ledger initialization failed for {skill}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("package", type=Path)
+    parser.add_argument("source", type=Path)
+    args = parser.parse_args()
+    os.umask(0o077)
+    activate(seed(args.package, args.source))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -188,6 +188,12 @@ enum Commands {
         #[arg(long, help_heading = help_text::HEADING_MOUNT)]
         allow_other: bool,
 
+        /// Reject writes through the FUSE mount, including propagated submounts.
+        ///
+        /// The separate physical source remains writable by its owner.
+        #[arg(long, help_heading = help_text::HEADING_MOUNT)]
+        read_only: bool,
+
         /// Root visible to readers for paths advertised by skill-discover.
         ///
         /// Set this to the mounted skills directory when readers cannot access
@@ -552,6 +558,7 @@ async fn run(
             source,
             mountpoint,
             allow_other,
+            read_only,
             skill_discover_root,
             foreground,
             managed,
@@ -606,6 +613,7 @@ async fn run(
                 source,
                 mountpoint,
                 allow_other,
+                read_only,
                 skill_discover_root,
                 foreground,
                 pid_file,
@@ -837,6 +845,7 @@ async fn cmd_mount(
     source: PathBuf,
     mountpoint: PathBuf,
     allow_other: bool,
+    read_only: bool,
     skill_discover_root: Option<PathBuf>,
     foreground: bool,
     pid_file: Option<PathBuf>,
@@ -2103,6 +2112,7 @@ async fn cmd_mount(
     // Mount options
     let options = MountOptions {
         allow_other,
+        read_only,
         foreground,
         fuse_options: vec!["noatime".to_string()],
     };

--- a/src/skillfs/crates/skillfs-fuse/src/lib.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/lib.rs
@@ -70,6 +70,8 @@ pub enum FuseError {
 pub struct MountOptions {
     /// Allow other users to access the mount (requires allow_other in fuse.conf)
     pub allow_other: bool,
+    /// Reject mutations through the FUSE mount at the kernel boundary.
+    pub read_only: bool,
     /// Run in foreground (don't daemonize)
     pub foreground: bool,
     /// Additional FUSE mount options
@@ -80,6 +82,7 @@ impl Default for MountOptions {
     fn default() -> Self {
         Self {
             allow_other: false,
+            read_only: false,
             foreground: false,
             fuse_options: vec!["noatime".to_string()],
         }

--- a/src/skillfs/crates/skillfs-fuse/src/mount.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/mount.rs
@@ -213,6 +213,9 @@ fn mount_inner(
 
     let mut fuse_opts: Vec<fuser::MountOption> = vec![];
     fuse_opts.push(fuser::MountOption::NoAtime);
+    if options.read_only {
+        fuse_opts.push(fuser::MountOption::RO);
+    }
     if options.allow_other {
         fuse_opts.push(fuser::MountOption::AllowOther);
     }

--- a/src/skillfs/deploy/kubernetes/30-ledger-pod.yaml
+++ b/src/skillfs/deploy/kubernetes/30-ledger-pod.yaml
@@ -1,0 +1,143 @@
+# Optional secure profile. Create skillfs-ledger-init from container/ledger-init.py
+# and replace both :dev image references before applying. See the user guide.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: skillfs-ledger-example
+spec:
+  restartPolicy: Always
+  initContainers:
+    - name: ledger-init
+      image: anolisa:dev
+      command: ["/usr/bin/python3.11", "/init/ledger-init.py", "/usr/share/anolisa/skills", "/state/source"]
+      env: &ledger-env
+        - {name: PYTHONPATH, value: /opt/agent-sec/lib/python3.11/site-packages}
+        - {name: HOME, value: /state/home}
+        - {name: XDG_CONFIG_HOME, value: /state/config}
+        - {name: XDG_DATA_HOME, value: /state/data}
+        - {name: XDG_RUNTIME_DIR, value: /state/run}
+      securityContext:
+        runAsUser: 0
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities: {drop: ["ALL"]}
+      volumeMounts:
+        - {name: state, mountPath: /state}
+        - {name: init, mountPath: /init, readOnly: true}
+        - {name: init-tmp, mountPath: /tmp}
+    - name: ledger
+      image: anolisa:dev
+      restartPolicy: Always
+      command: ["agent-sec-daemon"]
+      env: *ledger-env
+      securityContext:
+        runAsUser: 0
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities: {drop: ["ALL"]}
+      volumeMounts:
+        - {name: state, mountPath: /state}
+        - {name: ledger-tmp, mountPath: /tmp}
+      startupProbe:
+        exec: &ledger-health
+          command:
+            - /usr/bin/python3.11
+            - -c
+            - >-
+              from agent_sec_cli.daemon.client import daemon_health_reachable;
+              from agent_sec_cli.daemon.runtime import resolve_socket_path;
+              raise SystemExit(0 if daemon_health_reachable(resolve_socket_path()) else 1)
+        periodSeconds: 2
+        timeoutSeconds: 2
+        failureThreshold: 30
+      readinessProbe:
+        exec: *ledger-health
+        timeoutSeconds: 2
+      livenessProbe:
+        exec: *ledger-health
+        timeoutSeconds: 2
+        failureThreshold: 3
+    - name: skillfs
+      image: skillfs-sidecar:dev
+      restartPolicy: Always
+      env:
+        - {name: SKILLFS_SOURCE, value: /state/source}
+        - {name: SKILLFS_MOUNTPOINT, value: /shared/mount}
+        - {name: SKILLFS_DISCOVER_ROOT, value: /shared/mount/skills}
+        - name: SKILLFS_EXTRA_ARGS
+          value: --read-only --security --activation-mode file --activation-reload-mode poll --activation-events-log /state/activation-events.jsonl
+        # Virtual content remains readable when Ledger hides every business skill.
+        - {name: SKILLFS_PROBE_FILE, value: skills/skill-discover/SKILL.md}
+      securityContext: {privileged: true, runAsUser: 0}
+      volumeMounts:
+        - {name: state, mountPath: /state}
+        - {name: shared, mountPath: /shared, mountPropagation: Bidirectional}
+        - {name: fuse, mountPath: /dev/fuse}
+      startupProbe:
+        exec: {command: ["/usr/local/bin/skillfs-mount-probe", "--startup"]}
+        periodSeconds: 2
+        timeoutSeconds: 10
+        failureThreshold: 30
+      readinessProbe:
+        exec: {command: ["/usr/local/bin/skillfs-mount-probe", "--readiness"]}
+        timeoutSeconds: 10
+      livenessProbe:
+        exec: {command: ["/usr/local/bin/skillfs-mount-probe", "--liveness"]}
+        timeoutSeconds: 10
+        failureThreshold: 2
+    - name: agent-home
+      image: anolisa:dev
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          mkdir -p /agent-home/.copilot-shell
+          ln -sfn /shared/mount/skills /agent-home/.copilot-shell/skills
+          chown -R 10001:10001 /agent-home
+          chown 10001:10001 /workspace
+      volumeMounts:
+        - {name: agent-home, mountPath: /agent-home}
+        - {name: workspace, mountPath: /workspace}
+  containers:
+    - name: agent
+      image: anolisa:dev
+      command: ["cosh"]
+      stdin: true
+      tty: true
+      workingDir: /workspace
+      env:
+        - {name: HOME, value: /home/agent}
+        - {name: XDG_DATA_HOME, value: /home/agent/.local/share}
+      securityContext:
+        runAsUser: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities: {drop: ["ALL"]}
+      volumeMounts:
+        - {name: agent-home, mountPath: /home/agent}
+        - {name: workspace, mountPath: /workspace}
+        - {name: shared, mountPath: /shared, readOnly: true, mountPropagation: HostToContainer}
+        # Mask installed copies in the workload image, including extension bundles.
+        - {name: masked, mountPath: /usr/share/anolisa/skills, readOnly: true}
+        - {name: masked, mountPath: /usr/local/share/anolisa/skills, readOnly: true}
+        - {name: masked, mountPath: /usr/share/anolisa/extensions, readOnly: true}
+        - {name: masked, mountPath: /usr/local/share/anolisa/extensions, readOnly: true}
+      readinessProbe:
+        exec:
+          command: ["/bin/sh", "-ec", "timeout 5 cat /home/agent/.copilot-shell/skills/skill-discover/SKILL.md >/dev/null"]
+        timeoutSeconds: 10
+  volumes:
+    # Persist this whole volume together: source snapshots and Ledger signing keys.
+    # A changed package requires a fresh volume and a new scan; never wipe this one.
+    - {name: state, emptyDir: {}}
+    - {name: shared, emptyDir: {medium: Memory, sizeLimit: 16Mi}}
+    - {name: agent-home, emptyDir: {}}
+    - {name: workspace, emptyDir: {}}
+    - {name: masked, emptyDir: {}}
+    - {name: init-tmp, emptyDir: {}}
+    - {name: ledger-tmp, emptyDir: {}}
+    - name: init
+      configMap: {name: skillfs-ledger-init}
+    - name: fuse
+      hostPath: {path: /dev/fuse, type: CharDevice}

--- a/src/skillfs/deploy/kubernetes/README.md
+++ b/src/skillfs/deploy/kubernetes/README.md
@@ -23,6 +23,12 @@ for the complete workflow.
 | `00-namespace.yaml` | Isolated example namespace |
 | `10-example-configmap.yaml` | Example default and secondary skills |
 | `20-pod.yaml` | SkillFS sidecar and workload Pod |
+| `30-ledger-pod.yaml` | Optional read-only package → Ledger → secure SkillFS → Cosh profile |
+
+The optional Ledger profile needs the initializer ConfigMap and an ANOLISA RPM
+image in addition to the dedicated sidecar image. Follow the user guide's
+read-only installation section; do not apply all Pod examples together with
+`kubectl apply -f .`.
 
 ## Deploy
 

--- a/src/skillfs/scripts/test-ledger-init.py
+++ b/src/skillfs/scripts/test-ledger-init.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Run seed regressions; optionally exercise real Ledger, FUSE and Cosh on Linux.
+
+Use the agent-sec Python environment. --integration requires skillfs and cosh-core
+on PATH and a private container with /dev/fuse. No scanner or activation stubs.
+"""
+
+import argparse
+import errno
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import traceback
+from pathlib import Path
+from typing import Callable
+
+SCRIPT = Path(__file__).resolve().parents[1] / "container/ledger-init.py"
+spec = importlib.util.spec_from_file_location("ledger_init", SCRIPT)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+def rejected(call: Callable[[], object]) -> None:
+    try:
+        call()
+    except ValueError:
+        return
+    raise AssertionError("unsafe seed accepted")
+
+
+def check_seed(root: Path) -> None:
+    package = root / "package"
+    skill = package / "sample"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: sample\ndescription: Sample\n---\nHello.\n")
+    (skill / "run.sh").write_text("#!/bin/sh\nprintf 'hello\\n'\n")
+    (skill / "run.sh").chmod(0o555)
+    (skill / "SKILL.md").chmod(0o444)
+    skill.chmod(0o555)
+    source = root / "source"
+    copied = module.seed(package, source)[0]
+    assert source.stat().st_mode & 0o777 == 0o700
+    assert (copied / "run.sh").stat().st_mode & 0o777 == 0o755
+    assert (copied / "SKILL.md").stat().st_mode & 0o777 == 0o644
+    meta = copied / ".skill-meta"
+    meta.mkdir()
+    (meta / "keep").write_text("existing activation state")
+    module.seed(package, source)
+    assert (meta / "keep").read_text() == "existing activation state"
+    skill.chmod(0o755)
+    (skill / "SKILL.md").chmod(0o644)
+    (skill / "SKILL.md").write_text("changed package")
+    rejected(lambda: module.seed(package, source))
+    assert (meta / "keep").read_text() == "existing activation state"
+    (skill / "outside").symlink_to("/etc/passwd")
+    rejected(lambda: module.seed(package, root / "linked"))
+    (skill / "outside").unlink()
+    (skill / ".skill-meta").mkdir()
+    rejected(lambda: module.seed(package, root / "metadata"))
+    rejected(lambda: module.seed(package, package / "nested"))
+    print("PASS: read-only seed, modes, restart preservation, upgrade/link/metadata rejection")
+
+
+def eventually(predicate: Callable[[], bool]) -> None:
+    deadline = time.monotonic() + 20
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.2)
+    raise AssertionError("timed out waiting for mount/activation")
+
+
+def integration(root: Path) -> None:
+    from agent_sec_cli.skill_ledger.core.resolver import write_activation_contract
+
+    for name in ("skillfs", "cosh-core", "fusermount3", "timeout"):
+        assert shutil.which(name), f"missing {name}"
+    assert Path("/dev/fuse").exists()
+    assert (
+        os.geteuid() == 0 and Path("/.dockerenv").exists()
+    ), "use a disposable privileged container"
+    root.chmod(0o755)
+    for variable, directory in (
+        ("HOME", "home"),
+        ("XDG_CONFIG_HOME", "config"),
+        ("XDG_DATA_HOME", "data"),
+        ("XDG_RUNTIME_DIR", "run"),
+    ):
+        os.environ[variable] = str(root / directory)
+        (root / directory).mkdir(mode=0o700)
+    package = root / "bundle"
+    for name in ("accepted", "missing", "invalid"):
+        skill = package / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: A greeting\n---\nSay hello to the user.\n"
+        )
+        (skill / "SKILL.md").chmod(0o444)
+        skill.chmod(0o555)
+    package.chmod(0o755)
+    source = root / "live"
+    raw = Path("/usr/share/anolisa/skills")
+    raw.mkdir(parents=True, exist_ok=True)
+    raw.parent.chmod(0o755)
+    assert not list(raw.iterdir()), "use an image without installed skills"
+    subprocess.run(["mount", "--bind", str(package), str(raw)], check=True)
+    subprocess.run(["mount", "-o", "remount,bind,ro", str(raw)], check=True)
+    try:
+        (raw / "accepted/SKILL.md").write_text("must fail even as root")
+    except OSError as error:
+        assert error.errno == errno.EROFS, error
+    else:
+        raise AssertionError("package is not mounted read-only")
+    skills = module.seed(raw, source)
+    module.activate(skills)
+    accepted = source / "accepted"
+    record = json.loads((accepted / ".skill-meta/activation.json").read_text())
+    assert record["target"] and "pending" not in record["target"], record
+    assert (accepted / record["target"] / "SKILL.md").is_file()
+    before = (accepted / ".skill-meta/activation.json").read_bytes()
+    module.seed(package, source)
+    assert (accepted / ".skill-meta/activation.json").read_bytes() == before
+    # Remove both activation sources: file mode intentionally prefers xattr.
+    missing = source / "missing"
+    (missing / ".skill-meta/activation.json").unlink()
+    for skill in (missing, source / "invalid"):
+        if "user.agent_sec.skill_ledger.activation" in os.listxattr(skill):
+            os.removexattr(skill, "user.agent_sec.skill_ledger.activation")
+    (source / "invalid/.skill-meta/activation.json").write_text("{invalid")
+    mount = root / "mount"
+    mount.mkdir()
+    view = mount / "skills"
+    home_skills = root / "home/.copilot-shell/skills"
+    home_skills.parent.mkdir()
+    home_skills.symlink_to(view)
+    for path in [root / "home", home_skills.parent]:
+        path.chmod(0o755)
+        os.chown(path, 10001, 10001)
+
+    def discovered() -> set[str]:
+        request = {
+            "type": "registry_request",
+            "request_id": "seed-test",
+            "domain": "skills",
+            "action": "list",
+            "params": None,
+        }
+        output = subprocess.run(
+            ["cosh-core", "--registry"],
+            input=json.dumps(request) + "\n",
+            text=True,
+            capture_output=True,
+            timeout=30,
+            check=True,
+            cwd=root,
+            user=10001,
+            group=10001,
+            extra_groups=[],
+        ).stdout
+        response = next(
+            json.loads(line)
+            for line in output.splitlines()
+            if json.loads(line).get("type") == "registry_response"
+        )
+        assert response["success"], response
+        return {s["name"] for s in response["data"]}
+
+    with (root / "fuse.log").open("w") as log:
+        process = subprocess.Popen(
+            [
+                "skillfs",
+                "mount",
+                str(source),
+                str(mount),
+                "--foreground",
+                "--allow-other",
+                "--read-only",
+                "--security",
+                "--activation-mode",
+                "file",
+                "--activation-reload-mode",
+                "poll",
+                "--activation-events-log",
+                str(root / "events.jsonl"),
+                "--skill-discover-root",
+                str(view),
+            ],
+            stdout=log,
+            stderr=log,
+        )
+        try:
+            eventually(lambda: (view / "accepted/SKILL.md").is_file())
+            assert "Say hello" in (view / "accepted/SKILL.md").read_text()
+            assert not (view / "missing").exists()
+            assert not (view / "invalid").exists()
+            raw_names = discovered()
+            assert {"missing", "invalid"} <= raw_names, raw_names
+            masked = root / "masked"
+            masked.mkdir(mode=0o755)
+            subprocess.run(["mount", "--bind", str(masked), str(raw)], check=True)
+            names = discovered()
+            assert "accepted" in names and not names & {"missing", "invalid"}, names
+            # Check the actual FUSE mount, not the read-only flag of its parent bind.
+            for uid in (0, 10001):
+                child = os.fork()
+                if child == 0:
+                    try:
+                        os.setgroups([])
+                        os.setgid(uid)
+                        os.setuid(uid)
+                        skill = view / "accepted"
+                        file = skill / "SKILL.md"
+                        for action in (
+                            lambda: os.open(file, os.O_WRONLY),
+                            lambda: os.truncate(file, 0),
+                            lambda: (skill / "injected").write_text("injected"),
+                            lambda: (skill / "newdir").mkdir(),
+                            lambda: file.unlink(),
+                            lambda: file.rename(skill / "renamed"),
+                            lambda: file.chmod(0o777),
+                            lambda: os.setxattr(file, "user.test", b"injected"),
+                        ):
+                            try:
+                                action()
+                            except OSError as error:
+                                assert error.errno == errno.EROFS, error
+                            else:
+                                raise AssertionError("FUSE mutation succeeded")
+                    except BaseException:
+                        traceback.print_exc()
+                        os._exit(1)
+                    os._exit(0)
+                _, status = os.waitpid(child, 0)
+                assert os.waitstatus_to_exitcode(status) == 0, f"mutation check failed as UID {uid}"
+            assert "Say hello" in (accepted / "SKILL.md").read_text()
+            denied = subprocess.run(
+                ["cat", str(accepted / "SKILL.md")],
+                capture_output=True,
+                user=10001,
+                group=10001,
+                extra_groups=[],
+            )
+            assert denied.returncode != 0, "agent can read the private source"
+            write_activation_contract(accepted, {"schemaVersion": 1, "target": None})
+            eventually(lambda: not (view / "accepted").exists())
+            probe = SCRIPT.parent / "mount-probe.sh"
+            subprocess.run(
+                [
+                    "bash",
+                    str(probe),
+                    "--mountpoint",
+                    str(mount),
+                    "--file",
+                    "skills/skill-discover/SKILL.md",
+                ],
+                check=True,
+                timeout=15,
+            )
+            assert process.poll() is None, "normal hiding must not stop the mount"
+            print(
+                "PASS: real Ledger snapshot, read-only FUSE, Cosh isolation, live revocation, probe"
+            )
+        finally:
+            log.flush()
+            if process.poll() is not None:
+                print((root / "fuse.log").read_text())
+            subprocess.run(["fusermount3", "-u", str(mount)], check=False, timeout=10)
+            process.terminate()
+            process.wait(timeout=10)
+            subprocess.run(["umount", str(raw)], check=False, timeout=10)
+            subprocess.run(["umount", str(raw)], check=False, timeout=10)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--integration", action="store_true")
+    args = parser.parse_args()
+    os.umask(0o077)
+    with tempfile.TemporaryDirectory(
+        prefix="skillfs-ledger-test-", dir="/var/lib" if args.integration else None
+    ) as tmp:
+        root = Path(tmp)
+        check_seed(root)
+        if args.integration:
+            integration(root)


### PR DESCRIPTION
## Why

Read-only installed skills cannot maintain Ledger activation and snapshots in place. This follow-up to #3146 provides an explicit deployment path that preserves SkillFS's existing security decisions.

## What changed

Add an optional Kubernetes profile and a small initializer that copies a flat installed bundle into a private writable source, then calls the real Ledger scan/activation processor before starting SkillFS and Cosh. Ledger RPC health probes gate startup and readiness and restart an unresponsive daemon. Repeated initialization preserves Ledger state; changed packages require a fresh volume and a new scan. The profile masks original system skill/extension roots, gives Cosh only the propagated view, enforces kernel read-only access with the new `--read-only` mount option, and probes virtual discovery content so policy-driven hiding does not cause remount loops.

## Related issue

Follow-up to #3146 and the [Ledger deployment comment](https://github.com/alibaba/anolisa/pull/3146#issuecomment-5583938523).

## User / Agent impact

Read-only packages become initial content for a separately writable, privately managed skill source. Missing or invalid activation stays hidden; valid snapshots are readable through SkillFS. Cosh and SkillFS's activation protocol remain unchanged.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Migration or rollback guidance is needed

This is an opt-in deployment example; the existing sidecar example is unchanged. The new profile requires Kubernetes native sidecars, privileged FUSE/mount propagation, matching ANOLISA RPM and SkillFS images, and a dedicated state volume. The seed rejects links, special files and package-supplied Ledger metadata. State includes both signing keys and per-skill snapshots; no automatic approval or read-only bypass is introduced. Package upgrades deliberately use a new volume rather than overwriting existing runtime state. The watcher reloads activation already published by Ledger; this immutable-seed profile does not automatically rescan arbitrary source edits or tail its diagnostic JSONL log.

The profile enforces activation through FUSE and does not enable an independent Cosh Ledger hook. Custom-prefix images, additional extensions and preloaded homes require equivalent discovery isolation. Kubernetes mount propagation and the complete RPM-image Pod were not tested on a live cluster.

## Validation

Linux aarch64, Rust 1.86.0, Python 3.11.6:

- `cargo +1.86.0 fmt --all -- --check` and `cargo +1.86.0 clippy --workspace --all-targets -- -D warnings` passed.
- `cargo +1.86.0 test --workspace`: 1,600 passed, 7 ignored, 0 failed.
- `scripts/test.sh`: real FUSE smoke and managed-mount recovery passed.
- `python scripts/test-ledger-init.py`: read-only modes, preserved state, changed-package rejection, symlink/metadata rejection and path overlap passed.
- `python scripts/test-ledger-init.py --integration`: passed in a disposable privileged Ubuntu 24.04 container with networking disabled, current SkillFS/Cosh binaries, and the real Ledger runtime. Checks include a read-only bind-mounted package, signed snapshots from both built-in scanners, missing/invalid activation hidden, Cosh discovery as UID 10001, a raw-directory bypass negative control followed by masking, private-source denial, eight FUSE mutation attempts returning `EROFS` for both root and UID 10001, live revocation and an empty-business-view health probe. Ledger still updates activation in the private physical source while the FUSE mount is read-only.
- Black/Isort checks, YAML parsing/startup ordering/source-volume isolation checks, bilingual guide links and `git diff --check` passed.
- Ledger probe validation with Python 3.11.6: the command parsed from the manifest succeeds against a real daemon and fails before startup, after shutdown, with a stale socket, and with a nonresponsive listening socket. Six targeted daemon health/stale-socket tests and the seed regression passed. Probe processes and sockets were cleaned up; kubelet startup/restart behavior was not exercised on a live cluster.

`cargo +1.86.0 doc --workspace --no-deps` passed for the new default-false `MountOptions.read_only` field. Existing mounts remain writable unless `--read-only` is selected. Live Kubernetes/ACK validation remains a deployment acceptance step; no cloud resources were created.

## Documentation and rollback

Update both README summaries, both Kubernetes guides, and the manifest index. Stop the example Pod before reusing its state PVC; preserve the old volume and image for rollback. Delete only the example Pod/initializer ConfigMap when finished. Reverting this commit removes the optional profile without changing the existing activation implementation.
