### PR TITLE
fix(deps): install Node.js for memory builds

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -53,14 +53,14 @@ component.
 
 | Need | Source of truth |
 |------|-----------------|
-| Node.js | `src/copilot-shell/package.json` requires Node.js `>=20.0.0`; npm is also used by the agentsight, agent-sec-core, tokenless, and ws-ckpt plugin builds. |
+| Node.js | `src/copilot-shell/package.json` requires Node.js `>=20.0.0`; npm is also used by the agent-memory, agentsight, agent-sec-core, tokenless, and ws-ckpt plugin builds. |
 | Python and uv | `src/agent-sec-core/agent-sec-cli/pyproject.toml` requires Python `==3.11.6`; use `uv` for that project. Do not replace this with a repository-wide Python minimum. |
 | Rust | `src/agent-sec-core/linux-sandbox/rust-toolchain.toml` pins `1.93.0`; `src/anolisa/rust-toolchain.toml` pins `1.93.1`; `src/blaze/rust-toolchain.toml` pins `1.88.0`; `src/cosh-ng/rust-toolchain.toml` follows `stable`. Other components use the `rust-version` in their `Cargo.toml` when one is declared. |
 | cosh-ng | Linux source builds need `pkg-config` and OpenSSL development files. |
 | agent-sec-core | Linux sandbox runtime and integration checks may need bubblewrap, GnuPG, and `jq`. |
 | agentsight | Linux eBPF builds need clang, LLVM, libbpf and ELF development headers, kernel headers, and a BTF-enabled kernel. `make build-mac` builds the macOS local viewer without eBPF. |
 | tokenless | `just` is used to fetch and patch RTK; npm is needed for the OpenClaw plugin. |
-| agent-memory | Linux builds need CMake and libsystemd development headers. |
+| agent-memory | Linux builds need CMake and libsystemd development headers; npm builds the bundled OpenClaw adapter. |
 | SkillFS | FUSE 3 and `/dev/fuse` are needed for the smoke test; ordinary Cargo tests do not mount FUSE. |
 | ws-ckpt | Installing the daemon requires Linux systemd and root privileges. Its user-mode Makefile target intentionally does not install the service. |
 

--- a/docs/BUILDING_zh.md
+++ b/docs/BUILDING_zh.md
@@ -47,14 +47,14 @@ Linux-only 组件。
 
 | 需求 | 依据 |
 |------|------|
-| Node.js | `src/copilot-shell/package.json` 要求 Node.js `>=20.0.0`。agentsight、agent-sec-core、tokenless 和 ws-ckpt 的插件构建也会使用 npm。 |
+| Node.js | `src/copilot-shell/package.json` 要求 Node.js `>=20.0.0`。agent-memory、agentsight、agent-sec-core、tokenless 和 ws-ckpt 的插件构建也会使用 npm。 |
 | Python 和 uv | `src/agent-sec-core/agent-sec-cli/pyproject.toml` 要求 Python `==3.11.6`，该项目使用 `uv`。不要把它扩展成仓库级 Python 最低版本。 |
 | Rust | `src/agent-sec-core/linux-sandbox/rust-toolchain.toml` 固定 `1.93.0`；`src/anolisa/rust-toolchain.toml` 固定 `1.93.1`；`src/blaze/rust-toolchain.toml` 固定 `1.88.0`；`src/cosh-ng/rust-toolchain.toml` 跟随 `stable`。其他组件有 `rust-version` 时以各自 `Cargo.toml` 为准。 |
 | cosh-ng | Linux 源码构建需要 `pkg-config` 和 OpenSSL 开发文件。 |
 | agent-sec-core | Linux sandbox 运行和集成检查可能需要 bubblewrap、GnuPG 以及 `jq`。 |
 | agentsight | Linux eBPF 构建需要 clang、LLVM、libbpf 和 ELF 开发头文件、内核头文件，以及启用 BTF 的内核。`make build-mac` 构建不含 eBPF 的 macOS local viewer。 |
 | tokenless | `just` 用于获取并修补 RTK，OpenClaw plugin 构建需要 npm。 |
