### PR TITLE
docs(anolisa): clarify os_version metadata

### DIFF
--- a/src/anolisa/crates/anolisa-core/src/distribution.rs
+++ b/src/anolisa/crates/anolisa-core/src/distribution.rs
@@ -102,10 +102,14 @@ pub struct DistributionEntry {
     /// External signature URL (e.g. `*.sig` companion file).
     #[serde(default)]
     pub signature_url: Option<String>,
-    /// OS version constraint (e.g. `">=4"`, `"22.04"`).
+    /// Metadata retained for compatibility with existing indexes; not used
+    /// to filter or select artifact versions.
     #[serde(default)]
     pub os_version: Option<String>,
-    /// Sibling components this artifact depends on (by component name).
+    /// Dependency metadata retained for compatibility with existing indexes;
+    /// not used by dependency resolution or installation. Raw runtime
+    /// dependencies belong in `[[component.dependencies]]` in the artifact's
+    /// `component.toml`.
     #[serde(default)]
     pub dependencies: Vec<String>,
 }
@@ -405,6 +409,10 @@ impl DistributionIndex {
     }
 
     /// Resolve a query to a single matching entry.
+    ///
+    /// `os_version` is compatibility metadata and does not participate in
+    /// matching. Raw runtime dependencies are declared in the artifact's
+    /// `component.toml` and handled by the install workflow.
     ///
     /// Filter rules (in order):
     ///   1. `component` exact match.

--- a/src/anolisa/templates/distribution-index.toml
+++ b/src/anolisa/templates/distribution-index.toml
@@ -9,6 +9,12 @@
 # `file`, `binary`). Legacy `tar.gz` / `tar` strings are still accepted by the
 # loader but normalized to `tar_gz`; new templates should use `tar_gz`.
 #
+# Do not use `os_version` to express installation requirements: it is retained
+# for compatibility with existing indexes but does not participate in matching.
+# Raw runtime dependencies belong in `[[component.dependencies]]` in the
+# artifact's `component.toml` and are handled by the install workflow. OS,
+# architecture, and other target selectors still apply.
+#
 # IMPORTANT: This file is a TEMPLATE. Every value wrapped in
 # `<REPLACE_WITH_...>` (and every `example.invalid` URL) is a placeholder
 # meant to be substituted before the file is published as an actual
@@ -37,7 +43,6 @@ artifact_type = "rpm"             # rpm | deb | tar_gz | zip | oci | file | bina
 backend = "github-release"        # github-release | yum-repo | apt-repo | aliyun-oss | internal-registry | local-file
 url = "https://example.invalid/<REPLACE_WITH_PATH>/agentsight-0.5.0.alinux4.x86_64.rpm"
 os = "alinux"
-os_version = ">=4"
 arch = "x86_64"
 libc = "glibc"
 pkg_base = "rpm"
@@ -45,7 +50,6 @@ install_modes = ["system"]
 sha256 = "<REPLACE_WITH_SHA256>"
 signature_url = "https://example.invalid/<REPLACE_WITH_PATH>/agentsight-0.5.0.alinux4.x86_64.rpm.sig"
 size = 12345678
-dependencies = ["kernel-headers"]
 
 # -----------------------------------------------------------------------------
 # agentsight 0.5.0 — generic Linux x86_64 tarball (user + system mode)
@@ -66,7 +70,6 @@ install_modes = ["user", "system"]
 sha256 = "<REPLACE_WITH_SHA256>"
 signature_url = "https://example.invalid/<REPLACE_WITH_PATH>/agentsight-0.5.0-linux-x86_64.tar.gz.sig"
 size = 9876543
-dependencies = []
 
 # -----------------------------------------------------------------------------
 # agentsight 0.5.0 — macOS aarch64 tarball (user mode only)
@@ -86,4 +89,3 @@ install_modes = ["user"]
 sha256 = "<REPLACE_WITH_SHA256>"
 signature_url = "https://example.invalid/<REPLACE_WITH_PATH>/agentsight-0.5.0-macos-aarch64.tar.gz.sig"
 size = 8765432
-dependencies = []


### PR DESCRIPTION
## Why

The distribution index template and field documentation imply that `os_version` gates artifact selection, although the resolver does not apply it. Publishers can therefore mistake compatibility metadata for an enforced installation requirement.

## What changed

Clarify that `os_version` and index-level `dependencies` are retained as compatibility metadata: `os_version` does not participate in matching, and index dependencies are not used by dependency resolution or installation. Remove the misleading `os_version` and index-level `dependencies` examples, and point raw publishers to `[[component.dependencies]]` in the artifact's `component.toml` for runtime dependency declarations handled by the install workflow.

## Related issue

Related to #3138. This PR corrects the documented contract only; the issue remains open for discussion of selector semantics. It does not implement distribution-version gating or reject existing indexes.

## User / Agent impact

Publishers are no longer instructed to rely on `os_version` to restrict installation. Existing OS, architecture, and other target selectors continue to apply.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: only comments and the template change. The public field, serialization, parsing, resolution, and installation behavior remain unchanged. Runtime dependency handling retains its existing policy, including non-blocking warnings for manual-only dependencies in system mode.

## Validation

Linux x86_64; Rust compiler wrappers disabled because sccache is unavailable in the sandbox.

- `cargo test -p anolisa-core --lib distribution::tests --locked`: 18 passed, including template loading.
- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`: run with local-loopback access for HTTP fixtures.
- `cargo doc --workspace --no-deps --locked`
- `git diff --check`
- Inspected all three template entries: none declares index-level `dependencies`; the retained field defaults to an empty list.

## Documentation and rollback

Updated the distribution index rustdoc and template comments; removed the unsupported gating and index dependency examples. No version or changelog change is needed. Revert this commit to restore the previous wording and example; no data migration is involved.
