### PR TITLE
fix(sight): honor RUST_LOG regex in main logger

### DIFF
--- a/src/agentsight/src/logging.rs
+++ b/src/agentsight/src/logging.rs
@@ -127,7 +127,14 @@ impl Log for AgentsightLogger {
     }
 
     fn log(&self, record: &Record) {
-        if !self.enabled(record.metadata()) {
+        // `matches` (not just `enabled`) so a `RUST_LOG=level/regex` message
+        // filter is honored.
+        if !self
+            .filter
+            .lock()
+            .expect("log filter lock poisoned")
+            .matches(record)
+        {
             return;
         }
 
@@ -245,6 +252,42 @@ mod tests {
         // Call again — both are still poisoned (poison flag persists), so
         // both unwrap_or_else paths are exercised a second time
         logger.reconfigure(default_filter(true), open_log_writer(None));
+    }
+
+    /// `RUST_LOG=level/regex` must filter on the formatted message, not only
+    /// on record metadata.
+    #[test]
+    fn log_applies_message_regex_filter() {
+        let mut builder = env_filter::Builder::new();
+        builder
+            .try_parse("info/listening")
+            .expect("fixture filter should parse");
+        let filter = builder.build();
+
+        let dir = std::env::temp_dir().join(format!("agentsight-log-regex-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("tempdir");
+        let path = dir.join("regex.log");
+
+        let logger = AgentsightLogger::new(filter, open_log_writer(path.to_str()));
+        for message in [
+            "agentsight-enforcer listening on socket",
+            "unrelated chatter",
+        ] {
+            logger.log(
+                &Record::builder()
+                    .args(format_args!("{message}"))
+                    .level(log::Level::Info)
+                    .target("test")
+                    .build(),
+            );
+        }
+        logger.flush();
+
+        let contents = std::fs::read_to_string(&path).expect("read log");
+        assert!(contents.contains("listening on socket"));
+        assert!(!contents.contains("unrelated chatter"));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
## Why

主服务自研 logger（`src/logging.rs` 的 `AgentsightLogger`）在 `log()` 中只调用 `Filter::enabled(metadata)`——该方法仅检查 level/target，不评估 `RUST_LOG=level/regex` 中的消息 regex（env_filter 1.0.1 源码确认：`matches(record)` 才会对格式化后的消息做 regex 匹配）。结果是 regex 部分被静默忽略，匹配级别内的日志全量输出。

来源：#3159 的 Codex review 在 enforcer logger 上指出同类问题；enforcer 已在该 PR 修复，主服务为 pre-existing 同类缺陷，按约定单独成 PR。

## What changed

- `AgentsightLogger::log()` 改用 `filter.lock().expect(...).matches(record)`（保留既有 poison 语义：`enabled()` 本就 `expect`，不引入行为变化）
- 新增判别性单测 `log_applies_message_regex_filter`：构造 `info/listening` filter，分别 log 匹配与不匹配两条 record，断言仅匹配行落盘

## Related issue

no-issue: one-line correctness fix found via Codex review on #3159

## User / Agent impact

`RUST_LOG=level/regex` 的消息过滤对 trace/serve 主进程生效（此前 regex 被静默忽略）。无 regex 时行为与性能不变（`matches` 在无 regex 配置时短路）。

## Risk and compatibility

Low risk：仅修正过滤判定路径；日志格式、默认级别、poison 恢复语义均不变。

## Validation

- ECS 门禁（rustc/clippy 1.89.0，与 CI 对齐）：`cargo fmt --all --check`、`cargo clippy --workspace --exclude ebpf-ifc-engine --exclude actplane-ifc-compiler --all-targets -- -D warnings`（CI 原命令）、`cargo test -p agentsight --lib logging::`（5/5 通过）
- 判别性反证：将 `matches(record)` 换回 `enabled(record.metadata())` 后新测试必失败（两条消息均落盘），恢复后通过；ECS 与提交版 logging.rs sha256 一致

## Documentation and rollback

- 无文档变更：该修复使行为对齐既有 `RUST_LOG` 文档语义
- 回滚：revert 本 commit 即恢复旧行为