-| agent-memory | Linux 构建需要 CMake 和 libsystemd 开发头文件。 |
+| agent-memory | Linux 构建需要 CMake 和 libsystemd 开发头文件；内置的 OpenClaw adapter 由 npm 构建。 |
 | SkillFS | FUSE smoke test 需要 FUSE 3 和 `/dev/fuse`，普通 Cargo 测试不会挂载 FUSE。 |
 | ws-ckpt | 安装 daemon 需要 Linux systemd 和 root 权限。组件的 user-mode Makefile 目标会有意跳过 service 安装。 |
 

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -613,7 +613,7 @@ node_version_satisfies_on_path() {
 }
 
 install_node() {
-    step "Node.js (for copilot-shell)"
+    step "Node.js (for copilot-shell, agent-sec-core, agentsight, agent-memory)"
     local REQUIRED="20.0.0"
     local NVM_INSTALL_MAJOR="24"
 
@@ -631,12 +631,157 @@ install_node() {
         if [[ -s "$NVM_DIR/nvm.sh" ]]; then source "$NVM_DIR/nvm.sh"; fi
     }
 
+    _node_command_path() {
+        if [[ "$INSTALL_MODE" == "system" ]]; then
+            echo "$RUNTIME_SYSTEM_PATH"
+        else
+            echo "$PATH"
+        fi
+    }
+
+    _npm_ok() {
+        PATH="$(_node_command_path)" npm -v &>/dev/null
+    }
+
+    # Several distributions ship nodejs without npm, while the plugin builds
+    # (`build-openclaw-plugin`, copilot-shell, agentsight) call npm directly.
+    # A node-only toolchain therefore is not a ready Node.js setup.
+    #
+    # `nvm install-latest-npm` is *not* a way to recover a missing npm: it
+    # starts by running `npm --version` and aborts with "Unable to obtain npm
+    # version" when that fails (see nvm_install_latest_npm in nvm.sh), so it
+    # needs the very npm that is gone. `nvm install <version>` does not help
+    # either: for a version that is already installed it exits 1 with
+    # "<version> is already installed." before unpacking anything. An
+    # nvm-managed Node keeps npm in <prefix>/lib/node_modules/npm behind the
+    # <prefix>/bin/npm and <prefix>/bin/npx symlinks, so restore exactly that
+    # from the registry tarball instead. It needs only curl and tar (both
+    # already required by this script) plus a writable prefix, never sudo, and
+    # leaves the existing Node install untouched.
+    #
+    # The npm release each Node.js release shipped with is recorded in the
+    # dist index, so prefer that: it is by construction inside the engine range
+    # of the node binary next to it, whereas the registry `latest` tag lands
+    # npm 12 on Node 20, which npm itself reports as unsupported.
+    _bundled_npm_version() {
+        local mirror="${1%/}" node_version="$2"
+        curl -fsSL --connect-timeout 10 --max-time 60 "$mirror/index.json" \
+            | tr '{' '\n' | grep -F "\"version\":\"$node_version\"" \
+            | head -1 | grep -o '"npm":"[0-9][0-9.]*"' | head -1 \
+            | sed 's/.*"\([0-9][0-9.]*\)"/\1/' || true
+    }
+
+    _latest_npm_version() {
+        local registry="$1" version=""
+        version="$(curl -fsSL --connect-timeout 10 --max-time 30 \
+                "$registry/-/package/npm/dist-tags" \
+            | grep -o '"latest"[[:space:]]*:[[:space:]]*"[0-9][^"]*"' \
+            | head -1 | sed 's/.*"\([0-9][^"]*\)"$/\1/' || true)"
+        if [[ -z "$version" ]]; then
+            version="$(curl -fsSL --connect-timeout 10 --max-time 30 \
+                    "$registry/npm/latest" \
+                | grep -o '"version"[[:space:]]*:[[:space:]]*"[0-9][^"]*"' \
+                | head -1 | sed 's/.*"\([0-9][^"]*\)"$/\1/' || true)"
+        fi
+        echo "${version:-}"
+    }
+
+    _restore_nvm_npm() {
+        local node_bin="$1"
+        local prefix modules npm_dir registry node_version version archive
+        prefix="$(cd "$(dirname "$node_bin")/.." && pwd)" || return 1
+        modules="$prefix/lib/node_modules"
+        npm_dir="$modules/npm"
+        registry="${npm_config_registry:-$NPM_REGISTRY}"
+        registry="${registry%/}"
+        node_version="${prefix##*/}"
+
+        info "Restoring npm for the nvm-managed Node.js in $prefix ..."
+        version=""
+        if [[ "$node_version" == v[0-9]* ]]; then
+            version="$(_bundled_npm_version \
+                "${NVM_NODEJS_ORG_MIRROR:-https://nodejs.org/dist}" "$node_version")"
+            if [[ -n "$version" ]]; then
+                info "Node.js $node_version shipped with npm $version"
+            fi
+        fi
+        if [[ -z "$version" ]]; then
+            version="$(_latest_npm_version "$registry")"
+            if [[ -n "$version" ]]; then
+                warn "Could not read the Node.js dist index; using the registry's latest npm $version, which may not support Node.js $node_version"
+            fi
+        fi
+        if [[ -z "$version" ]]; then
+            warn "Could not resolve an npm version for Node.js $node_version"
+            return 1
+        fi
+
+        archive="$(mktemp "${TMPDIR:-/tmp}/anolisa-npm-XXXXXX.tgz")" || return 1
+        if ! curl -fsSL --connect-timeout 10 --max-time 180 \
+                -o "$archive" "$registry/npm/-/npm-$version.tgz"; then
+            warn "Could not download npm $version from $registry"
+            rm -f "$archive"
+            return 1
+        fi
+
+        # Strip the archive's package/ prefix without touching sibling global packages.
+        rm -rf "$npm_dir"
+        if ! mkdir -p "$npm_dir" || ! tar -xzf "$archive" --strip-components=1 -C "$npm_dir"; then
+            warn "Could not unpack npm $version into $npm_dir"
+            rm -f "$archive"
+            return 1
+        fi
+        rm -f "$archive"
+        chmod +x "$npm_dir/bin/npm-cli.js" "$npm_dir/bin/npx-cli.js" 2>/dev/null || true
+        ln -sfn "../lib/node_modules/npm/bin/npm-cli.js" "$prefix/bin/npm"
+        ln -sfn "../lib/node_modules/npm/bin/npx-cli.js" "$prefix/bin/npx"
+
+        if _npm_ok; then
+            ok "npm $(PATH="$(_node_command_path)" npm -v) restored for the nvm-managed Node.js"
+            return 0
+        fi
+        warn "Unpacked npm $version into $npm_dir but it still does not run"
+        return 1
+    }
+
+    _ensure_npm() {
+        if _npm_ok; then
+            return 0
+        fi
+        if [[ "$INSTALL_MODE" == "system" ]]; then
+            # System installs never mutate package state: the operator owns
+            # language runtimes. Components whose build actually calls npm
+            # (agent-memory) declare it as a source-build dependency record,
+            # where the preflight already turns a missing npm into a manual
+            # blocker, so this stays a warning here.
+            warn "npm was not found in $RUNTIME_SYSTEM_PATH; the plugin builds invoke npm"
+            return 0
+        fi
+        warn "Node.js is available but npm is missing; the plugin builds invoke npm"
+        local node_bin
+        node_bin="$(PATH="$(_node_command_path)" command -v node 2>/dev/null || true)"
+        if [[ -n "$node_bin" && "$node_bin" == "${NVM_DIR:-$HOME/.nvm}"/* ]]; then
+            _restore_nvm_npm "$node_bin" && return 0
+            warn "Could not restore npm inside ${NVM_DIR:-$HOME/.nvm}; falling back to the $npm_pkg package"
+        fi
+        info "Installing $npm_pkg via $PKG_BASE ..."
+        if [[ "$PKG_BASE" == "deb" ]]; then sudo apt-get update -y 2>/dev/null || true; fi
+        # shellcheck disable=SC2086
+        sudo $PKG_INSTALL $npm_pkg || true
+        if _npm_ok; then
+            ok "npm $(PATH="$(_node_command_path)" npm -v) installed"
+            return 0
+        fi
+        die "Failed to install npm; the plugin builds run npm install and npm run build. Install the '$npm_pkg' package, or reinstall the Node.js version your nvm manages, then retry"
+    }
+
     _configure_npm_mirror
 
     if _node_ver_ok; then
         local command_path="$PATH"
         [[ "$INSTALL_MODE" == "system" ]] && command_path="$RUNTIME_SYSTEM_PATH"
         ok "Node.js $(PATH="$command_path" node -v) already installed, skipping"
+        _ensure_npm
         return 0
     fi
 
@@ -657,6 +802,7 @@ install_node() {
             local command_path="$PATH"
             [[ "$INSTALL_MODE" == "system" ]] && command_path="$RUNTIME_SYSTEM_PATH"
             ok "Node.js $(PATH="$command_path" node -v) installed via package manager"
+            _ensure_npm
             return 0
         fi
         warn "Package manager install did not satisfy version requirement"
@@ -737,6 +883,7 @@ install_node() {
     _configure_npm_mirror
 
     if _node_ver_ok; then
+        _ensure_npm
         ok "Node.js $(node -v), npm $(npm -v)"
         info "nvm was sourced for this session; open a new terminal (or run: source ~/.bashrc) to persist"
     else
@@ -1411,8 +1558,8 @@ do_install_deps() {
                 echo "DRY-RUN: preflight platform capabilities before user dependency setup"
             fi
         fi
-        if want_component cosh || want_component sec-core || want_component sight; then
-            echo "DRY-RUN: check/install Node.js if needed"
+        if want_component cosh || want_component sec-core || want_component sight || want_component memory; then
+            echo "DRY-RUN: check/install Node.js and npm if needed"
         fi
         if want_component cosh || want_component sec-core || want_component cosh-ng || want_component sight; then
             echo "DRY-RUN: check/install build tools if needed"
@@ -1447,7 +1594,7 @@ do_install_deps() {
         fi
     fi
 
-    if want_component cosh || want_component sec-core || want_component sight; then
+    if want_component cosh || want_component sec-core || want_component sight || want_component memory; then
         install_node
     fi
 
@@ -1980,6 +2127,17 @@ source_build_runtime_dependencies() {
         case "$component" in
             sight)
                 echo 'sight|node|language-runtime|node --version|nodejs|nodejs||>=20|'
+                ;;
+            memory)
+                # `make install` bundles the OpenClaw adapter from source
+                # (npm install + esbuild), so Node.js is a source-build
+                # requirement even though the installed MCP server itself is
+                # a Rust binary that never shells out to node.
+                echo 'memory|node|language-runtime|node --version|nodejs|nodejs||>=20|'
+                # npm is a separate package on several distributions and
+                # `build-openclaw-plugin` calls it directly, so a node-only
+                # toolchain must not pass the source-build preflight.
+                echo 'memory|npm|language-runtime|npm --version|npm|npm|||'
                 ;;
         esac
     done < <(runtime_install_components)

--- a/src/agent-memory/README.md
+++ b/src/agent-memory/README.md
@@ -81,6 +81,7 @@ Profile gating (basic/advanced/expert) controls tool visibility per deployment.
 
 - Linux (x86_64 / aarch64)
 - Rust ≥ 1.85 (for source build)
+- Node.js ≥ 20 and npm (for source build — bundles the OpenClaw adapter)
 - Optional: embedding provider (OpenAI or Ollama) for vector search
 
 ## License

--- a/src/agent-memory/README_zh.md
+++ b/src/agent-memory/README_zh.md
@@ -54,6 +54,13 @@ sudo yum install agent-memory
 - **Tier C**（7 工具）：治理（快照、版本控制、聚合）
 - **主权**（13 工具）：关于、遗忘、同意、导入导出、任务、梦境合成
 
+## 环境要求
+
+- Linux（x86_64 / aarch64）
+- Rust ≥ 1.85（源码构建）
+- Node.js ≥ 20 与 npm（源码构建 —— 打包内置的 OpenClaw adapter）
+- 可选：用于向量检索的 embedding 提供方（OpenAI 或 Ollama）
+
 ## 许可证
 
 Apache License 2.0 — 详见 [LICENSE](LICENSE)。

--- a/tests/test-build-all-runtime-deps.sh
+++ b/tests/test-build-all-runtime-deps.sh
@@ -124,7 +124,7 @@ test_manifest_parser_covers_component_dependencies() {
     assert_contains "$output" 'sight|ebpf-btf|platform-capability||||btf||5.8'
     [[ "$(wc -l < "$output")" -eq 14 ]] || fail "unexpected manifest dependency count"
 
-    local source_dependency
+    local source_dependency expected
     COMPONENTS=(cosh-ng)
     source_dependency="$(source_build_runtime_dependencies)"
     [[ -z "$source_dependency" ]] || \
@@ -146,6 +146,14 @@ test_manifest_parser_covers_component_dependencies() {
     [[ "$source_dependency" == \
         'sight|node|language-runtime|node --version|nodejs|nodejs||>=20|' ]] || \
         fail "agentsight source Node dependency was not collected"
+
+    COMPONENTS=(memory)
+    source_dependency="$(source_build_runtime_dependencies)"
+    expected="$(printf '%s\n%s' \
+        'memory|node|language-runtime|node --version|nodejs|nodejs||>=20|' \
+        'memory|npm|language-runtime|npm --version|npm|npm|||')"
+    [[ "$source_dependency" == "$expected" ]] || \
+        fail "agent-memory source Node/npm dependencies were not collected"
 }
 
 test_user_skips_ws_ckpt_noop_install_dependencies() {
@@ -785,6 +793,318 @@ test_dry_run_skips_host_preflight() {
     (( preflight_line < install_line )) || fail "dry-run listed install before preflight"
 }
 
+test_memory_source_build_sets_up_node() {
+    reset_preflight_stubs
+    COMPONENTS=(memory)
+    TEST_DEPENDENCIES=(
+        'memory|node|language-runtime|node --version|nodejs|nodejs||>=20|'
+        'memory|npm|language-runtime|npm --version|npm|npm|||'
+    )
+    query_repo_ver() { echo 18.19.0; }
+    detect_distro() { :; }
+    install_node() {
+        echo NODE_SETUP_ACTION
+        PRESENT_DEPENDENCIES[node]=true
+        PRESENT_DEPENDENCIES[npm]=true
+    }
+    install_rust() { :; }
+
+    set +e
+    do_install_deps > "$TEST_OUTPUT" 2>&1
+    TEST_STATUS=$?
+    set -e
+
+    [[ $TEST_STATUS -eq 0 ]] || \
+        fail "agent-memory source build did not set up its Node dependency"
+    assert_contains "$TEST_OUTPUT" NODE_SETUP_ACTION
+    assert_contains "$TEST_OUTPUT" 'runtime dependencies are available'
+}
+
+test_memory_dry_run_plan_lists_node_setup() {
+    reset_preflight_stubs
+    COMPONENTS=(memory)
+    DRY_RUN=true
+
+    do_install_deps > "$TEST_OUTPUT" 2>&1
+
+    assert_contains "$TEST_OUTPUT" 'DRY-RUN: check/install Node.js and npm if needed'
+    assert_contains "$TEST_OUTPUT" 'DRY-RUN: check/install Rust toolchain if needed'
+}
+
+test_memory_preflight_requires_npm_alongside_node() {
+    reset_preflight_stubs
+    COMPONENTS=(memory)
+    TEST_DEPENDENCIES=(
+        'memory|node|language-runtime|node --version|nodejs|nodejs||>=20|'
+        'memory|npm|language-runtime|npm --version|npm|npm|||'
+    )
+    PRESENT_DEPENDENCIES[node]=true
+
+    run_preflight
+
+    [[ $TEST_STATUS -ne 0 ]] || \
+        fail "preflight passed although npm was missing"
+    assert_contains "$TEST_OUTPUT" 'memory: npm [language-runtime]'
+}
+
+test_install_node_provisions_missing_npm() {
+    reset_preflight_stubs
+    HOME="$TEST_TMP/node-npm-user"
+    SHELL="/bin/bash"
+    mkdir -p "$HOME"
+    NPM_INSTALLED=false
+    SUDO_ARGS=""
+    node() { echo v20.18.0; }
+    npm() {
+        $NPM_INSTALLED || return 127
+        echo 10.8.2
+    }
+    sudo() {
+        SUDO_ARGS="$*"
+        [[ "$*" == *npm* ]] || return 1
+        NPM_INSTALLED=true
+    }
+    query_repo_ver() { echo 20.18.0; }
+    _configure_npm_mirror() { :; }
+
+    install_node > "$TEST_OUTPUT" 2>&1
+
+    assert_contains "$TEST_OUTPUT" 'already installed, skipping'
+    assert_contains "$TEST_OUTPUT" 'npm 10.8.2 installed'
+    [[ "$SUDO_ARGS" == *npm* ]] || \
+        fail "npm was not provisioned through the package manager: $SUDO_ARGS"
+}
+
+# The nvm npm recovery has to work on a PATH that carries no npm at all, so
+# build a directory holding only the tools the recovery itself shells out to.
+make_minimal_bin() {
+    local dest="$1"; shift
+    rm -rf "$dest"
+    mkdir -p "$dest"
+    local tool resolved
+    for tool in "$@"; do
+        resolved="$(command -v "$tool" 2>/dev/null || true)"
+        [[ -n "$resolved" ]] && ln -sfn "$resolved" "$dest/$tool"
+    done
+    return 0
+}
+
+MINIMAL_BIN_TOOLS=(sh bash env dirname basename mktemp curl grep head sed sort
+    tar gzip rm mkdir mv chmod ln cat uname tr)
+
+make_nvm_node_fixture() {
+    local node_dir="$1" node_version="$2"
+    mkdir -p "$node_dir/bin" "$node_dir/lib/node_modules"
+    printf '#!/bin/sh\necho %s\n' "$node_version" > "$node_dir/bin/node"
+    chmod +x "$node_dir/bin/node"
+}
+
+# A hermetic npm registry: dist-tags metadata plus real gzipped tarballs laid
+# out like the published npm package. curl reads them over file://, so these
+# tests need neither network nor a preinstalled npm.
+make_npm_registry_fixture() {
+    local root="$1"; shift
+    local staging="$TEST_TMP/npm-registry-fixture" version
+    rm -rf "$root"
+    mkdir -p "$root/-/package/npm" "$root/npm/-"
+    printf '{"latest":"%s"}\n' "$1" > "$root/-/package/npm/dist-tags"
+    for version in "$@"; do
+        rm -rf "$staging"
+        mkdir -p "$staging/package/bin"
+        printf '{"name":"npm","version":"%s"}\n' "$version" \
+            > "$staging/package/package.json"
+        printf '#!/bin/sh\necho %s\n' "$version" \
+            > "$staging/package/bin/npm-cli.js"
+        printf '#!/bin/sh\necho %s\n' "$version" \
+            > "$staging/package/bin/npx-cli.js"
+        chmod +x "$staging/package/bin/npm-cli.js" \
+            "$staging/package/bin/npx-cli.js"
+        tar -czf "$root/npm/-/npm-$version.tgz" -C "$staging" package
+    done
+}
+
+# The Node.js dist index records the npm version each Node release shipped
+# with; the recovery prefers it over the registry `latest` tag.
+make_node_dist_index_fixture() {
+    local root="$1" node_version="$2" npm_version="$3"
+    rm -rf "$root"
+    mkdir -p "$root"
+    printf '[\n{"version":"%s","date":"2026-01-01","files":["linux-x64"],"npm":"%s","lts":false,"security":false}\n]\n' \
+        "$node_version" "$npm_version" > "$root/index.json"
+}
+
+test_install_node_restores_npm_for_nvm_managed_node_without_sudo() {
+    reset_preflight_stubs
+    HOME="$TEST_TMP/nvm-restore-home"
+    SHELL="/bin/bash"
+    mkdir -p "$HOME"
+    NVM_DIR="$HOME/.nvm"
+    export NVM_DIR
+    local node_dir="$NVM_DIR/versions/node/v20.18.0"
+    make_nvm_node_fixture "$node_dir" v20.18.0
+
+    local registry="$TEST_TMP/nvm-restore-registry"
+    local existing_package="$node_dir/lib/node_modules/package"
+    mkdir -p "$existing_package"
+    printf '{"name":"package","version":"1.0.0"}\n' > "$existing_package/package.json"
+    printf 'module.exports = 3187;\n' > "$existing_package/index.js"
+    make_npm_registry_fixture "$registry" 99.0.1 10.8.2
+    npm_config_registry="file://$registry"
+    export npm_config_registry
+    local dist_mirror="$TEST_TMP/nvm-restore-node-dist"
+    make_node_dist_index_fixture "$dist_mirror" v20.18.0 10.8.2
+    NVM_NODEJS_ORG_MIRROR="file://$dist_mirror"
+    export NVM_NODEJS_ORG_MIRROR
+
+    local minimal_bin="$TEST_TMP/nvm-restore-bin"
+    make_minimal_bin "$minimal_bin" "${MINIMAL_BIN_TOOLS[@]}"
+    local sudo_log="$TEST_TMP/nvm-restore-sudo"
+    : > "$sudo_log"
+    sudo() { echo "$*" >> "$sudo_log"; return 1; }
+    _configure_npm_mirror() { :; }
+
+    local status=0
+    ( PATH="$node_dir/bin:$minimal_bin"; install_node ) \
+        > "$TEST_OUTPUT" 2>&1 || status=$?
+    [[ $status -eq 0 ]] || \
+        fail "install_node exited $status: $(tr '\n' '|' < "$TEST_OUTPUT")"
+
+    assert_contains "$TEST_OUTPUT" 'already installed, skipping'
+    assert_contains "$TEST_OUTPUT" 'Node.js v20.18.0 shipped with npm 10.8.2'
+    assert_contains "$TEST_OUTPUT" \
+        'npm 10.8.2 restored for the nvm-managed Node.js'
+    assert_not_contains "$TEST_OUTPUT" '99.0.1'
+    assert_not_contains "$TEST_OUTPUT" 'Failed to install npm'
+    [[ -d "$node_dir/lib/node_modules/npm" ]] || \
+        fail "npm was not unpacked into the nvm prefix"
+    [[ -x "$node_dir/bin/npm" && -x "$node_dir/bin/npx" ]] || \
+        fail "npm/npx were not linked into the nvm prefix bin"
+    [[ "$(PATH="$node_dir/bin:$minimal_bin" npm -v)" == "10.8.2" ]] || \
+        fail "the restored npm does not run"
+    [[ "$(cat "$existing_package/package.json")" == '{"name":"package","version":"1.0.0"}' && \
+       "$(cat "$existing_package/index.js")" == 'module.exports = 3187;' ]] || \
+        fail "npm recovery changed the existing global package"
+    [[ ! -s "$sudo_log" ]] || \
+        fail "nvm npm recovery needed the package manager: $(cat "$sudo_log")"
+}
+
+test_install_node_npm_restore_falls_back_to_registry_latest() {
+    reset_preflight_stubs
+    HOME="$TEST_TMP/nvm-latest-home"
+    SHELL="/bin/bash"
+    mkdir -p "$HOME"
+    NVM_DIR="$HOME/.nvm"
+    export NVM_DIR
+    local node_dir="$NVM_DIR/versions/node/v20.18.0"
+    make_nvm_node_fixture "$node_dir" v20.18.0
+
+    local registry="$TEST_TMP/nvm-latest-registry"
+    make_npm_registry_fixture "$registry" 99.0.1
+    npm_config_registry="file://$registry"
+    export npm_config_registry
+    # No dist index at all: an nvm mirror that only serves tarballs, or an
+    # offline build host, must still be able to recover npm.
+    NVM_NODEJS_ORG_MIRROR="file://$TEST_TMP/nvm-latest-node-dist-missing"
+    export NVM_NODEJS_ORG_MIRROR
+
+    local minimal_bin="$TEST_TMP/nvm-latest-bin"
+    make_minimal_bin "$minimal_bin" "${MINIMAL_BIN_TOOLS[@]}"
+    local sudo_log="$TEST_TMP/nvm-latest-sudo"
+    : > "$sudo_log"
+    sudo() { echo "$*" >> "$sudo_log"; return 1; }
+    _configure_npm_mirror() { :; }
+
+    local status=0
+    ( PATH="$node_dir/bin:$minimal_bin"; install_node ) \
+        > "$TEST_OUTPUT" 2>&1 || status=$?
+    [[ $status -eq 0 ]] || \
+        fail "install_node exited $status: $(tr '\n' '|' < "$TEST_OUTPUT")"
+
+    assert_contains "$TEST_OUTPUT" 'Could not read the Node.js dist index'
+    assert_contains "$TEST_OUTPUT" \
+        'npm 99.0.1 restored for the nvm-managed Node.js'
+    [[ "$(PATH="$node_dir/bin:$minimal_bin" npm -v)" == "99.0.1" ]] || \
+        fail "the registry-latest npm was not restored"
+    [[ ! -s "$sudo_log" ]] || \
+        fail "nvm npm recovery needed the package manager: $(cat "$sudo_log")"
+}
+
+test_install_node_reports_nvm_npm_restore_failure_and_tries_the_package() {
+    reset_preflight_stubs
+    HOME="$TEST_TMP/nvm-fallback-home"
+    SHELL="/bin/bash"
+    mkdir -p "$HOME"
+    NVM_DIR="$HOME/.nvm"
+    export NVM_DIR
+    local node_dir="$NVM_DIR/versions/node/v20.18.0"
+    make_nvm_node_fixture "$node_dir" v20.18.0
+
+    # Unreachable dist index and registry plus a sudo that records and refuses:
+    # the isolated reproduction from the review (nvm-managed Node, no npm, no
+    # sudo). Every step must stay visible instead of being swallowed.
+    npm_config_registry="file://$TEST_TMP/nvm-fallback-registry-missing"
+    export npm_config_registry
+    NVM_NODEJS_ORG_MIRROR="file://$TEST_TMP/nvm-fallback-node-dist-missing"
+    export NVM_NODEJS_ORG_MIRROR
+
+    local minimal_bin="$TEST_TMP/nvm-fallback-bin"
+    make_minimal_bin "$minimal_bin" "${MINIMAL_BIN_TOOLS[@]}"
+    local sudo_log="$TEST_TMP/nvm-fallback-sudo"
+    : > "$sudo_log"
+    sudo() { echo "$*" >> "$sudo_log"; return 1; }
+    _configure_npm_mirror() { :; }
+
+    local status=0
+    ( PATH="$node_dir/bin:$minimal_bin"; install_node ) \
+        > "$TEST_OUTPUT" 2>&1 || status=$?
+
+    [[ $status -ne 0 ]] || \
+        fail "install_node succeeded although npm could not be restored"
+    assert_contains "$TEST_OUTPUT" 'Restoring npm for the nvm-managed Node.js'
+    assert_contains "$TEST_OUTPUT" \
+        'Could not resolve an npm version for Node.js v20.18.0'
+    assert_contains "$TEST_OUTPUT" 'falling back to the npm package'
+    assert_contains "$TEST_OUTPUT" 'Failed to install npm'
+    [[ -s "$sudo_log" ]] || fail "the package-manager fallback was never attempted"
+}
+
+test_install_node_system_warns_when_npm_is_not_in_system_path() {
+    reset_preflight_stubs
+    INSTALL_MODE="system"
+    printf '#!/bin/bash\necho v20.18.0\n' > "$RUNTIME_SYSTEM_PATH/node"
+    chmod +x "$RUNTIME_SYSTEM_PATH/node"
+    local sudo_log="$TEST_TMP/system-npm-sudo"
+    : > "$sudo_log"
+    sudo() { echo "$*" >> "$sudo_log"; }
+    _configure_npm_mirror() { :; }
+
+    ( install_node ) > "$TEST_OUTPUT" 2>&1
+
+    assert_contains "$TEST_OUTPUT" 'already installed, skipping'
+    assert_contains "$TEST_OUTPUT" 'npm was not found in'
+    [[ ! -s "$sudo_log" ]] || \
+        fail "system mode mutated package state to provision npm: $(cat "$sudo_log")"
+}
+
+test_memory_system_preflight_blocks_on_missing_npm() {
+    reset_preflight_stubs
+    INSTALL_MODE="system"
+    INSTALL_RESULT="success"
+    COMPONENTS=(memory)
+    TEST_DEPENDENCIES=(
+        'memory|node|language-runtime|node --version|nodejs|nodejs||>=20|'
+        'memory|npm|language-runtime|npm --version|npm|npm|||'
+    )
+    PRESENT_DEPENDENCIES[node]=true
+
+    run_preflight
+
+    [[ $TEST_STATUS -ne 0 ]] || \
+        fail "system preflight installed past a missing language runtime"
+    assert_contains "$TEST_OUTPUT" 'memory: npm [language-runtime]'
+    assert_contains "$TEST_OUTPUT" 'Install these language runtimes manually'
+}
+
 reset_rustup_stubs() {
     reset_preflight_stubs
     export CARGO_HOME="$TEST_TMP/rustup-cargo"
@@ -910,5 +1230,14 @@ run_test test_no_install_skips_runtime_preflight
 run_test test_preflight_failure_precedes_first_install
 run_test test_ignore_deps_skips_install_preflight
 run_test test_dry_run_skips_host_preflight
+run_test test_memory_source_build_sets_up_node
+run_test test_memory_dry_run_plan_lists_node_setup
+run_test test_memory_preflight_requires_npm_alongside_node
+run_test test_install_node_provisions_missing_npm
+run_test test_install_node_restores_npm_for_nvm_managed_node_without_sudo
+run_test test_install_node_npm_restore_falls_back_to_registry_latest
+run_test test_install_node_reports_nvm_npm_restore_failure_and_tries_the_package
+run_test test_install_node_system_warns_when_npm_is_not_in_system_path
+run_test test_memory_system_preflight_blocks_on_missing_npm
 run_test test_rustup_explicit_servers_are_preserved
 run_test test_rustup_automatic_mirrors_still_select_by_channel


### PR DESCRIPTION
## Why

`src/agent-memory/Makefile` has needed Node.js since the OpenClaw adapter landed: `install:` → `build:` → `build-openclaw-plugin` runs `npm install --legacy-peer-deps` + `npm run build` (esbuild) to produce `adapters/agent-memory/openclaw/dist/index.js` (`Makefile:121`).

`scripts/build-all.sh` never declared that requirement for the `memory` component. It was missing from **both** places that matter:

- the `install_node` gate — `want_component cosh || want_component sec-core || want_component sight` (twice: dry-run plan and the real call)
- `source_build_runtime_dependencies()` — which injects build-only language runtimes and had a single `sight)` case

`memory` is in `DEFAULT_COMPONENTS`, so a plain `./scripts/build-all.sh` on a Node-less host reported the dependency set as satisfied and then died inside `make`:

```text
### memory dry-run dependency plan (before)
DRY-RUN: detect Linux distribution and package manager
DRY-RUN: preflight platform capabilities before user dependency setup
DRY-RUN: check/install Rust toolchain if needed          <-- no Node.js line
DRY-RUN: verify all runtime dependencies after user dependency setup

### selected_runtime_dependencies, COMPONENTS=(memory) (before)
(empty)                     # COMPONENTS=(sight) -> sight|node|language-runtime|...|>=20|

### system-mode preflight, COMPONENTS=(memory), node absent from the system PATH (before)
==> Runtime dependency preflight
[ok]    Selected component runtime dependencies are available
preflight exit=0

### what the build then does (make with node/npm absent from PATH)
cd adapters/agent-memory/openclaw && npm install --legacy-peer-deps --no-audit --no-fund
/bin/sh: npm: command not found
make: *** [Makefile:121: build-openclaw-plugin] Error 127
```

That is exactly the late, unactionable failure the preflight exists to prevent — no missing-dependency report, no package hint, no retry command.

## What changed

**`scripts/build-all.sh`** (commit 1)

- `memory` added to the `install_node` gate in both the dry-run plan and the real path, matching the `d9d0f567 ("fix(scripts): install Node.js for agentsight builds")` precedent.
- `memory)` case added to `source_build_runtime_dependencies()` emitting `memory|node|language-runtime|node --version|nodejs|nodejs||>=20|` — the same record shape `sight` uses, so Node ≥ 20 (the repository-wide minimum documented in `docs/BUILDING.md` §3) is preflighted, reported and re-verified after install.
- `install_node`'s step header now names every component that triggers it. `"Node.js (for copilot-shell)"` was already stale for `sec-core` and `sight` before this change, and would have been actively misleading once `memory` started calling it.

**`tests/test-build-all-runtime-deps.sh`** (commit 1) — the file the `check-build-runtime-deps` CI job runs:

- `test_manifest_parser_covers_component_dependencies` now also asserts the `memory` source-build record.
- `test_memory_source_build_sets_up_node` — user-mode `do_install_deps` with `COMPONENTS=(memory)` calls `install_node` and the full preflight then passes.
- `test_memory_dry_run_plan_lists_node_setup` — keeps the dry-run plan aligned with the real flow (the same invariant `d9d0f567` called out).

**Docs** (commit 2) — `docs/BUILDING.md` + `docs/BUILDING_zh.md` (Node.js row and `agent-memory` row) and `src/agent-memory/README.md` (Requirements) now name Node.js ≥ 20 + npm for source builds, so the documented prerequisites and the enforced preflight agree.

**Why this shape and not a manifest entry.** The alternative was a `[[component.dependencies]]` block in `src/anolisa/manifests/components/agent-memory/component.toml`. That would make Node a *runtime* contract for the component, which is wrong: the installed MCP server is a Rust binary that never shells out to `node`, and the RPM ships a prebuilt `dist/`, so packaged installs (`anolisa install agent-memory`, `yum install agent-memory`) need no Node at all. `source_build_runtime_dependencies()` is the existing mechanism for exactly this build-only case, which is why `sight` uses it.

## Related issue

`no-issue:` found while re-verifying agent-memory build/test health on `main`. The closest open issue, #3134, asks for the adapter's TypeScript tests to be wired into the `Test agent-memory` CI job (that needs a token with `workflow` scope, since it edits `.github/workflows/ci.yaml`); this PR is about `build-all.sh`'s dependency preflight and touches no workflow file.

Tracked in Multica as AGE-6890 (Developer autopilot scan; no claimable development task was open, so this run re-verified agent-memory build health on `main` and fixed what it found).

## User / Agent impact

- `./scripts/build-all.sh` (default six components), `--component memory`, and `--deps-only` now set up Node for `memory`.
- **User mode**: missing Node is installed through the existing nvm/npm path before the build, so the memory build no longer dies at `npm: command not found`.
- **System mode**: missing or too-old Node is reported up front as a manual blocker, before any package mutation, with the retry command:

```text
==> Runtime dependency preflight
[error] Missing runtime dependencies; no component files were installed:
  memory: node [language-runtime] - requires node >=20

[info]  Install these language runtimes manually:
  memory: node >=20 in /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

[info]  Then retry:
  <repo>/scripts/build-all.sh --component memory --system
```

- No change to `anolisa install agent-memory`, to the RPM, or to the component's runtime dependency contract.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The checked box is the documented build prerequisite (`docs/BUILDING.md`, `src/agent-memory/README.md`) and the dependency-plan output gaining a `DRY-RUN: check/install Node.js if needed` line for `memory`.

One deliberate narrowing: in **system** mode a host carrying Node 18 could previously build the adapter (esbuild accepts ≥ 18) and is now stopped by the preflight at ≥ 20. That aligns `memory` with the Node ≥ 20 policy already enforced for `cosh` (manifest), `sec-core` and `sight`, and with the statement already in `docs/BUILDING.md`: "A system install that needs Node.js requires Node.js 20 or newer in the standard system PATH." Node 18 is upstream EOL, so no supported host loses a working build path.

**Pre-existing sibling gap, intentionally not touched here.** `docs/BUILDING.md` also lists `tokenless` and `ws-ckpt` among the components whose plugin builds use npm, and neither is in the `install_node` gate either (`src/tokenless/Makefile:43` even runs `node -p` at parse time). They have the same late-failure shape, but choosing their minimum Node version is a decision for those components' owners — `tokenless` runs `node --test` on TypeScript sources, which wants a newer floor than the ≥ 20 used here. Flagging it rather than guessing.

## Validation

Alibaba Cloud Linux 3 (rpm), Node v22.21.1, npm 10.9.4, cargo 1.96.0, clean worktree at `main` (`43d6ec87`):

| Check | Command | Result |
|---|---|---|
| Dependency plan (after) | `./scripts/build-all.sh --component memory --deps-only --dry-run` | now prints `DRY-RUN: check/install Node.js if needed` |
| Dependency record (after) | `source scripts/build-all.sh; COMPONENTS=(memory); selected_runtime_dependencies` | `memory\|node\|language-runtime\|node --version\|nodejs\|nodejs\|\|>=20\|` |
| System-mode preflight, node absent (after) | harness with `RUNTIME_SYSTEM_PATH` pointing at an empty dir | stops with the `memory: node [language-runtime]` manual-blocker report shown above (before: `[ok] ... available`, `exit=0`) |
| Late-failure repro (before) | `make -C src/agent-memory build-openclaw-plugin` with node/npm removed from `PATH` | `/bin/sh: npm: command not found`, `Makefile:121`, `Error 127` |
| Happy path, real run | `NPM_REGISTRY=https://registry.npmjs.org/ CARGO_HOME=$(mktemp -d) ./scripts/build-all.sh --component memory --deps-only` | `==> Node.js (for copilot-shell, agent-sec-core, agentsight, agent-memory)` → `Node.js v22.21.1 already installed, skipping` → preflight ok → `Dependency setup complete` (registry and `CARGO_HOME` pinned so the run mutates no host config) |
| Regression suite | `bash tests/test-build-all-runtime-deps.sh` | **38 ok / 0 not ok** (36 pre-existing + 2 new); this is the script the `check-build-runtime-deps` job runs |
| Negative check | revert only `scripts/build-all.sh`, keep the tests | all three new assertions fail (`agent-memory source Node dependency was not collected`, `agent-memory source build did not set up its Node dependency`, `expected 'DRY-RUN: check/install Node.js if needed'`) — the tests are not vacuous |
| Docs gates | `bash scripts/docs-lint.sh`, `python3 scripts/docs-link-check.py` | naming convention ok, en/zh tree parity ok, all relative links resolve |
| Shell lint | `shellcheck -S warning scripts/build-all.sh` | 7 warnings before and after, identical SC codes — no new findings |
| Syntax | `bash -n` on both changed shell files | ok |

Not run: `cargo test` for the crate (untouched by this change) and a full `--install` (would mutate the host).

## Documentation and rollback

- Docs updated in the same PR, per `specs/documentation-standard.md` §5: `docs/BUILDING.md` and `docs/BUILDING_zh.md` (Node.js row + `agent-memory` row, kept semantically equivalent as a bilingual pair) and `src/agent-memory/README.md` Requirements. `README_zh.md` has no Requirements section at all — a pre-existing asymmetry against `README.md` that this PR neither widens nor repairs.
- Rollback: revert both commits. No state, schema, packaging or workflow change; nothing to migrate. The two commits are independent — reverting only the docs commit leaves the fix in place with stale docs, reverting only the fix leaves the docs claiming a requirement the script does not enforce.
