### PR TITLE
fix(sec-core): skip read-only raw user skills

### DIFF
--- a/docs/user-guide/en/agent-security/agent-sec-core/skill-ledger.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/skill-ledger.md
@@ -154,6 +154,15 @@ written for the skipped item, while global key initialization keeps its normal
 behavior. An explicit `scan <dir>` remains strict: it exits `1` and points the
 caller to `analyze` for read-only findings.
 
+The same batch skip also applies to host-backed Skills directly under
+`$XDG_DATA_HOME/anolisa/skills/` (default `~/.local/share/anolisa/skills/`), with
+`reasonCode=readonly_default_skill`, when ledger state is not writable and the
+Skill is not covered by `managedSkillDirs`. This includes image-provided raw
+user Skills made read-only to the runtime user. Writable raw user Skills are
+scanned normally; skipped Skills are not added to `managedSkillDirs`.
+Explicit scans and writes to managed user Skills still fail on permission
+errors. SkillFS backing and resolver errors remain errors.
+
 `check` and `status` are unchanged. A skipped Skill with no prior ledger
 artifacts returns `none`, and aggregate health can remain `unscanned`. These
 values do not turn the batch skip into an attestation or a safety verdict.
@@ -574,6 +583,15 @@ Default directories are enabled by default; `managedSkillDirs` holds directories
 - `"path/to/skill"` — a single Skill directory (must also contain `SKILL.md`)
 
 Non-existent directories are silently ignored. Additionally, running `scan` or `certify` on a Skill auto-appends unregistered directories to the config for later `--all` batch operations. `check` is a read-only status query and never writes config.
+
+For direct children of the raw user root `$XDG_DATA_HOME/anolisa/skills/` (default
+`~/.local/share/anolisa/skills/`), auto-remember records only the individual Skill
+path, even when sibling Skills exist. Scanning a writable Skill therefore does
+not add its read-only siblings to `managedSkillDirs`. Other roots retain the
+existing parent-glob heuristic. Existing configuration entries are not rewritten:
+an existing glob still makes covered user Skills managed and keeps write failures
+strict. If you confirm that a raw-root glob was unintentionally added, replace it
+with the individual paths you intend to manage, preserving any intentional coverage.
 
 #### Scheduled Default Quick Scans
 

--- a/docs/user-guide/zh/agent-security/agent-sec-core/skill-ledger.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/skill-ledger.md
@@ -143,6 +143,14 @@ child.on("close", (code) => {
 全局密钥初始化行为保持不变。显式 `scan <dir>` 仍保持严格语义：退出码为 `1`，并提示
 调用方使用 `analyze` 获取只读 findings。
 
+同样的批量跳过规则也适用于 `$XDG_DATA_HOME/anolisa/skills/`（默认
+`~/.local/share/anolisa/skills/`）直接子目录中由 host 提供的 Skill：
+当账本状态不可写且未被 `managedSkillDirs` 覆盖时，返回
+`reasonCode=readonly_default_skill`。这包括镜像中对运行用户只读的 raw 用户 Skill。
+可写的 raw 用户 Skill 正常扫描；跳过项不会加入 `managedSkillDirs`。
+显式扫描和已纳管用户 Skill 的写入仍会因权限错误而失败。
+SkillFS backing 和 resolver 的错误仍按错误处理。
+
 `check` 和 `status` 的语义不变。若跳过项此前不存在任何账本 artifact，`check`
 返回 `none`，聚合健康度仍可能为 `unscanned`；这些值不会把批量跳过转化为认证或
 安全结论。
@@ -538,6 +546,13 @@ agent-sec-cli skill-ledger decide /path/to/skill --clear
 - `"path/to/skill"` — 单个 Skill 目录（同样需包含 `SKILL.md`）
 
 不存在的目录会被静默忽略。此外，对 Skill 执行 `scan` 或 `certify` 时，未收录的目录会自动追加到配置中，方便后续 `--all` 批量操作。`check` 是只读状态检查，不会写入配置。
+
+对于 raw 用户根 `$XDG_DATA_HOME/anolisa/skills/`（默认
+`~/.local/share/anolisa/skills/`）的直接子 Skill，自动记忆仅登记该 Skill
+自身路径，即使存在其它兄弟 Skill 也不扩大为父目录通配符。因此，扫描可写 Skill
+不会把只读兄弟 Skill 一并加入 `managedSkillDirs`。其它根目录保留现有父目录通配符规则。
+已有配置条目不会自动改写：已有通配符覆盖的用户 Skill 仍视为已纳管，写入失败仍会报错。
+若确认 raw 根通配符属于误添加，可将它替换为实际需要纳管的各个 Skill 路径，保留有意配置的覆盖范围。
 
 #### 定时执行默认快速扫描
 

--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -359,7 +359,10 @@ The six integrity states are `pass` / `none` / `drifted` / `warn` / `deny` /
 `analyze` for read-only content findings. In batch mode, a host-backed packaged
 Skill under `/usr/share/anolisa/skills/` or `/usr/local/share/anolisa/skills/`
 whose ledger state is read-only is reported as `status=skipped`,
-`reasonCode=readonly_system_skill`, `persisted=false`. This operational skip is
+`reasonCode=readonly_system_skill`, `persisted=false`. Read-only host Skills directly
+under `$XDG_DATA_HOME/anolisa/skills/` (default `~/.local/share/anolisa/skills/`)
+are also skipped with `reasonCode=readonly_default_skill` unless covered by
+`managedSkillDirs`; managed user Skills retain write errors. This operational skip is
 not a `pass` result or an attestation. An explicit `scan <dir>` remains an error.
 When a skipped Skill has no prior ledger artifacts, `check` and `status`
 continue to report `none` / `unscanned`; neither value means `pass`.

--- a/src/agent-sec-core/README_zh.md
+++ b/src/agent-sec-core/README_zh.md
@@ -340,7 +340,10 @@ agent-sec-cli scan-pii --input ./sample.log --include-low-confidence
 请使用 `analyze`。批量模式下，如果 `/usr/share/anolisa/skills/` 或
 `/usr/local/share/anolisa/skills/` 下由 host 提供的已打包 Skill 无法写入账本状态，
 命令会返回 `status=skipped`、`reasonCode=readonly_system_skill`、
-`persisted=false`。这个运行状态不是 `pass` 结果，也不构成认证；显式执行
+`persisted=false`。`$XDG_DATA_HOME/anolisa/skills/`（默认
+`~/.local/share/anolisa/skills/`）直接子目录中由 host 提供的只读 Skill，
+在未被 `managedSkillDirs` 覆盖时也会跳过，原因码为 `readonly_default_skill`；
+已纳管的用户 Skill 仍保留写入错误。这个运行状态不是 `pass` 结果，也不构成认证；显式执行
 `scan <dir>` 仍会报错。如果跳过项此前没有任何账本 artifact，`check` 和 `status`
 仍会分别报告 `none` / `unscanned`；二者都不表示 `pass`。
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/config.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/config.py
@@ -371,6 +371,12 @@ def is_default_system_skill_dir(skill_dir: str | Path) -> bool:
     return canonical_dir.parent in DEFAULT_SYSTEM_SKILL_ROOTS
 
 
+def is_default_user_skill_dir(skill_dir: str | Path) -> bool:
+    """Return whether *skill_dir* is an immediate child of the raw user root."""
+    canonical_dir = _lexical_path(Path(skill_dir).expanduser())
+    return canonical_dir.parent == get_anolisa_skill_dir()
+
+
 def _is_path_covered_by_entries(skill_dir: Path, entries: list[str]) -> bool:
     """Match a canonical path against config entries without filesystem access."""
     target = _lexical_path(skill_dir)
@@ -401,8 +407,10 @@ def remember_skill_dir(
     """Append *skill_dir* (or its parent glob) to ``managedSkillDirs`` if not covered.
 
     Heuristic for entry format:
+    - Raw user default Skills keep individual paths so auto-remember does not
+      turn read-only siblings into explicitly managed Skills.
     - If the parent directory contains **at least two** sibling sub-directories
-      that each contain ``SKILL.md``, add ``"parent/*"`` (glob pattern).
+      that each contain ``SKILL.md``, other roots use ``"parent/*"``.
     - Otherwise, add the specific directory path.
 
     After appending, runs :func:`_compact_skill_dirs` to prune entries that
@@ -430,7 +438,7 @@ def remember_skill_dir(
     except OSError:
         sibling_skills = []
 
-    if len(sibling_skills) >= 2:
+    if not is_default_user_skill_dir(skill_dir) and len(sibling_skills) >= 2:
         entry = str(parent) + "/*"
     else:
         entry = str(skill_dir)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/certifier.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/certifier.py
@@ -13,6 +13,8 @@ from typing import Any, Literal
 
 from agent_sec_cli.skill_ledger.config import (
     is_default_system_skill_dir,
+    is_default_user_skill_dir,
+    is_managed_covered,
     remember_skill_dir,
 )
 from agent_sec_cli.skill_ledger.core.file_hasher import (
@@ -87,11 +89,19 @@ def _remember_skill_dir_best_effort(skill_dir: str) -> None:
         )
 
 
-def _readonly_system_skip_payload(
+def _readonly_default_skip_payload(
     root: ResolvedSkillRoot,
 ) -> dict[str, Any] | None:
-    """Return a batch skip result for a host-backed, read-only system Skill."""
-    if root.source != "host" or not is_default_system_skill_dir(root.canonical_dir):
+    """Skip read-only host defaults while keeping managed user Skills strict."""
+    if root.source != "host":
+        return None
+    if is_default_system_skill_dir(root.canonical_dir):
+        reason_code = "readonly_system_skill"
+    elif is_default_user_skill_dir(root.canonical_dir) and not is_managed_covered(
+        root.canonical_dir
+    ):
+        reason_code = "readonly_default_skill"
+    else:
         return None
     writable, _reason = ledger_update_access(root)
     if writable:
@@ -100,7 +110,7 @@ def _readonly_system_skip_payload(
         "canonicalSkillDir": str(root.canonical_dir),
         "skillName": root.skill_name,
         "status": "skipped",
-        "reasonCode": "readonly_system_skill",
+        "reasonCode": reason_code,
         "persisted": False,
     }
 
@@ -521,7 +531,10 @@ def scan_skill(
     """Run built-in scanners as needed and record signed scan results."""
     root = resolve_skill_root(skill_dir)
     validate_resolved_skill_root(root)
-    if _readonly_system_skip_payload(root) is not None:
+    if (
+        is_default_system_skill_dir(root.canonical_dir)
+        and _readonly_default_skip_payload(root) is not None
+    ):
         raise SkillLedgerError(
             f"cannot update read-only system skill: {root.canonical_dir}; "
             "use 'agent-sec-cli skill-ledger analyze <skill_dir> --format json' "
@@ -624,7 +637,7 @@ def scan_batch(
         try:
             root = resolve_skill_root(skill_dir)
             validate_resolved_skill_root(root)
-            skipped = _readonly_system_skip_payload(root)
+            skipped = _readonly_default_skip_payload(root)
             if skipped is not None:
                 results.append(skipped)
                 continue

--- a/src/agent-sec-core/docs/design/SKILL_LEDGER_zh.md
+++ b/src/agent-sec-core/docs/design/SKILL_LEDGER_zh.md
@@ -258,7 +258,7 @@ class SigningBackend(Protocol):
 
 **合并策略**：默认目录默认启用，由 `enableDefaultSkillDirs` 控制；`managedSkillDirs` 存放 skill-ledger 动态管理或用户额外配置的目录，不再兼容旧的 `skillDirs` 字段。解析时默认目录在前，`managedSkillDirs` 在后，自动去重。`scanners` 按 `name` 合并，用户配置可覆盖同名扫描器；`activationPolicy` 是全局运行态策略，当前只执行 `pass_warn_only` 行为，历史配置值 `pass_only` / `latest_scanned` 会兼容读取并归一化；`signingBackend` 当前会被读取到配置摘要中，但不会改变实际签名后端。
 
-**自动记忆**：用户对某个 skill 执行 `scan` 或 `certify` 时，若该 skill 目录不在当前有效目录中，会自动追加到 `managedSkillDirs`。其中 `scan` 只在 manifest 持久化成功或成功返回 `noop` 后记忆；scanner 失败、落盘失败和批量跳过均不触发记忆。`check` 是只读状态检查，不会写配置、manifest 或 snapshot。若父目录下有 ≥2 个包含 `SKILL.md` 的兄弟 skill，则追加父目录 glob（`parent/*`）而非单个路径。追加后自动压缩（compact）：若某 glob 已覆盖某个单目录条目，则移除冗余的单目录条目。
+**自动记忆**：用户对某个 skill 执行 `scan` 或 `certify` 时，若该 skill 目录未被 `managedSkillDirs` 覆盖，会自动追加到该配置。其中 `scan` 只在 manifest 持久化成功或成功返回 `noop` 后记忆；scanner 失败、落盘失败和批量跳过均不触发记忆。`check` 是只读状态检查，不会写配置、manifest 或 snapshot。raw 用户默认根的直接子 Skill 仅登记自身路径，避免可写 Skill 将只读兄弟 Skill 一并纳管；其它根目录下若有 ≥2 个包含 `SKILL.md` 的兄弟 skill，则追加父目录 glob（`parent/*`）而非单个路径。追加后自动压缩（compact）：若某 glob 已覆盖某个单目录条目，则移除冗余的单目录条目。已有 glob 不自动收窄，因为配置不区分用户显式设置与历史自动登记；确认属于误扩大的 raw 根条目后，可手动替换为需要纳管的各个 Skill 路径。
 
 #### 默认后端：Ed25519 + 加密密钥文件
 
@@ -378,6 +378,8 @@ GPG 仍是**分发签名**（sign-skill.sh → trusted-keys → verifier.py）�
 - 已有对应 scanner 结果且文件未变时跳过该 scanner。
 
 `scan --all` 对所有发现的 Skill 执行相同补齐逻辑；若没有任何 scanner 需要执行，不写 manifest，只报告 `noop`。对于上述只读已打包系统 Skill，批量路径不运行 scanner，也不写入逐 Skill manifest、snapshot、`.skill-meta` 状态或配置，返回 `status=skipped`、`reasonCode=readonly_system_skill`、`persisted=false`。`skipped` 是运行状态，不是六种完整性状态之一，不表示 `pass`，也不构成认证；它本身不使批量命令失败，只有实际 `status=error` 才使批量命令返回退出码 1。全局密钥初始化行为不变。`--force` 会强制重跑其它请求 scanner 并重签 manifest。
+
+`scan --all` 和默认 `init` baseline 对 raw 用户默认根 `$XDG_DATA_HOME/anolisa/skills/`（回退为 `~/.local/share/anolisa/skills/`）的直接子目录也应用批量跳过：仅当来源为 host、未被 `managedSkillDirs` 覆盖且实际账本写入目标不可写时，返回 `status=skipped`、`reasonCode=readonly_default_skill`、`persisted=false`，不运行 scanner、不写账本或自动纳管。已纳管的用户 Skill、显式扫描、SkillFS backing 和 resolver 错误仍保持原有错误语义；可写目录正常扫描。已有 `.skill-meta` 时检查该目录的写入权限，否则检查 Skill 根目录。
 
 新版本只会链接历史中最近的完整可信 artifact：候选的 schema、`versionId`/文件名、`skillName`、manifestHash、签名与 snapshot 必须全部匹配。版本号从该可信父版本之后选择首个未被版本 JSON 或 snapshot 占用的编号；没有可信父版本时从 `v000001` 起选择首个空槽。这样既不覆盖损坏或部分写入的证据，也不允许无效 latest 或孤立的超大编号控制恢复可用性。无可信父版本时两个 previous 字段均为 `null`；只有可信父版本的 `always_allow` 决策可以继承。
 

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
@@ -1600,28 +1600,150 @@ def test_readonly_system_scan_all_skips_while_read_commands_still_run(
     assert not (system_skill / ".skill-meta").exists()
 
 
-def test_scan_all_preserves_mixed_skip_success_and_error_exit_codes(
-    ws,
-    monkeypatch,
+@pytest.mark.parametrize("command", [["scan", "--all"], ["init"]])
+@pytest.mark.parametrize("existing_meta", [False, True])
+def test_readonly_raw_user_batch_skips_but_explicit_and_managed_scans_fail(
+    tmp_path, monkeypatch, command, existing_meta
 ):
-    """Skipped system Skills do not mask writable success or real user errors."""
-    case_root = ws.root / "mixed_system_scan"
-    system_root = case_root / "system-skills"
+    """Exercise real write permissions at the skill root and existing metadata."""
+    data_root = tmp_path / "xdg_data"
+    skill = make_skill(data_root / "anolisa/skills", "weather", {})
+    target = skill / ".skill-meta" if existing_meta else skill
+    target.mkdir(exist_ok=True)
+    env = {
+        "HOME": str(tmp_path / "home"),
+        "XDG_CONFIG_HOME": str(tmp_path / "xdg_config"),
+        "XDG_DATA_HOME": str(data_root),
+        "XDG_RUNTIME_DIR": str(tmp_path / "runtime"),
+    }
+    config = {"enableDefaultSkillDirs": True, "managedSkillDirs": []}
+    write_skill_ledger_config(tmp_path, config)
+    config_path = tmp_path / "xdg_config/agent-sec/skill-ledger/config.json"
+    config_before = config_path.read_bytes()
+    tree_before = snapshot_file_tree(skill)
+    monkeypatch.setattr(config_module, "DEFAULT_SKILL_DIRS", [])
+
+    target.chmod(0o555)
+    try:
+        if os.access(target, os.W_OK):
+            pytest.skip("requires a user subject to directory write permissions")
+        result = run_skill_ledger(command, env_extra=env)
+        assert result.returncode == 0, result.stdout + result.stderr
+        out = parse_json_output(result.stdout)
+        assert out["keyCreated"] is True
+        assert out["results"] == [
+            {
+                "canonicalSkillDir": str(skill),
+                "skillName": "weather",
+                "status": "skipped",
+                "reasonCode": "readonly_default_skill",
+                "persisted": False,
+            }
+        ]
+        assert config_path.read_bytes() == config_before
+        assert snapshot_file_tree(skill) == tree_before
+        assert (skill / ".skill-meta").exists() == existing_meta
+
+        explicit = run_skill_ledger(["scan", str(skill)], env_extra=env)
+        assert explicit.returncode == 1
+
+        config["enableDefaultSkillDirs"] = False
+        for entry in (str(skill), str(skill.parent) + "/*"):
+            config["managedSkillDirs"] = [entry]
+            write_skill_ledger_config(tmp_path, config)
+            managed = run_skill_ledger(command, env_extra=env)
+            assert managed.returncode == 1
+            assert parse_json_output(managed.stdout)["results"][0]["status"] == "error"
+            assert config_path.read_bytes() == json.dumps(config).encode()
+            assert snapshot_file_tree(skill) == tree_before
+    finally:
+        target.chmod(0o755)
+
+
+@pytest.mark.parametrize("command", [["scan", "--all"], ["init"]])
+@pytest.mark.parametrize("readonly_first", [False, True])
+@pytest.mark.parametrize("existing_meta", [False, True])
+def test_raw_user_mixed_readonly_batch_remains_skipped_on_repeat(
+    tmp_path, monkeypatch, command, readonly_first, existing_meta
+):
+    """Remembering a writable Skill must not manage its read-only sibling."""
+    data_root = tmp_path / "data"
+    root = data_root / "anolisa/skills"
+    readonly = make_skill(root, "a-readonly" if readonly_first else "z-readonly", {})
+    writable = make_skill(root, "z-writable" if readonly_first else "a-writable", {})
+    target = readonly / ".skill-meta" if existing_meta else readonly
+    target.mkdir(exist_ok=True)
+    env = {
+        "HOME": str(tmp_path / "home"),
+        "XDG_CONFIG_HOME": str(tmp_path / "xdg_config"),
+        "XDG_DATA_HOME": str(data_root),
+        "XDG_RUNTIME_DIR": str(tmp_path / "runtime"),
+        "AGENT_SEC_DATA_DIR": str(tmp_path / "events"),
+    }
+    write_skill_ledger_config(tmp_path, {"managedSkillDirs": []})
+    config_path = tmp_path / "xdg_config/agent-sec/skill-ledger/config.json"
+    monkeypatch.setattr(config_module, "DEFAULT_SKILL_DIRS", [])
+    tree_before = snapshot_file_tree(readonly)
+    target.chmod(0o555)
+    try:
+        if os.access(target, os.W_OK):
+            pytest.skip("requires a user subject to directory write permissions")
+        for writable_status in ("scanned", "noop"):
+            result = run_skill_ledger(
+                [*command, "--scanners", "code-scanner"], env_extra=env
+            )
+            assert result.returncode == 0, result.stdout + result.stderr
+            items = parse_json_output(result.stdout)["results"]
+            assert [item["skillName"] for item in items] == sorted(
+                [readonly.name, writable.name]
+            )
+            by_name = {item["skillName"]: item for item in items}
+            assert by_name[readonly.name] == {
+                "canonicalSkillDir": str(readonly),
+                "skillName": readonly.name,
+                "status": "skipped",
+                "reasonCode": "readonly_default_skill",
+                "persisted": False,
+            }
+            assert by_name[writable.name]["status"] == writable_status
+            assert json.loads(config_path.read_text())["managedSkillDirs"] == [
+                str(writable)
+            ]
+            assert (writable / ".skill-meta/latest.json").is_file()
+            assert snapshot_file_tree(readonly) == tree_before
+            assert (readonly / ".skill-meta").exists() == existing_meta
+    finally:
+        target.chmod(0o755)
+
+
+@pytest.mark.parametrize("raw_user", [False, True])
+def test_scan_all_preserves_mixed_skip_success_and_error_exit_codes(
+    tmp_path,
+    monkeypatch,
+    raw_user,
+):
+    """Skipped defaults do not mask writable success or real user errors."""
+    case_root = tmp_path / "mixed_system_scan"
+    data_root = case_root / "xdg_data"
+    system_root = (
+        data_root / "anolisa/skills" if raw_user else case_root / "system-skills"
+    )
     system_skill = make_skill(system_root, "system", {"main.py": "print('ok')\n"})
     user_skill = make_skill(
         case_root / "user-skills",
         "user",
         {"main.py": "print('ok')\n"},
     )
-    data_root = case_root / "xdg_data"
     runtime_root = case_root / "runtime"
-    data_root.mkdir(parents=True)
+    data_root.mkdir(parents=True, exist_ok=True)
     runtime_root.mkdir()
     write_skill_ledger_config(
         case_root,
         {
-            "enableDefaultSkillDirs": False,
-            "managedSkillDirs": [str(system_skill), str(user_skill)],
+            "enableDefaultSkillDirs": raw_user,
+            "managedSkillDirs": (
+                [str(user_skill)] if raw_user else [str(system_skill), str(user_skill)]
+            ),
         },
     )
     env = {
@@ -1629,11 +1751,9 @@ def test_scan_all_preserves_mixed_skip_success_and_error_exit_codes(
         "XDG_DATA_HOME": str(data_root),
         "XDG_RUNTIME_DIR": str(runtime_root),
     }
-    monkeypatch.setattr(
-        config_module,
-        "DEFAULT_SYSTEM_SKILL_ROOTS",
-        (system_root,),
-    )
+    if not raw_user:
+        monkeypatch.setattr(config_module, "DEFAULT_SYSTEM_SKILL_ROOTS", (system_root,))
+    monkeypatch.setattr(config_module, "DEFAULT_SKILL_DIRS", [])
     monkeypatch.setattr(
         "agent_sec_cli.skill_ledger.core.certifier.ledger_update_access",
         lambda _root: (False, "read-only"),

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_canonical_workflows.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_canonical_workflows.py
@@ -201,15 +201,18 @@ def test_batch_error_exposes_only_canonical_path(
     assert str(live) not in json.dumps(result)
 
 
-def test_readonly_host_system_skill_is_skipped_without_skill_directory_writes(
+@pytest.mark.parametrize("root_name", ["system-skills", "data/anolisa/skills"])
+def test_readonly_host_default_skill_is_skipped_without_skill_directory_writes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    root_name: str,
 ) -> None:
-    system_root = tmp_path / "system-skills"
+    system_root = tmp_path / root_name
     skill = _make_skill(system_root, "weather", "weather")
     root = ResolvedSkillRoot(skill, skill, "host")
     backend = _backend(tmp_path, monkeypatch)
-    _set_system_root(system_root, monkeypatch)
+    if root_name == "system-skills":
+        _set_system_root(system_root, monkeypatch)
     scanner_called = False
     remember_called = False
 
@@ -245,7 +248,11 @@ def test_readonly_host_system_skill_is_skipped_without_skill_directory_writes(
             "canonicalSkillDir": str(skill),
             "skillName": "weather",
             "status": "skipped",
-            "reasonCode": "readonly_system_skill",
+            "reasonCode": (
+                "readonly_system_skill"
+                if root_name == "system-skills"
+                else "readonly_default_skill"
+            ),
             "persisted": False,
         }
     ]
@@ -278,15 +285,18 @@ def test_explicit_readonly_host_system_scan_stays_strict(
     ).exists()
 
 
-def test_writable_host_system_skill_is_scanned(
+@pytest.mark.parametrize("root_name", ["system-skills", "data/anolisa/skills"])
+def test_writable_host_default_skill_is_scanned(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    root_name: str,
 ) -> None:
-    system_root = tmp_path / "system-skills"
+    system_root = tmp_path / root_name
     skill = _make_skill(system_root, "weather", "weather")
     root = ResolvedSkillRoot(skill, skill, "host")
     backend = _backend(tmp_path, monkeypatch)
-    _set_system_root(system_root, monkeypatch)
+    if root_name == "system-skills":
+        _set_system_root(system_root, monkeypatch)
     monkeypatch.setattr(certifier_core, "resolve_skill_root", lambda _path: root)
     monkeypatch.setattr(
         certifier_core,
@@ -306,6 +316,8 @@ def test_writable_host_system_skill_is_scanned(
     assert result[0]["status"] == "scanned"
     assert result[0]["scanStatus"] == "pass"
     assert (skill / ".skill-meta" / "latest.json").is_file()
+    config_path = tmp_path / "config/agent-sec/skill-ledger/config.json"
+    assert json.loads(config_path.read_text())["managedSkillDirs"] == [str(skill)]
 
 
 def test_writable_skillfs_backing_under_system_path_is_scanned(
@@ -334,17 +346,23 @@ def test_writable_skillfs_backing_under_system_path_is_scanned(
     assert not canonical.exists()
 
 
-def test_readonly_skillfs_backing_is_not_downgraded_to_system_skip(
+@pytest.mark.parametrize("root_name", ["system-skills", "data/anolisa/skills"])
+def test_readonly_skillfs_backing_is_not_downgraded_to_default_skip(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    root_name: str,
 ) -> None:
-    system_root = tmp_path / "system-skills"
+    system_root = tmp_path / root_name
     canonical = system_root / "weather"
     live = _make_skill(tmp_path / "backing", "weather", "weather")
     root = ResolvedSkillRoot(canonical, live, "skillfs")
     backend = _backend(tmp_path, monkeypatch)
-    _set_system_root(system_root, monkeypatch)
+    if root_name == "system-skills":
+        _set_system_root(system_root, monkeypatch)
     monkeypatch.setattr(certifier_core, "resolve_skill_root", lambda _path: root)
+    monkeypatch.setattr(
+        certifier_core, "ledger_update_access", lambda _root: (False, "read-only")
+    )
     monkeypatch.setattr(
         certifier_core,
         "_auto_invoke_scanners",
@@ -368,14 +386,30 @@ def test_readonly_skillfs_backing_is_not_downgraded_to_system_skip(
     assert "backing ledger is read-only" in result[0]["error"]
 
 
-def test_readonly_user_skill_is_not_downgraded_to_system_skip(
+@pytest.mark.parametrize(
+    ("root_name", "managed_suffix"),
+    [
+        ("user-skills", None),
+        ("data/anolisa/skills", "weather"),
+        ("data/anolisa/skills", "*"),
+        ("data/anolisa/skills", "**"),
+    ],
+)
+def test_readonly_managed_or_other_user_skill_is_not_downgraded_to_default_skip(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    root_name: str,
+    managed_suffix: str | None,
 ) -> None:
-    skill = _make_skill(tmp_path / "user-skills", "weather", "weather")
+    skill = _make_skill(tmp_path / root_name, "weather", "weather")
     root = ResolvedSkillRoot(skill, skill, "host")
     backend = _backend(tmp_path, monkeypatch)
+    if managed_suffix is not None:
+        _write_config(tmp_path, [skill.parent / managed_suffix])
     monkeypatch.setattr(certifier_core, "resolve_skill_root", lambda _path: root)
+    monkeypatch.setattr(
+        certifier_core, "ledger_update_access", lambda _root: (False, "read-only")
+    )
     monkeypatch.setattr(
         certifier_core,
         "_auto_invoke_scanners",

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_config.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_config.py
@@ -28,6 +28,7 @@ from agent_sec_cli.skill_ledger.config import (
     effective_skill_dir_entries,
     is_covered,
     is_default_system_skill_dir,
+    is_default_user_skill_dir,
     is_managed_covered,
     load_config,
     remember_skill_dir,
@@ -567,6 +568,41 @@ class TestIsCovered(unittest.TestCase):
         self.assertTrue(is_managed_covered(hidden, config))
 
 
+def test_raw_user_remember_keeps_individual_paths(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    for custom_xdg in (False, True):
+        data_root = tmp_path / "data" if custom_xdg else home / ".local/share"
+        if custom_xdg:
+            monkeypatch.setenv("XDG_DATA_HOME", str(data_root))
+        else:
+            monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(data_root / "config"))
+        root = data_root / "anolisa/skills"
+        first, sibling, later = [root / name for name in ("first", "sibling", "later")]
+        for skill in (first, sibling):
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text("---\nname: test\n---\n")
+        config_module.save_config({"managedSkillDirs": []})
+
+        assert remember_skill_dir(first) == str(first)
+        assert not is_managed_covered(sibling)
+        later.mkdir()
+        (later / "SKILL.md").write_text("---\nname: test\n---\n")
+        assert remember_skill_dir(later) == str(later)
+        assert load_config()["managedSkillDirs"] == [str(first), str(later)]
+        assert not is_managed_covered(sibling)
+        before = config_module.config_path().read_bytes()
+        assert remember_skill_dir(first) is None
+        assert config_module.config_path().read_bytes() == before
+
+        for entry in (str(first), str(root) + "/*", str(root) + "/**"):
+            config_module.save_config({"managedSkillDirs": [entry]})
+            before = config_module.config_path().read_bytes()
+            assert remember_skill_dir(first) is None
+            assert config_module.config_path().read_bytes() == before
+
+
 def test_raw_user_defaults_follow_xdg_and_default_opt_out(tmp_path, monkeypatch):
     home = tmp_path / "home"
     monkeypatch.setenv("HOME", str(home))
@@ -592,6 +628,11 @@ def test_raw_user_defaults_follow_xdg_and_default_opt_out(tmp_path, monkeypatch)
         (skill / "SKILL.md").write_text("---\nname: raw-probe\n---\n")
         assert skill in resolve_skill_dirs({"enableDefaultSkillDirs": True})
         assert not resolve_skill_dirs({"enableDefaultSkillDirs": False})
+        assert is_default_user_skill_dir(skill)
+        assert not is_default_user_skill_dir(skill.parent)
+        assert not is_default_user_skill_dir(skill / "nested")
+        assert not is_default_user_skill_dir(root / "anolisa/skills-evil/raw-probe")
+        assert not is_default_system_skill_dir(skill)
 
 
 def test_raw_user_defaults_normalize_leading_slashes(tmp_path, monkeypatch):
@@ -608,6 +649,7 @@ def test_raw_user_defaults_normalize_leading_slashes(tmp_path, monkeypatch):
         (skill / "SKILL.md").write_text("---\nname: raw-probe\n---\n")
         assert skill in resolve_skill_dirs(config)
         assert is_covered(skill, config)
+        assert is_default_user_skill_dir(skill)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

#3146 added raw user skills to default discovery. Images with read-only raw skills then fail during `init` or `scan --all` when Ledger tries to create `.skill-meta`. Auto-remembering a writable sibling as `parent/*` can also make the read-only skill appear managed and disable the batch skip on the same or next run.

## What changed

Extend the existing batch guard to host-backed, unmanaged, read-only skills directly under the raw user default root, resolved through the existing XDG helper. Return `status=skipped`, `reasonCode=readonly_default_skill`, and `persisted=false` before scanning or writing skill metadata. Auto-remember raw user skills by individual path so successful writable siblings do not expand managed coverage; other roots keep their existing registration rules.

## Related issue

no-issue: focused follow-up regression fix for the raw user discovery added by #3146.

## User / Agent impact

Read-only raw defaults no longer fail an otherwise successful batch, including mixed writable/read-only siblings and repeated runs in either discovery order. Writable skills scan normally; explicit scans and managed user skills retain write errors. Skips do not produce an attestation or activation state.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The skip is limited to exact default-root children with non-writable Ledger state. Existing `readonly_system_skill` results, SkillFS/resolver errors, and real scan/write errors retain their behavior. No new CLI option, configuration field, dependency, manifest format, or activation/SkillFS behavior is introduced.

Existing `managedSkillDirs` patterns are preserved because configuration does not record whether a pattern was user-configured or auto-generated. A pre-existing raw-root glob therefore remains managed and strict. After confirming unintended coverage, users can replace that glob with individual paths they intend to manage; there is no automatic configuration migration.

## Validation

Python 3.11.6 on macOS: **263 passed, 3 subtests passed**. The nine new regression cases were first run against the previous implementation and failed as expected.

```bash
cd src/agent-sec-core
PYTHONPATH=agent-sec-cli/src:tests/unit-test python -m pytest -q \
  tests/unit-test/skill_ledger/{test_config,test_canonical_workflows,test_live_root}.py \
  tests/unit-test/security_middleware/backends/test_skill_ledger_backend.py \
  tests/integration-test/skill-ledger/test_skill_ledger_integration.py
```

- `make python-code-pretty`, `git diff --check`, and `bash scripts/docs-lint.sh` passed. Incremental Ruff found no new findings; two pre-existing test import-order findings remain unchanged.
- CLI regression tests cover `init` and `scan --all`, both sibling orders, read-only skill roots and existing metadata directories, two consecutive runs, exact-path registration, untouched skipped content, and strict explicit/exact-managed/glob-managed failures. Configuration tests also cover HOME fallback, custom XDG roots, later sibling additions, repeated registration, and preservation of existing patterns.
- Native Alibaba Cloud Linux 4.0.4, kernel 6.6.102, Python 3.11.6, UID/GID 65534: **27 CLI expectations passed**. This includes 19 checks of the `c8a2339ca023ba9e5280e263169d6a56fc3201d4` commit and 8 counterfactual checks reproducing the review issue on `f2a994fd5`.
- Real bind/remount read-only fixtures cover the HOME default skill subtree and a custom-XDG existing `.skill-meta`. Root and non-root write probes return `EROFS`. All 16 repeated mixed-directory runs on the fix exit 0 with stable skips; three strict scans retain `EROFS` failures.
- All 14 temporary mounts and the remote run directory were removed. Checked installation/configuration and host mount baselines remained unchanged. This validates source CLI behavior, not RPM delivery, SkillFS/FUSE, or Agent integration.

The subsequent `ee494fe65` update only trims README detail. Production code and tests are identical to the Linux-tested revision; documentation lint and diff checks passed.

## Documentation and rollback

README summaries cover the batch skip behavior. Individual-path auto-registration and existing-pattern details are documented in both user-guide languages and the existing Ledger design contract. Revert this commit to restore previous behavior. The change adds no stored-state format migration; rollback preserves already-recorded individual paths.
