### PR TITLE
fix(cosh-ng): [core] prefer in-VPC SysOM endpoint

### DIFF
--- a/docs/user-guide/en/user-entrypoint/cosh-ng/core/providers.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/core/providers.md
@@ -66,6 +66,34 @@ model = "qwen3.7-plus"
 For an ECS RAM role, use `type = "aliyun"` with
 `auth_source = "ecs_ram_role"`; static AK/SK values are then unnecessary.
 
+The `aliyun` provider picks its SysOM API host automatically: on an ECS instance
+that can reach the in-VPC proxy it uses that, which lets instances without
+public egress work, and otherwise it uses the public host. Set
+`sysom_endpoint` only to pin a specific host:
+
+```toml
+[ai.providers.aliyun]
+type = "aliyun"
+auth_source = "ecs_ram_role"
+sysom_endpoint = "https://sysom.cn-shanghai.aliyuncs.com"
+model = "qwen3.7-plus"
+```
+
+`sysom_endpoint` is deliberately separate from `base_url`: `base_url` is an
+OpenAI-compatible setting and is ignored by the `aliyun` provider.
+
+The override order is `COSH_SYSOM_ENDPOINT`, then `sysom_endpoint`, then the
+VPC probe, then the public endpoint. Overrides accept a bare host with an
+optional port or an HTTP(S) URL; URL paths are discarded and invalid overrides
+are ignored. Only automatically selected VPC routes connect directly, matching
+the probe. Explicit overrides (including an explicitly configured VPC host) and
+public fallback retain system proxy settings. Use `NO_PROXY` when an explicit
+endpoint should bypass your proxy.
+
+Inference allows 3 seconds for connection setup and 120 seconds of read
+inactivity. Successful reads reset the inactivity timer; healthy streaming
+responses have no total-duration deadline.
+
 | `type` | Use |
 |---|---|
 | `dashscope` | DashScope OpenAI-compatible endpoint with Qwen reasoning support |

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/core/providers.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/core/providers.md
@@ -59,6 +59,22 @@ model = "qwen3.7-plus"
 
 使用 ECS RAM role 时，设置 `type = "aliyun"` 和 `auth_source = "ecs_ram_role"`，无需保存静态 AK/SK。
 
+`aliyun` provider 会自动选择 SysOM API 主机：在能连通 VPC 内网代理的 ECS 上走内网，因此不通公网的实例也能使用；否则走公网主机。只有需要固定到某个主机时才设置 `sysom_endpoint`：
+
+```toml
+[ai.providers.aliyun]
+type = "aliyun"
+auth_source = "ecs_ram_role"
+sysom_endpoint = "https://sysom.cn-shanghai.aliyuncs.com"
+model = "qwen3.7-plus"
+```
+
+`sysom_endpoint` 与 `base_url` 是刻意分开的两个设置：`base_url` 属于 OpenAI 兼容语义，`aliyun` provider 不读取它。
+
+优先级依次为 `COSH_SYSOM_ENDPOINT`、`sysom_endpoint`、VPC 探测、公网端点。覆盖值支持裸主机名（可带端口）或 HTTP(S) URL；URL 路径会被丢弃，非法覆盖值按未设置处理。仅自动选中的 VPC 路由直连，与探针保持一致；显式覆盖（包括显式配置的 VPC 主机）和公网回退仍遵守系统代理。需要让显式端点绕过代理时，请设置 `NO_PROXY`。
+
+推理请求的建连超时为 3 秒，读取空闲超时为 120 秒；成功读取会重置空闲计时，持续正常输出的流没有总时长限制。
+
 | `type` | 用途 |
 |---|---|
 | `dashscope` | 支持 Qwen reasoning 的 DashScope OpenAI-compatible endpoint |

--- a/src/cosh-ng/README.md
+++ b/src/cosh-ng/README.md
@@ -110,6 +110,12 @@ the shell and Core. In enhanced integration, the cosh-core runtime makes
 Composer that accepts a leading `/skill:<name>` and validated workspace-local
 `@path` references.
 
+For `type = "aliyun"`, SysOM automatically prefers a reachable VPC endpoint.
+Set `ai.providers.<id>.sysom_endpoint` to pin an endpoint; `COSH_SYSOM_ENDPOINT`
+takes precedence, and `base_url` does not route SysOM. Only automatic VPC routes
+bypass system proxies; explicit overrides and public fallback retain proxy
+settings. See [provider configuration](../../docs/user-guide/en/user-entrypoint/cosh-ng/core/providers.md).
+
 To run one locally installed ACP adapter without entering the interactive
 Shell, verify it first and then pipe the prompt through stdin:
 

--- a/src/cosh-ng/README_zh.md
+++ b/src/cosh-ng/README_zh.md
@@ -103,6 +103,11 @@ bash: hello: command not found
 会打开一次性 Composer，可在开头指定 `/skill:<name>`，并添加经过验证的工作空间内
 `@路径`引用。
 
+`type = "aliyun"` 时，SysOM 自动优先使用可达的 VPC 端点。
+设置 `ai.providers.<id>.sysom_endpoint` 可固定端点，`COSH_SYSOM_ENDPOINT` 优先级更高，
+`base_url` 不参与 SysOM 选路。仅自动选中的 VPC 路由绕过系统代理，显式覆盖与公网回退
+仍保留代理设置。详见 [provider 配置](../../docs/user-guide/zh/user-entrypoint/cosh-ng/core/providers.md)。
+
 如果要在不进入交互式 Shell 的情况下运行本机已安装的 ACP Adapter，可以先检查
 Adapter，再通过 stdin 发送 prompt。
 

--- a/src/cosh-ng/crates/cosh-core/src/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/auth.rs
@@ -324,14 +324,14 @@ pub(crate) fn apply_auth_credentials(
         response.values.get("security_token").cloned()
     };
 
-    // Preserve explicit_cache across auth refresh so a 401/403
-    // re-auth does not silently reset the user's explicit cache preference
-    // to None (which persist_config_to_dir would then omit).
-    let existing_explicit_cache = config
-        .ai
-        .providers
-        .get(&response.provider_id)
-        .and_then(|p| p.explicit_cache);
+    // Preserve settings the auth response cannot carry, so a 401/403 re-auth
+    // does not silently reset them to None (which persist_config_to_dir would
+    // then omit): the user's explicit cache preference, and any SysOM endpoint
+    // they configured -- losing the latter would quietly switch the client back
+    // to probing.
+    let existing = config.ai.providers.get(&response.provider_id);
+    let existing_explicit_cache = existing.and_then(|p| p.explicit_cache);
+    let existing_sysom_endpoint = existing.and_then(|p| p.sysom_endpoint.clone());
 
     config.ai.active_provider = Some(response.provider_id.clone());
     config.ai.active_model = final_model.clone();
@@ -339,6 +339,7 @@ pub(crate) fn apply_auth_credentials(
         provider_type: Some(provider_type),
         auth_source,
         base_url: Some(base_url),
+        sysom_endpoint: existing_sysom_endpoint,
         api_key: Some(api_key),
         model: final_model.clone(),
         extra_params: None,
@@ -985,6 +986,40 @@ mod tests {
         assert_eq!(p.api_key.as_deref(), Some("sk-new"));
         // explicit_cache must survive re-auth
         assert_eq!(p.explicit_cache, Some(true));
+    }
+
+    #[test]
+    fn auth_refresh_preserves_sysom_endpoint() {
+        let mut config = CoreConfig::default();
+        config.ai.providers.insert(
+            "aliyun".to_string(),
+            ProviderConfig {
+                provider_type: Some("aliyun".to_string()),
+                sysom_endpoint: Some("https://sysom.cn-shanghai.aliyuncs.com".to_string()),
+                access_key_id: Some("old-ak".to_string()),
+                model: Some("qwen3.7-plus".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let response = AuthResponse {
+            provider_id: "aliyun".to_string(),
+            provider_type: None,
+            values: HashMap::from([
+                ("access_key_id".to_string(), "new-ak".to_string()),
+                ("access_key_secret".to_string(), "new-sk".to_string()),
+            ]),
+            persist: true,
+        };
+        apply_auth_credentials(&mut config, &response).unwrap();
+
+        let p = config.ai.providers.get("aliyun").unwrap();
+        assert_eq!(p.access_key_id.as_deref(), Some("new-ak"));
+        // Losing this would silently switch the client back to probing.
+        assert_eq!(
+            p.sysom_endpoint.as_deref(),
+            Some("https://sysom.cn-shanghai.aliyuncs.com")
+        );
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/auth/preflight.rs
+++ b/src/cosh-ng/crates/cosh-core/src/auth/preflight.rs
@@ -17,7 +17,6 @@ use crate::config::ResolvedProvider;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(8);
-const ALIYUN_SYSOM_ENDPOINT: &str = "https://sysom.cn-hangzhou.aliyuncs.com";
 const ALIYUN_PERMISSION_PATH: &str = "/api/v1/openapi/initial";
 const ALIYUN_PERMISSION_ACTION: &str = "InitialSysom";
 const ALIYUN_COPILOT_PATH: &str = "/api/v1/copilot/generate_copilot_stream_response";
@@ -81,16 +80,16 @@ impl fmt::Display for AuthPreflightError {
                 "Model {model:?} is unavailable. Check the Model name and access entitlement."
             ),
             Self::EndpointUnreachable => formatter.write_str(
-                "The endpoint could not be reached. Check the Base URL and network connection.",
+                "The endpoint could not be reached. Check the endpoint configuration and network connection.",
             ),
             Self::Timeout => formatter.write_str(
-                "The endpoint did not respond in time. Check the Base URL and network connection.",
+                "The endpoint did not respond in time. Check the endpoint configuration and network connection.",
             ),
             Self::RateLimited => formatter.write_str(
                 "The provider rate-limited the validation request. Check quota or try again later.",
             ),
             Self::ProviderUnavailable => formatter.write_str(
-                "The provider is temporarily unavailable. Try again later or check the Base URL.",
+                "The provider is temporarily unavailable. Try again later or check the endpoint configuration.",
             ),
             Self::ServiceNotReady => formatter.write_str(
                 "Aliyun SysOM is not authorized for this account. Complete service authorization and try again.",
@@ -99,7 +98,7 @@ impl fmt::Display for AuthPreflightError {
                 "ECS RAM Role credentials are not available yet. Authorize the instance role and try again.",
             ),
             Self::UnsupportedResponse => formatter.write_str(
-                "The endpoint returned an unsupported validation response. Check the Base URL and provider compatibility.",
+                "The endpoint returned an unsupported validation response. Check the endpoint configuration and provider compatibility.",
             ),
         }
     }
@@ -139,7 +138,7 @@ async fn preflight_auth_inner(provider: &ResolvedProvider) -> Result<(), AuthPre
         return preflight_aliyun(provider).await;
     }
 
-    let client = build_client()?;
+    let client = build_client(None)?;
     match provider.provider_type.as_str() {
         "dashscope" => {
             preflight_model_endpoint(&client, provider, ModelFallback::ListThenChat).await
@@ -155,11 +154,18 @@ async fn preflight_auth_inner(provider: &ResolvedProvider) -> Result<(), AuthPre
     }
 }
 
-fn build_client() -> Result<Client, AuthPreflightError> {
-    Client::builder()
+fn build_client(
+    endpoint: Option<&crate::provider::sysom::endpoint::ResolvedEndpoint>,
+) -> Result<Client, AuthPreflightError> {
+    let builder = Client::builder()
         .connect_timeout(CONNECT_TIMEOUT)
         .timeout(REQUEST_TIMEOUT)
-        .redirect(reqwest::redirect::Policy::none())
+        .redirect(reqwest::redirect::Policy::none());
+    let builder = match endpoint {
+        Some(endpoint) => endpoint.configure_client(builder),
+        None => builder,
+    };
+    builder
         .build()
         .map_err(|_| AuthPreflightError::EndpointUnreachable)
 }
@@ -369,12 +375,15 @@ async fn preflight_aliyun(provider: &ResolvedProvider) -> Result<(), AuthPreflig
         .ok_or(AuthPreflightError::CredentialSourceUnavailable);
     }
 
-    let client = build_client()?;
-    let base_url = if provider.base_url.trim().is_empty() {
-        ALIYUN_SYSOM_ENDPOINT
-    } else {
-        provider.base_url.as_str()
-    };
+    let resolved = crate::provider::sysom::endpoint::resolve(&provider.sysom_endpoint).await;
+    let client = build_client(Some(&resolved))?;
+    tracing::debug!(
+        host = %resolved.host,
+        origin = resolved.origin.as_str(),
+        "sysom preflight endpoint"
+    );
+    let base_url = resolved.base_url();
+    let base_url = base_url.as_str();
     let payload = br#"{"check_only":true,"source":"cosh"}"#;
     let request = signed_aliyun_request(
         &client,
@@ -840,7 +849,12 @@ mod tests {
 
     fn provider(base_url: &str, provider_type: &str) -> ResolvedProvider {
         ResolvedProvider {
-            base_url: base_url.to_string(),
+            base_url: if provider_type == "aliyun" {
+                "http://127.0.0.1:1".to_string()
+            } else {
+                base_url.to_string()
+            },
+            sysom_endpoint: base_url.to_string(),
             api_key: "sk-private-value".to_string(),
             model: "test-model".to_string(),
             provider_type: provider_type.to_string(),
@@ -851,6 +865,52 @@ mod tests {
             security_token: None,
             explicit_cache: false,
         }
+    }
+
+    #[test]
+    fn endpoint_error_messages_are_provider_neutral() {
+        for (error, code) in [
+            (
+                AuthPreflightError::EndpointUnreachable,
+                "endpoint_unreachable",
+            ),
+            (AuthPreflightError::Timeout, "timeout"),
+            (
+                AuthPreflightError::ProviderUnavailable,
+                "provider_unavailable",
+            ),
+            (
+                AuthPreflightError::UnsupportedResponse,
+                "unsupported_response",
+            ),
+        ] {
+            let message = error.to_string();
+            assert_eq!(error.code(), code);
+            assert!(
+                message.contains("endpoint configuration"),
+                "{code}: {message}"
+            );
+            assert!(!message.contains("Base URL"), "{code}: {message}");
+            assert!(!message.contains("sysom_endpoint"), "{code}: {message}");
+        }
+    }
+
+    #[tokio::test]
+    async fn aliyun_connection_failure_uses_neutral_endpoint_hint() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let mut aliyun = provider(&format!("http://{address}"), "aliyun");
+        aliyun.access_key_id = "test-access-key".to_string();
+        aliyun.access_key_secret = "test-secret".to_string();
+
+        let error = preflight_auth(&aliyun)
+            .await
+            .expect_err("unreachable SysOM endpoint");
+        assert_eq!(error, AuthPreflightError::EndpointUnreachable);
+        let message = error.to_string();
+        assert!(message.contains("endpoint configuration"), "{message}");
+        assert!(!message.contains("Base URL"), "{message}");
     }
 
     #[tokio::test]

--- a/src/cosh-ng/crates/cosh-core/src/auth/preflight.rs
+++ b/src/cosh-ng/crates/cosh-core/src/auth/preflight.rs
@@ -726,10 +726,11 @@ fn hex_sha256(value: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{Read, Write};
+    use std::io::{ErrorKind, Read, Write};
     use std::net::{TcpListener, TcpStream};
     use std::sync::{Arc, Mutex};
     use std::thread;
+    use std::time::Instant;
 
     use super::*;
 
@@ -759,14 +760,50 @@ mod tests {
     }
 
     impl MockServer {
+        /// How long the mock waits for a connection that may never come.
+        ///
+        /// A client that gives up before it dials — `request_timeout_is_classified`
+        /// uses a 10ms timeout, which under a saturated CPU can fire before the
+        /// request future is ever polled — leaves nothing to accept. A blocking
+        /// accept would then leave the thread alive forever and `finish()`'s
+        /// `join()` would stall the whole test binary rather than failing one
+        /// test.
+        const ACCEPT_TIMEOUT: Duration = Duration::from_secs(5);
+
         fn spawn(replies: Vec<Reply>) -> Self {
+            Self::spawn_with_accept_timeout(replies, Self::ACCEPT_TIMEOUT)
+        }
+
+        fn spawn_with_accept_timeout(replies: Vec<Reply>, accept_timeout: Duration) -> Self {
             let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
             let address = listener.local_addr().expect("mock address");
             let requests = Arc::new(Mutex::new(Vec::new()));
             let captured = Arc::clone(&requests);
             let thread = thread::spawn(move || {
+                listener
+                    .set_nonblocking(true)
+                    .expect("mock listener nonblocking");
                 for reply in replies {
-                    let (mut stream, _) = listener.accept().expect("accept mock request");
+                    let deadline = Instant::now() + accept_timeout;
+                    let mut stream = loop {
+                        match listener.accept() {
+                            Ok((stream, _)) => break stream,
+                            Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                                if Instant::now() >= deadline {
+                                    // No client arrived. Leave the recorded
+                                    // requests short so an assertion fails
+                                    // instead of the suite hanging.
+                                    return;
+                                }
+                                thread::sleep(Duration::from_millis(1));
+                            }
+                            Err(err) => panic!("accept mock request: {err}"),
+                        }
+                    };
+                    // `read_request` relies on a read timeout, which needs a
+                    // blocking socket; accepted sockets can inherit the
+                    // listener's non-blocking flag.
+                    stream.set_nonblocking(false).expect("mock stream blocking");
                     let request = read_request(&mut stream);
                     captured.lock().unwrap().push(request);
                     if !reply.delay.is_zero() {
@@ -1167,6 +1204,32 @@ mod tests {
         assert_eq!(
             preflight_auth(&provider(&format!("http://{address}/v1"), "dashscope")).await,
             Err(AuthPreflightError::EndpointUnreachable)
+        );
+    }
+
+    /// `finish()` must return even when no client ever connects.
+    ///
+    /// This is the hang `request_timeout_is_classified` triggered: a 10ms client
+    /// timeout can fire before the request future is first polled, so nothing is
+    /// ever dialed. With a blocking accept the mock thread never exits and
+    /// `join()` stalls the entire test binary — one flaky test becomes a hung
+    /// suite with no failing assertion to point at.
+    #[test]
+    fn mock_server_finish_returns_when_no_client_connects() {
+        let accept_timeout = Duration::from_millis(200);
+        let server = MockServer::spawn_with_accept_timeout(
+            vec![Reply::json(200, r#"{"id":"unused"}"#)],
+            accept_timeout,
+        );
+
+        let started = Instant::now();
+        let requests = server.finish();
+        let elapsed = started.elapsed();
+
+        assert!(requests.is_empty(), "no request should have been recorded");
+        assert!(
+            elapsed < accept_timeout * 10,
+            "finish() blocked for {elapsed:?}, accept timeout was {accept_timeout:?}"
         );
     }
 

--- a/src/cosh-ng/crates/cosh-core/src/config.rs
+++ b/src/cosh-ng/crates/cosh-core/src/config.rs
@@ -117,6 +117,14 @@ pub struct ProviderConfig {
     pub auth_source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
+    /// SysOM API host, honoured only by the `aliyun` provider type.
+    ///
+    /// Separate from `base_url` because that one is OpenAI-compatible and
+    /// defaults to a DashScope address, which is not a SysOM endpoint. Unset,
+    /// the client prefers the VPC proxy when reachable and the public host
+    /// otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sysom_endpoint: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -937,6 +945,18 @@ impl CoreConfig {
 
         let provider_cfg = self.ai.providers.get(&provider_name);
 
+        // SysOM's API host, kept deliberately separate from `base_url`.
+        //
+        // `base_url` is an OpenAI-compatible concept: unset it falls back to the
+        // DashScope compatible-mode address below. Feeding that into the SysOM
+        // ACS3 path sent signed traffic to DashScope, so the two no longer share
+        // a field. Empty here means "not configured", which lets the endpoint
+        // resolver fall through to probing the VPC proxy.
+        let sysom_endpoint = provider_cfg
+            .and_then(|p| p.sysom_endpoint.as_deref())
+            .map(expand_env_vars)
+            .unwrap_or_default();
+
         let base_url = provider_cfg
             .and_then(|p| p.base_url.as_deref())
             .map(expand_env_vars)
@@ -986,6 +1006,7 @@ impl CoreConfig {
 
         ResolvedProvider {
             base_url,
+            sysom_endpoint,
             api_key,
             model,
             provider_type,
@@ -1002,6 +1023,12 @@ impl CoreConfig {
 #[derive(Debug, Clone)]
 pub struct ResolvedProvider {
     pub base_url: String,
+    /// SysOM API host from this provider's own configuration, or empty.
+    ///
+    /// Never holds an OpenAI-compatible URL: it has no default and no env
+    /// fallback, so an empty value means the endpoint resolver should decide
+    /// between the VPC proxy and the public host on its own.
+    pub sysom_endpoint: String,
     pub api_key: String,
     pub model: String,
     pub provider_type: String,
@@ -1109,6 +1136,12 @@ fn persist_config_to_dir(config: &CoreConfig, dir: &std::path::Path) -> Result<(
         }
         if let Some(ref url) = provider.base_url {
             preserved.push_str(&format!("base_url = \"{}\"\n", escape_toml_value(url)));
+        }
+        if let Some(ref host) = provider.sysom_endpoint {
+            preserved.push_str(&format!(
+                "sysom_endpoint = \"{}\"\n",
+                escape_toml_value(host)
+            ));
         }
         if let Some(ref key) = provider.api_key {
             preserved.push_str(&format!("api_key = \"{}\"\n", escape_toml_value(key)));
@@ -1431,6 +1464,71 @@ allowed_tools = ["search"]
         assert_eq!(server.command, "");
         assert_eq!(server.url.as_deref(), Some("https://mcp.example.com/mcp"));
         assert_eq!(server.bearer_token.as_deref(), Some("${MCP_TOKEN}"));
+    }
+
+    /// `base_url` must never reach the SysOM endpoint, in any of the shapes
+    /// that used to leak it there.
+    ///
+    /// Each shape is real: absent is a hand-written ECS RAM role profile; empty
+    /// is what `cosh auth` writes for the aliyun template; a compat URL is what
+    /// `settings.json` migration carries in regardless of provider type. All
+    /// must leave `sysom_endpoint` empty so the resolver probes instead of
+    /// signing SysOM traffic for an OpenAI-compatible host.
+    #[test]
+    fn base_url_never_becomes_the_sysom_endpoint() {
+        for base_url_line in [
+            "",
+            r#"base_url = """#,
+            r#"base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1""#,
+            r#"base_url = "https://api.openai.com/v1""#,
+        ] {
+            let toml_str = format!(
+                r#"
+[ai]
+active_provider = "aliyun-ecs"
+
+[ai.providers.aliyun-ecs]
+type = "aliyun"
+auth_source = "ecs_ram_role"
+{base_url_line}
+model = "qwen3.7-plus"
+"#
+            );
+            let config: CoreConfig = toml::from_str(&toml_str).unwrap();
+            let resolved = config.resolve_provider();
+
+            assert_eq!(
+                resolved.sysom_endpoint, "",
+                "base_url leaked into sysom_endpoint for {base_url_line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn configured_sysom_endpoint_is_carried_through() {
+        let toml_str = r#"
+[ai]
+active_provider = "aliyun-ecs"
+
+[ai.providers.aliyun-ecs]
+type = "aliyun"
+auth_source = "ecs_ram_role"
+base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+sysom_endpoint = "https://sysom.cn-shanghai.aliyuncs.com"
+model = "qwen3.7-plus"
+"#;
+        let config: CoreConfig = toml::from_str(toml_str).unwrap();
+        let resolved = config.resolve_provider();
+
+        assert_eq!(
+            resolved.sysom_endpoint,
+            "https://sysom.cn-shanghai.aliyuncs.com"
+        );
+        // The compat base_url stays intact for the OpenAI-compatible consumers.
+        assert_eq!(
+            resolved.base_url,
+            "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        );
     }
 
     #[test]
@@ -1812,6 +1910,41 @@ api_key = "sk-user"
         assert_eq!(provider.api_key.as_deref(), Some("sk-user"));
         assert!(provider.base_url.is_none());
         assert!(provider.model.is_none());
+    }
+
+    #[test]
+    fn sysom_endpoint_survives_refresh_persist_and_reload() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+[ai]
+active_provider = "aliyun"
+[ai.providers.aliyun]
+type = "aliyun"
+sysom_endpoint = "https://sysom.cn-shanghai.aliyuncs.com"
+"#,
+        )
+        .unwrap();
+        let mut config = CoreConfig::load_from_paths(None, Some(&path), None);
+        let response = crate::auth::AuthResponse {
+            provider_id: "aliyun".to_string(),
+            provider_type: None,
+            values: HashMap::from([
+                ("access_key_id".to_string(), "new-ak".to_string()),
+                ("access_key_secret".to_string(), "new-sk".to_string()),
+            ]),
+            persist: true,
+        };
+        crate::auth::apply_auth_credentials(&mut config, &response).unwrap();
+        persist_config_to_dir(&config, tmp.path()).unwrap();
+        let reloaded = CoreConfig::load_from_paths(None, Some(&path), None).resolve_provider();
+        assert_eq!(
+            reloaded.sysom_endpoint,
+            "https://sysom.cn-shanghai.aliyuncs.com"
+        );
+        assert_eq!(reloaded.access_key_id, "new-ak");
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/core/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/auth.rs
@@ -36,13 +36,15 @@ impl CoshCore {
         let resolved = self.config.resolve_provider();
         if resolved.provider_type == "aliyun" {
             if resolved.auth_source.as_deref() == Some("ecs_ram_role") {
-                self.provider =
-                    Box::new(crate::provider::sysom::SysomProvider::from_ecs_ram_role());
+                self.provider = Box::new(crate::provider::sysom::SysomProvider::from_ecs_ram_role(
+                    &resolved.sysom_endpoint,
+                ));
             } else if !resolved.access_key_id.is_empty() && !resolved.access_key_secret.is_empty() {
                 self.provider = Box::new(crate::provider::sysom::SysomProvider::new(
                     &resolved.access_key_id,
                     &resolved.access_key_secret,
                     resolved.security_token.as_deref(),
+                    &resolved.sysom_endpoint,
                 ));
             } else {
                 tracing::warn!("Aliyun auth response missing AK/SK");

--- a/src/cosh-ng/crates/cosh-core/src/main.rs
+++ b/src/cosh-ng/crates/cosh-core/src/main.rs
@@ -57,7 +57,9 @@ fn create_provider(config: &CoreConfig) -> Box<dyn provider::ContentGenerator> {
     // Aliyun provider uses AK/SK, not API key
     if resolved.provider_type == "aliyun" {
         if resolved.auth_source.as_deref() == Some("ecs_ram_role") {
-            return Box::new(provider::sysom::SysomProvider::from_ecs_ram_role());
+            return Box::new(provider::sysom::SysomProvider::from_ecs_ram_role(
+                &resolved.sysom_endpoint,
+            ));
         }
         if resolved.access_key_id.is_empty() || resolved.access_key_secret.is_empty() {
             tracing::warn!("no AK/SK configured for aliyun, using mock provider");
@@ -69,6 +71,7 @@ fn create_provider(config: &CoreConfig) -> Box<dyn provider::ContentGenerator> {
             &resolved.access_key_id,
             &resolved.access_key_secret,
             resolved.security_token.as_deref(),
+            &resolved.sysom_endpoint,
         ));
     }
     if resolved.api_key.is_empty() {

--- a/src/cosh-ng/crates/cosh-core/src/provider/sysom.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/sysom.rs
@@ -40,6 +40,12 @@ const INSTANCE_ID_CACHE_TTL_SECS: u64 = 3 * 3600;
 const METADATA_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 /// Read timeout for ECS metadata service.
 const METADATA_READ_TIMEOUT: Duration = Duration::from_secs(2);
+/// Connect timeout for the SysOM API.
+///
+/// Bounds connection setup so an unreachable endpoint surfaces as a prompt
+/// error instead of stalling on the protocol stack's own timeout, which was
+/// measured at 61 seconds from an ECS with no public egress.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EcsAuthChallenge {
@@ -293,8 +299,13 @@ impl SysomProvider {
         let authorization =
             self.sign_request("POST", API_PATH, &sign_headers, &hashed_payload, &creds);
 
-        // Build reqwest request
-        let client = reqwest::Client::new();
+        // Bound connection setup only. No total request timeout: this is a
+        // Server-Sent Events stream whose lifetime is the model's, so a total
+        // timeout would truncate healthy long completions.
+        let client = reqwest::Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .build()
+            .map_err(|err| format!("failed to build HTTP client: {err}"))?;
         let mut req = client
             .post(&url)
             .header("host", &self.endpoint)

--- a/src/cosh-ng/crates/cosh-core/src/provider/sysom.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/sysom.rs
@@ -21,11 +21,11 @@ use super::{ContentGenerator, GenerateConfig, GenerateStream, Message, ToolDecla
 
 use self::stream::sysom_event_stream;
 
+pub mod endpoint;
 mod stream;
 
 type HmacSha256 = Hmac<Sha256>;
 
-const DEFAULT_ENDPOINT: &str = "sysom.cn-hangzhou.aliyuncs.com";
 const API_PATH: &str = "/api/v1/copilot/generate_copilot_stream_response";
 const API_VERSION: &str = "2023-12-30";
 const API_ACTION: &str = "GenerateCopilotStreamResponse";
@@ -63,7 +63,13 @@ struct SysomCredentials {
 
 /// SysOM Provider that connects to Aliyun SysOM API with ACS3-HMAC-SHA256 signing.
 pub struct SysomProvider {
-    endpoint: String,
+    /// Explicit endpoint override from configuration; empty when unset.
+    ///
+    /// The effective host is resolved per request rather than here because
+    /// these constructors are synchronous yet run inside the tokio runtime: a
+    /// blocking reachability probe would occupy a worker thread. Resolution is
+    /// cached process-wide, so the probe still runs at most once.
+    configured_endpoint: String,
     credentials: RwLock<SysomCredentials>,
     is_sts: bool,
     cancelled: Arc<AtomicBool>,
@@ -71,11 +77,16 @@ pub struct SysomProvider {
 }
 
 impl SysomProvider {
-    pub fn new(access_key_id: &str, access_key_secret: &str, security_token: Option<&str>) -> Self {
+    pub fn new(
+        access_key_id: &str,
+        access_key_secret: &str,
+        security_token: Option<&str>,
+        configured_endpoint: &str,
+    ) -> Self {
         let is_sts = security_token.is_some();
         let instance_id = resolve_instance_id();
         Self {
-            endpoint: DEFAULT_ENDPOINT.to_string(),
+            configured_endpoint: configured_endpoint.to_string(),
             credentials: RwLock::new(SysomCredentials {
                 access_key_id: access_key_id.to_string(),
                 access_key_secret: access_key_secret.to_string(),
@@ -87,10 +98,10 @@ impl SysomProvider {
         }
     }
 
-    pub fn from_ecs_ram_role() -> Self {
+    pub fn from_ecs_ram_role(configured_endpoint: &str) -> Self {
         let instance_id = resolve_instance_id();
         Self {
-            endpoint: DEFAULT_ENDPOINT.to_string(),
+            configured_endpoint: configured_endpoint.to_string(),
             credentials: RwLock::new(SysomCredentials {
                 access_key_id: String::new(),
                 access_key_secret: String::new(),
@@ -100,11 +111,6 @@ impl SysomProvider {
             cancelled: Arc::new(AtomicBool::new(false)),
             instance_id,
         }
-    }
-
-    pub fn with_endpoint(mut self, endpoint: &str) -> Self {
-        self.endpoint = endpoint.to_string();
-        self
     }
 
     /// Build the JSON request body for the SysOM API.
@@ -269,14 +275,23 @@ impl SysomProvider {
     /// Send a streaming request using current credentials.
     async fn do_streaming_request(&self, body_bytes: &[u8]) -> Result<GenerateStream, String> {
         let creds = self.credentials.read().unwrap().clone();
-        let url = format!("https://{}{}", self.endpoint, API_PATH);
+        let resolved = endpoint::resolve(&self.configured_endpoint).await;
+        tracing::debug!(
+            host = %resolved.host,
+            origin = resolved.origin.as_str(),
+            "sysom endpoint"
+        );
+        let url = format!("{}{}", resolved.base_url(), API_PATH);
+        let host = resolved.host;
         let timestamp = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
         let nonce = Uuid::new_v4().to_string();
         let hashed_payload = hex_sha256(body_bytes);
 
-        // Build headers for signing
+        // `host` feeds the signature, the URL and the wire header alike: the
+        // gateway recomputes the signature from the Host it receives, so the
+        // three must not diverge.
         let mut sign_headers: Vec<(String, String)> = vec![
-            ("host".to_string(), self.endpoint.clone()),
+            ("host".to_string(), host.clone()),
             ("x-acs-version".to_string(), API_VERSION.to_string()),
             ("x-acs-action".to_string(), API_ACTION.to_string()),
             ("x-acs-date".to_string(), timestamp.clone()),
@@ -308,7 +323,7 @@ impl SysomProvider {
             .map_err(|err| format!("failed to build HTTP client: {err}"))?;
         let mut req = client
             .post(&url)
-            .header("host", &self.endpoint)
+            .header("host", &host)
             .header("x-acs-version", API_VERSION)
             .header("x-acs-action", API_ACTION)
             .header("x-acs-date", &timestamp)

--- a/src/cosh-ng/crates/cosh-core/src/provider/sysom.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/sysom.rs
@@ -47,6 +47,37 @@ const METADATA_READ_TIMEOUT: Duration = Duration::from_secs(2);
 /// measured at 61 seconds from an ECS with no public egress.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 
+/// Inactivity timeout for the SysOM API response.
+///
+/// A *total* request timeout is the wrong instrument: the response is a
+/// Server-Sent Events stream whose length belongs to the model, so a deadline
+/// would truncate healthy long completions. A read timeout applies per read and
+/// resets after each successful one, so it bounds a server that accepts the
+/// connection and then goes silent while leaving a steadily streaming response
+/// untouched.
+///
+/// Deliberately generous: the largest legitimate gap is time-to-first-token
+/// while the model is queued, and the goal is to turn an unbounded hang into a
+/// bounded failure rather than to police latency.
+const READ_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Build the HTTP client for the streaming API.
+///
+/// Both bounds are parameters so a test can assert the stalled-connection
+/// behaviour without waiting the production read timeout.
+fn build_streaming_client(
+    endpoint: &endpoint::ResolvedEndpoint,
+    connect_timeout: Duration,
+    read_timeout: Duration,
+) -> Result<reqwest::Client, String> {
+    endpoint
+        .configure_client(reqwest::Client::builder())
+        .connect_timeout(connect_timeout)
+        .read_timeout(read_timeout)
+        .build()
+        .map_err(|err| format!("failed to build HTTP client: {err}"))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EcsAuthChallenge {
     pub instance_id: String,
@@ -282,6 +313,7 @@ impl SysomProvider {
             "sysom endpoint"
         );
         let url = format!("{}{}", resolved.base_url(), API_PATH);
+        let client = build_streaming_client(&resolved, CONNECT_TIMEOUT, READ_TIMEOUT)?;
         let host = resolved.host;
         let timestamp = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
         let nonce = Uuid::new_v4().to_string();
@@ -314,13 +346,6 @@ impl SysomProvider {
         let authorization =
             self.sign_request("POST", API_PATH, &sign_headers, &hashed_payload, &creds);
 
-        // Bound connection setup only. No total request timeout: this is a
-        // Server-Sent Events stream whose lifetime is the model's, so a total
-        // timeout would truncate healthy long completions.
-        let client = reqwest::Client::builder()
-            .connect_timeout(CONNECT_TIMEOUT)
-            .build()
-            .map_err(|err| format!("failed to build HTTP client: {err}"))?;
         let mut req = client
             .post(&url)
             .header("host", &host)

--- a/src/cosh-ng/crates/cosh-core/src/provider/sysom/endpoint.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/sysom/endpoint.rs
@@ -1,0 +1,649 @@
+//! Endpoint resolution for the SysOM API, preferring the VPC proxy.
+//!
+//! ECS instances without public egress cannot reach the public SysOM endpoint,
+//! but Alibaba Cloud exposes the same service inside every VPC at
+//! `sysom.vpc-proxy.aliyuncs.com`. That name resolves only inside a VPC, and
+//! the VPC's private DNS maps it to the POP of the instance's own region, so the
+//! client needs no region handling of its own.
+//!
+//! Reachability is decided by a single bounded TCP connect rather than by
+//! probing the ECS metadata service: metadata returns 403 on hardened instances,
+//! which would misclassify exactly the hosts that most need the internal route.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::sync::OnceCell;
+
+/// Public endpoint, used when the VPC proxy is not reachable.
+pub const PUBLIC_HOST: &str = "sysom.cn-hangzhou.aliyuncs.com";
+
+/// VPC-internal endpoint. Region-less: private DNS resolves it per region.
+pub const VPC_PROXY_HOST: &str = "sysom.vpc-proxy.aliyuncs.com";
+
+/// Overrides the whole resolution, as an escape hatch and for debugging.
+const ENV_ENDPOINT: &str = "COSH_SYSOM_ENDPOINT";
+/// Redirects the probe target so tests can point it at a local listener.
+const ENV_PROBE_HOST: &str = "COSH_SYSOM_VPC_PROXY_HOST";
+/// Shortens the probe deadline so tests need not wait the production value.
+const ENV_PROBE_TIMEOUT_MS: &str = "COSH_SYSOM_PROBE_TIMEOUT_MS";
+
+/// Absolute deadline for the reachability probe.
+///
+/// Inside a VPC the proxy answers in tens of milliseconds. Outside one the name
+/// does not resolve, and an NXDOMAIN costs single-digit to ~90ms against a
+/// healthy resolver, so this deadline is the ceiling for a resolver that stalls
+/// rather than the routine cost of running on a non-VPC host.
+const PROBE_DEADLINE_MS: u64 = 500;
+
+/// Maximum length of a DNS name.
+const MAX_HOST_LEN: usize = 253;
+
+/// Scheme assumed for a bare host and used for the probed and fallback hosts.
+const DEFAULT_SCHEME: &str = "https";
+
+/// How the effective host was chosen. Surfaced in logs so an operator can tell
+/// which route an instance took without reproducing the probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EndpointOrigin {
+    /// Explicitly configured, via env var or `sysom_endpoint`.
+    Configured,
+    /// VPC proxy: the probe reached it.
+    VpcProxy,
+    /// Public endpoint: the probe failed, timed out, or this is not a VPC host.
+    Public,
+}
+
+impl EndpointOrigin {
+    /// Stable identifier for logs.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Configured => "configured",
+            Self::VpcProxy => "vpc_proxy",
+            Self::Public => "public",
+        }
+    }
+}
+
+/// The chosen SysOM endpoint and how it was chosen.
+pub struct ResolvedEndpoint {
+    /// Bare `host` or `host:port`.
+    ///
+    /// Invariant: carries no scheme, slash or path. Callers use it verbatim as
+    /// the signed `host` header, so any extra character would desynchronise the
+    /// signature from the wire Host and the gateway would answer
+    /// `SignatureDoesNotMatch`.
+    pub host: String,
+    /// `http` or `https`.
+    ///
+    /// Carried separately rather than assumed, because a configured endpoint may
+    /// legitimately be plain HTTP — a local proxy or a test server — and forcing
+    /// TLS onto it turns a working configuration into a handshake failure.
+    pub scheme: String,
+    pub origin: EndpointOrigin,
+}
+
+impl ResolvedEndpoint {
+    /// Scheme and host joined, without a trailing slash or path.
+    pub fn base_url(&self) -> String {
+        format!("{}://{}", self.scheme, self.host)
+    }
+
+    /// Keep automatic VPC requests on the same direct path as the probe.
+    pub fn configure_client(&self, builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
+        match self.origin {
+            EndpointOrigin::VpcProxy => builder.no_proxy(),
+            EndpointOrigin::Configured | EndpointOrigin::Public => builder,
+        }
+    }
+}
+
+/// Probe result, computed at most once per process.
+///
+/// Wrapped in a `Mutex<Option<..>>` so tests can swap in a fresh cell.
+static VPC_REACHABLE: Mutex<Option<Arc<OnceCell<bool>>>> = Mutex::new(None);
+
+/// Return the shared probe cache, creating it if necessary.
+fn reachability_cache() -> Arc<OnceCell<bool>> {
+    VPC_REACHABLE
+        .lock()
+        .expect("vpc reachability cache lock")
+        .get_or_insert_with(Arc::default)
+        .clone()
+}
+
+/// Resolve the SysOM host, preferring the VPC proxy when it is reachable.
+///
+/// Priority, short-circuiting on the first match so an explicit choice never
+/// pays for the probe:
+///
+/// 1. `COSH_SYSOM_ENDPOINT`
+/// 2. `configured_endpoint` (the provider's `sysom_endpoint` setting)
+/// 3. VPC proxy, if the probe reaches it
+/// 4. Public endpoint
+///
+/// Step 2 deliberately does not read `base_url`: that setting is
+/// OpenAI-compatible and defaults to a DashScope address, so honouring it here
+/// sent ACS3-signed SysOM traffic to DashScope.
+///
+/// A *failed* probe lands on the public endpoint, which is the behaviour before
+/// VPC support existed, so an unreachable proxy degrades to "no improvement"
+/// rather than to a new outage.
+///
+/// A *successful* probe commits the process: the verdict is cached for the
+/// process lifetime and requests carry no fallback of their own. A proxy that
+/// completes the TCP handshake but cannot serve the API, or a route that
+/// disappears after the probe, therefore fails hard instead of reverting to
+/// public. Recovering from that would mean re-signing against a second host
+/// mid-request, which is out of scope here.
+pub async fn resolve(configured_endpoint: &str) -> ResolvedEndpoint {
+    if let Some((scheme, host)) = env_endpoint(ENV_ENDPOINT) {
+        tracing::debug!(host = %host, origin = "configured", "sysom endpoint from env");
+        return ResolvedEndpoint {
+            host,
+            scheme,
+            origin: EndpointOrigin::Configured,
+        };
+    }
+    if let Some((scheme, host)) = split_endpoint(configured_endpoint) {
+        tracing::debug!(host = %host, origin = "configured", "sysom endpoint from config");
+        return ResolvedEndpoint {
+            host,
+            scheme,
+            origin: EndpointOrigin::Configured,
+        };
+    }
+    if probe_vpc_proxy().await {
+        return ResolvedEndpoint {
+            host: VPC_PROXY_HOST.to_string(),
+            scheme: DEFAULT_SCHEME.to_string(),
+            origin: EndpointOrigin::VpcProxy,
+        };
+    }
+    ResolvedEndpoint {
+        host: PUBLIC_HOST.to_string(),
+        scheme: DEFAULT_SCHEME.to_string(),
+        origin: EndpointOrigin::Public,
+    }
+}
+
+/// Read an env var as an endpoint, ignoring values that are empty or malformed.
+///
+/// Ignoring beats failing here: a typo in an override must not take the provider
+/// down, and must not let an arbitrary string reach the signed `host` header.
+fn env_endpoint(key: &str) -> Option<(String, String)> {
+    split_endpoint(&std::env::var(key).ok()?)
+}
+
+/// Split a configured endpoint into its scheme and bare `host` or `host:port`.
+///
+/// Accepts what the existing config shapes allow — a bare host, or a URL with a
+/// scheme, port and path — and returns `None` for anything that fails
+/// validation. A bare host is assumed to be HTTPS.
+///
+/// Only `http` and `https` are admitted; anything else (`file`, `ftp`, …) is
+/// rejected rather than silently reduced to its host.
+fn split_endpoint(input: &str) -> Option<(String, String)> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let url = if trimmed.contains("://") {
+        reqwest::Url::parse(trimmed).ok()?
+    } else {
+        if !is_valid_host(trimmed) {
+            return None;
+        }
+        reqwest::Url::parse(&format!("{DEFAULT_SCHEME}://{trimmed}")).ok()?
+    };
+    let scheme = url.scheme();
+    if !matches!(scheme, "http" | "https") {
+        return None;
+    }
+    let host = url.host_str()?;
+    let host = match url.port() {
+        Some(port) => format!("{host}:{port}"),
+        None => host.to_string(),
+    };
+    is_valid_host(&host).then(|| (scheme.to_string(), host))
+}
+
+/// Accept only characters legal in a host or `host:port`.
+///
+/// The allowlist is what upholds the `ResolvedEndpoint::host` invariant: it
+/// admits no scheme separator, slash, whitespace or control character.
+fn is_valid_host(host: &str) -> bool {
+    !host.is_empty()
+        && host.len() <= MAX_HOST_LEN
+        && host
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | ':'))
+}
+
+/// Probe target as `host:port`, honouring the test override.
+///
+/// Any scheme on the override is ignored: the probe is a bare TCP connect.
+fn probe_target() -> String {
+    match env_endpoint(ENV_PROBE_HOST).map(|(_, host)| host) {
+        Some(host) if host.contains(':') => host,
+        Some(host) => format!("{host}:443"),
+        None => format!("{VPC_PROXY_HOST}:443"),
+    }
+}
+
+/// Probe deadline, honouring the test override.
+fn probe_deadline() -> Duration {
+    let millis = std::env::var(ENV_PROBE_TIMEOUT_MS)
+        .ok()
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(PROBE_DEADLINE_MS);
+    Duration::from_millis(millis)
+}
+
+/// Whether the VPC proxy accepts a TCP connection, computed once per process.
+///
+/// One connect covers both DNS resolution and L4 reachability. DNS failure,
+/// refusal and timeout are all treated the same: not reachable.
+///
+/// The deadline bounds the *caller*, not the resolver. `TcpStream::connect`
+/// resolves a hostname on the blocking pool, and `timeout` can only detach that
+/// task, never cancel it, so a wedged resolver keeps one blocking thread busy
+/// after `resolve` has already returned. The per-process cache bounds that to a
+/// single occurrence. `sls::fetch_region_id_from_metadata` has no such tail
+/// because it dials a fixed `SocketAddr` and never resolves a name.
+async fn probe_vpc_proxy() -> bool {
+    let cell = reachability_cache();
+    *cell
+        .get_or_init(|| async {
+            let target = probe_target();
+            let deadline = probe_deadline();
+            let started = std::time::Instant::now();
+            let reachable = matches!(
+                tokio::time::timeout(deadline, tokio::net::TcpStream::connect(&target)).await,
+                Ok(Ok(_))
+            );
+            tracing::info!(
+                target = %target,
+                reachable,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "sysom vpc proxy probe"
+            );
+            reachable
+        })
+        .await
+}
+
+#[cfg(test)]
+fn reset_reachability_cache() {
+    *VPC_REACHABLE.lock().expect("vpc reachability cache lock") = None;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::TcpListener;
+
+    use super::*;
+
+    /// Serialize env-var-dependent tests to avoid cross-test interference.
+    static ENV_TEST_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    /// RAII guard that restores an env var on drop so tests never leak state
+    /// even if the test body panics.
+    struct EnvVarGuard {
+        key: &'static str,
+        old_value: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let old_value = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, old_value }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let old_value = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, old_value }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.old_value {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    /// Address that swallows packets without answering, so the probe can only
+    /// end by hitting its deadline. TEST-NET-1 (RFC 5737) is reserved for
+    /// documentation and is not routable, so no real host is contacted.
+    const BLACKHOLE: &str = "192.0.2.1:443";
+
+    /// Bind a listener that accepts connections, standing in for the proxy.
+    fn live_listener() -> TcpListener {
+        TcpListener::bind("127.0.0.1:0").expect("bind probe listener")
+    }
+
+    /// Bind then drop, yielding an address that refuses connections.
+    fn closed_port() -> String {
+        let listener = live_listener();
+        let addr = listener.local_addr().expect("listener addr").to_string();
+        drop(listener);
+        addr
+    }
+
+    fn assert_host_invariant(host: &str) {
+        assert!(
+            !host.contains("://"),
+            "host must not carry a scheme: {host}"
+        );
+        assert!(!host.contains('/'), "host must not carry a path: {host}");
+    }
+
+    async fn http_responder(body: &'static str) -> (String, tokio::task::JoinHandle<()>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap().to_string();
+        let task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 4096];
+            assert!(stream.read(&mut request).await.unwrap() > 0);
+            stream
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+        });
+        (address, task)
+    }
+
+    #[tokio::test]
+    async fn only_automatic_vpc_routes_bypass_proxy() {
+        for (origin, expected) in [
+            (EndpointOrigin::VpcProxy, "direct"),
+            (EndpointOrigin::Configured, "proxy"),
+            (EndpointOrigin::Public, "proxy"),
+        ] {
+            let (host, direct) = http_responder("direct").await;
+            let (proxy_host, proxy) = http_responder("proxy").await;
+            let resolved = ResolvedEndpoint {
+                host,
+                scheme: "http".to_string(),
+                origin,
+            };
+            let builder = reqwest::Client::builder()
+                .proxy(reqwest::Proxy::all(format!("http://{proxy_host}")).unwrap())
+                .timeout(Duration::from_secs(3));
+            let client = resolved.configure_client(builder).build().unwrap();
+            let response = client.get(resolved.base_url()).send().await;
+            let body = match response {
+                Ok(response) => response.text().await,
+                Err(err) => Err(err),
+            };
+            direct.abort();
+            proxy.abort();
+            let _ = direct.await;
+            let _ = proxy.await;
+            assert_eq!(body.unwrap(), expected, "origin={origin:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn env_override_wins_and_skips_probe() {
+        let _lock = ENV_TEST_MUTEX.lock().await;
+        reset_reachability_cache();
+        let listener = live_listener();
+        let probe_addr = listener.local_addr().expect("listener addr").to_string();
+        let _endpoint = EnvVarGuard::set(ENV_ENDPOINT, "sysom.cn-shanghai.aliyuncs.com");
+        let _probe = EnvVarGuard::set(ENV_PROBE_HOST, &probe_addr);
+
+        let resolved = resolve("").await;
+
+        assert_eq!(resolved.origin, EndpointOrigin::Configured);
+        assert_eq!(resolved.host, "sysom.cn-shanghai.aliyuncs.com");
+        assert_host_invariant(&resolved.host);
+
+        // Nothing must have dialed the probe target.
+        listener
+            .set_nonblocking(true)
+            .expect("listener nonblocking");
+        assert!(
+            listener.accept().is_err(),
+            "probe ran despite an explicit endpoint override"
+        );
+    }
+
+    #[tokio::test]
+    async fn configured_endpoint_wins_and_skips_probe() {
+        let _lock = ENV_TEST_MUTEX.lock().await;
+        reset_reachability_cache();
+        let listener = live_listener();
+        let probe_addr = listener.local_addr().expect("listener addr").to_string();
+        let _endpoint = EnvVarGuard::remove(ENV_ENDPOINT);
+        let _probe = EnvVarGuard::set(ENV_PROBE_HOST, &probe_addr);
+
+        let resolved = resolve("http://127.0.0.1:8080/v1").await;
+
+        assert_eq!(resolved.origin, EndpointOrigin::Configured);
+        assert_eq!(resolved.host, "127.0.0.1:8080");
+        assert_host_invariant(&resolved.host);
+
+        listener
+            .set_nonblocking(true)
+            .expect("listener nonblocking");
+        assert!(
+            listener.accept().is_err(),
+            "probe ran despite an explicit configured endpoint"
+        );
+    }
+
+    /// Pins step 1 above step 2. Without this, inverting the two leaves every
+    /// other test green: each one sets at most one of the pair, so nothing
+    /// observes which of them outranks the other.
+    #[tokio::test]
+    async fn env_override_outranks_configured_endpoint() {
+        let _lock = ENV_TEST_MUTEX.lock().await;
+        reset_reachability_cache();
+        let _endpoint = EnvVarGuard::set(ENV_ENDPOINT, "from-env.example.com");
+
+        let resolved = resolve("https://from-config.example.com").await;
+        assert_eq!(resolved.host, "from-env.example.com");
+
+        drop(_endpoint);
+        let _absent = EnvVarGuard::remove(ENV_ENDPOINT);
+        reset_reachability_cache();
+
+        let resolved = resolve("https://from-config.example.com").await;
+        assert_eq!(resolved.host, "from-config.example.com");
+    }
+
+    #[tokio::test]
+    async fn reachable_probe_selects_vpc_proxy() {
+        let _lock = ENV_TEST_MUTEX.lock().await;
+        reset_reachability_cache();
+        let listener = live_listener();
+        let probe_addr = listener.local_addr().expect("listener addr").to_string();
+        let _endpoint = EnvVarGuard::remove(ENV_ENDPOINT);
+        let _probe = EnvVarGuard::set(ENV_PROBE_HOST, &probe_addr);
+
+        let resolved = resolve("").await;
+
+        assert_eq!(resolved.origin, EndpointOrigin::VpcProxy);
+        assert_eq!(resolved.host, VPC_PROXY_HOST);
+        assert_host_invariant(&resolved.host);
+    }
+
+    #[tokio::test]
+    async fn unresolvable_probe_falls_back_to_public() {
+        let _lock = ENV_TEST_MUTEX.lock().await;
+        reset_reachability_cache();
+        let _endpoint = EnvVarGuard::remove(ENV_ENDPOINT);
+        let _probe = EnvVarGuard::set(ENV_PROBE_HOST, "no-such-host.invalid:443");
+
+        let resolved = resolve("").await;
+
+        assert_eq!(resolved.origin, EndpointOrigin::Public);
+        assert_eq!(resolved.host, PUBLIC_HOST);
+        assert_host_invariant(&resolved.host);
+    }
+
+    #[tokio::test]
+    async fn refused_probe_falls_back_to_public() {
+        let _lock = ENV_TEST_MUTEX.lock().await;
+        reset_reachability_cache();
+        let _endpoint = EnvVarGuard::remove(ENV_ENDPOINT);
+        let _probe = EnvVarGuard::set(ENV_PROBE_HOST, &closed_port());
+
+        let resolved = resolve("").await;
+
+        assert_eq!(resolved.origin, EndpointOrigin::Public);
+        assert_eq!(resolved.host, PUBLIC_HOST);
+    }
+
+    /// The load-bearing test for "a failed probe must not look like a hang":
+    /// against a black hole, resolution must still return within the deadline.
+    ///
+    /// Weak on networks that answer TEST-NET-1 with `ENETUNREACH` instead of
+    /// dropping the packets: there the connect fails immediately and this
+    /// degrades into another refusal test, passing without exercising the
+    /// deadline at all. A green run is therefore not by itself proof that the
+    /// deadline works.
+    #[tokio::test]
+    async fn blackholed_probe_respects_deadline() {
+        let _lock = ENV_TEST_MUTEX.lock().await;
+        reset_reachability_cache();
+        let _endpoint = EnvVarGuard::remove(ENV_ENDPOINT);
+        let _probe = EnvVarGuard::set(ENV_PROBE_HOST, BLACKHOLE);
+        let _timeout = EnvVarGuard::set(ENV_PROBE_TIMEOUT_MS, "200");
+
+        let started = std::time::Instant::now();
+        let resolved = resolve("").await;
+        let elapsed = started.elapsed();
+
+        assert_eq!(resolved.origin, EndpointOrigin::Public);
+        assert!(
+            elapsed < Duration::from_millis(1_000),
+            "resolution took {elapsed:?}, deadline was 200ms"
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_env_override_is_ignored() {
+        let _lock = ENV_TEST_MUTEX.lock().await;
+        reset_reachability_cache();
+        let _probe = EnvVarGuard::set(ENV_PROBE_HOST, &closed_port());
+
+        for bad in ["evil.com/../path", "host with space", "", "host\u{7f}name"] {
+            reset_reachability_cache();
+            let _endpoint = EnvVarGuard::set(ENV_ENDPOINT, bad);
+            let resolved = resolve("").await;
+            assert_eq!(
+                resolved.origin,
+                EndpointOrigin::Public,
+                "malformed override {bad:?} was not ignored"
+            );
+            assert_host_invariant(&resolved.host);
+        }
+    }
+
+    #[test]
+    fn split_endpoint_accepts_supported_shapes() {
+        assert_eq!(
+            split_endpoint("sysom.cn-hangzhou.aliyuncs.com"),
+            Some((
+                "https".to_string(),
+                "sysom.cn-hangzhou.aliyuncs.com".to_string()
+            ))
+        );
+        assert_eq!(
+            split_endpoint("https://sysom.cn-hangzhou.aliyuncs.com"),
+            Some((
+                "https".to_string(),
+                "sysom.cn-hangzhou.aliyuncs.com".to_string()
+            ))
+        );
+        assert_eq!(
+            split_endpoint("http://127.0.0.1:8080/v1"),
+            Some(("http".to_string(), "127.0.0.1:8080".to_string()))
+        );
+        assert_eq!(
+            split_endpoint("  spaced.example.com  "),
+            Some(("https".to_string(), "spaced.example.com".to_string()))
+        );
+    }
+
+    #[test]
+    fn bare_endpoints_follow_the_same_url_validation() {
+        for host in ["proxy:65536", "proxy:invalid", "proxy:80:90", ":443"] {
+            assert_eq!(split_endpoint(host), None, "accepted {host}");
+            assert_eq!(split_endpoint(&format!("https://{host}")), None);
+        }
+        for host in ["EXAMPLE.COM:443", "example.com:8443", "127.0.0.1:8080"] {
+            assert_eq!(
+                split_endpoint(host),
+                split_endpoint(&format!("https://{host}"))
+            );
+        }
+    }
+
+    #[test]
+    fn split_endpoint_rejects_unsupported_shapes() {
+        assert_eq!(split_endpoint(""), None);
+        assert_eq!(split_endpoint("   "), None);
+        assert_eq!(split_endpoint("host/path"), None);
+        assert_eq!(split_endpoint("host with space"), None);
+        assert_eq!(split_endpoint(&"a".repeat(MAX_HOST_LEN + 1)), None);
+        assert_eq!(split_endpoint("file:///etc/passwd"), None);
+        assert_eq!(split_endpoint("ftp://example.com"), None);
+    }
+
+    /// IPv6 is unsupported, and must stay *rejected* rather than half-accepted:
+    /// `host_str` keeps the brackets, which the host allowlist excludes, so the
+    /// value never reaches the signed `host` header. Admitting IPv6 later means
+    /// deciding whether the brackets belong in the signature, so this pins the
+    /// boundary instead of leaving it to chance.
+    #[test]
+    fn split_endpoint_rejects_ipv6() {
+        assert_eq!(split_endpoint("http://[::1]:8080/v1"), None);
+        assert_eq!(split_endpoint("https://[2400:3200::1]"), None);
+        assert_eq!(split_endpoint("[::1]:8080"), None);
+    }
+
+    /// A plain-HTTP endpoint must stay plain HTTP. Upgrading it to HTTPS turns a
+    /// working local proxy or test server into a TLS handshake failure.
+    #[tokio::test]
+    async fn configured_http_scheme_is_preserved() {
+        let _lock = ENV_TEST_MUTEX.lock().await;
+        reset_reachability_cache();
+        let _endpoint = EnvVarGuard::remove(ENV_ENDPOINT);
+
+        let resolved = resolve("http://127.0.0.1:9999/v1").await;
+
+        assert_eq!(resolved.scheme, "http");
+        assert_eq!(resolved.host, "127.0.0.1:9999");
+        assert_eq!(resolved.base_url(), "http://127.0.0.1:9999");
+        assert_host_invariant(&resolved.host);
+    }
+
+    #[tokio::test]
+    async fn probed_and_fallback_hosts_use_https() {
+        let _lock = ENV_TEST_MUTEX.lock().await;
+        reset_reachability_cache();
+        let _endpoint = EnvVarGuard::remove(ENV_ENDPOINT);
+        let _probe = EnvVarGuard::set(ENV_PROBE_HOST, "no-such-host.invalid:443");
+
+        let resolved = resolve("").await;
+
+        assert_eq!(resolved.scheme, "https");
+        assert_eq!(resolved.base_url(), format!("https://{PUBLIC_HOST}"));
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/provider/sysom/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/sysom/tests.rs
@@ -1,5 +1,194 @@
 use super::*;
 
+use futures::FutureExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream as AsyncTcpStream};
+use tokio::sync::oneshot;
+
+const TEST_READ_TIMEOUT: Duration = Duration::from_secs(1);
+const TEST_COMPLETION_BOUND: Duration = Duration::from_secs(5);
+const TEST_WATCHDOG: Duration = Duration::from_secs(10);
+const CHUNK_INTERVAL: Duration = Duration::from_millis(250);
+const KEEPALIVE_CHUNKS: usize = 12;
+const FIRST_EVENT: &str = "data: first\n\n";
+const KEEPALIVE_EVENT: &str = "data: keep-alive\n\n";
+const DONE_EVENT: &str = "data: [DONE]\n\n";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StreamingScenario {
+    SilentBeforeHeaders,
+    SilentAfterHeaders,
+    SilentAfterFirstChunk,
+    Healthy,
+}
+
+async fn write_sse_chunk(socket: &mut AsyncTcpStream, event: &str) -> std::io::Result<()> {
+    let chunk = format!("{:x}\r\n{event}\r\n", event.len());
+    socket.write_all(chunk.as_bytes()).await
+}
+
+async fn serve_streaming_scenario(
+    listener: TcpListener,
+    scenario: StreamingScenario,
+    request_received: oneshot::Sender<()>,
+) -> std::io::Result<()> {
+    let (mut socket, _) = listener.accept().await?;
+    socket.set_nodelay(true)?;
+    let mut request = Vec::new();
+    let mut buffer = [0; 1024];
+    while !request.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+        let read = socket.read(&mut buffer).await?;
+        if read == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "client closed before sending request headers",
+            ));
+        }
+        request.extend_from_slice(&buffer[..read]);
+    }
+    let _ = request_received.send(());
+
+    if scenario != StreamingScenario::SilentBeforeHeaders {
+        socket
+            .write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\
+                  Transfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
+            )
+            .await?;
+    }
+    if matches!(
+        scenario,
+        StreamingScenario::SilentAfterFirstChunk | StreamingScenario::Healthy
+    ) {
+        write_sse_chunk(&mut socket, FIRST_EVENT).await?;
+    }
+    if scenario == StreamingScenario::Healthy {
+        for _ in 0..KEEPALIVE_CHUNKS {
+            tokio::time::sleep(CHUNK_INTERVAL).await;
+            write_sse_chunk(&mut socket, KEEPALIVE_EVENT).await?;
+        }
+        write_sse_chunk(&mut socket, DONE_EVENT).await?;
+        socket.write_all(b"0\r\n\r\n").await?;
+        socket.shutdown().await?;
+    } else {
+        std::future::pending::<()>().await;
+    }
+    drop(socket);
+    Ok(())
+}
+
+async fn check_streaming_scenario(scenario: StreamingScenario) {
+    let mut server = None;
+    let outcome = tokio::time::timeout(
+        TEST_WATCHDOG,
+        std::panic::AssertUnwindSafe(async {
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind streaming fixture");
+            let endpoint = endpoint::ResolvedEndpoint {
+                host: listener.local_addr().expect("fixture address").to_string(),
+                scheme: "http".to_string(),
+                // Isolate this loopback fixture from host proxies; this is not a VPC probe.
+                origin: endpoint::EndpointOrigin::VpcProxy,
+            };
+            let client =
+                build_streaming_client(&endpoint, Duration::from_secs(3), TEST_READ_TIMEOUT)
+                    .expect("build streaming client");
+            let (request_received_tx, request_received_rx) = oneshot::channel();
+            server = Some(tokio::spawn(serve_streaming_scenario(
+                listener,
+                scenario,
+                request_received_tx,
+            )));
+
+            let started = std::time::Instant::now();
+            let request = client.post(endpoint.base_url());
+            let (received, response) = tokio::join!(request_received_rx, request.send());
+            received.expect("fixture must accept the connection and receive request headers");
+
+            if scenario == StreamingScenario::SilentBeforeHeaders {
+                let error = response.expect_err("silent response headers must time out");
+                assert!(error.is_timeout(), "expected a read timeout, got {error:?}");
+            } else {
+                let mut response = response.expect("receive SSE response headers");
+                assert_eq!(response.status(), reqwest::StatusCode::OK);
+                assert_eq!(response.headers()["content-type"], "text/event-stream");
+
+                if scenario == StreamingScenario::Healthy {
+                    let body = response.text().await.expect("healthy SSE must finish");
+                    let expected = format!(
+                        "{FIRST_EVENT}{}{DONE_EVENT}",
+                        KEEPALIVE_EVENT.repeat(KEEPALIVE_CHUNKS)
+                    );
+                    assert_eq!(body, expected);
+                    assert!(
+                        started.elapsed() > TEST_READ_TIMEOUT,
+                        "healthy stream must outlive a total request timeout"
+                    );
+                } else {
+                    if scenario == StreamingScenario::SilentAfterFirstChunk {
+                        let mut first = Vec::new();
+                        while first.len() < FIRST_EVENT.len() {
+                            let chunk = response
+                                .chunk()
+                                .await
+                                .expect("read the first SSE event")
+                                .expect("first SSE event must not be EOF");
+                            first.extend_from_slice(&chunk);
+                        }
+                        assert_eq!(first, FIRST_EVENT.as_bytes());
+                    }
+                    let error = response
+                        .chunk()
+                        .await
+                        .expect_err("stalled SSE body must time out, not reach EOF");
+                    assert!(error.is_timeout(), "expected a read timeout, got {error:?}");
+                }
+            }
+            assert!(
+                started.elapsed() < TEST_COMPLETION_BOUND,
+                "{scenario:?} exceeded {TEST_COMPLETION_BOUND:?}"
+            );
+        })
+        .catch_unwind(),
+    )
+    .await;
+
+    // Reap the server even when an assertion panics or the watchdog expires.
+    if let Some(server) = server {
+        server.abort();
+        match server.await {
+            Ok(result) => result.expect("streaming fixture failed"),
+            Err(error) => assert!(error.is_cancelled(), "fixture task failed: {error}"),
+        }
+    }
+    match outcome {
+        Ok(Ok(())) => {}
+        Ok(Err(panic)) => std::panic::resume_unwind(panic),
+        Err(error) => panic!("{scenario:?} exceeded watchdog {TEST_WATCHDOG:?}: {error}"),
+    }
+}
+
+#[tokio::test]
+async fn streaming_client_bounds_a_silent_server() {
+    check_streaming_scenario(StreamingScenario::SilentBeforeHeaders).await;
+}
+
+#[tokio::test]
+async fn streaming_client_bounds_silence_after_sse_headers() {
+    check_streaming_scenario(StreamingScenario::SilentAfterHeaders).await;
+}
+
+#[tokio::test]
+async fn streaming_client_bounds_silence_after_first_chunk() {
+    check_streaming_scenario(StreamingScenario::SilentAfterFirstChunk).await;
+}
+
+#[tokio::test]
+async fn streaming_client_preserves_a_healthy_long_stream() {
+    check_streaming_scenario(StreamingScenario::Healthy).await;
+}
+
 #[test]
 fn region_id_strips_single_zone_suffix() {
     assert_eq!(

--- a/src/cosh-ng/crates/cosh-core/src/provider/sysom/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/sysom/tests.rs
@@ -24,7 +24,7 @@ fn generate_console_url_uses_region_and_instance_id() {
 #[test]
 fn build_request_preserves_user_provided_secrets() {
     let provider = SysomProvider {
-        endpoint: DEFAULT_ENDPOINT.to_string(),
+        configured_endpoint: String::new(),
         credentials: std::sync::RwLock::new(SysomCredentials {
             access_key_id: "test-id".to_string(),
             access_key_secret: "test-secret".to_string(),
@@ -46,7 +46,7 @@ fn build_request_preserves_user_provided_secrets() {
 
 fn test_provider() -> SysomProvider {
     SysomProvider {
-        endpoint: DEFAULT_ENDPOINT.to_string(),
+        configured_endpoint: String::new(),
         credentials: std::sync::RwLock::new(SysomCredentials {
             access_key_id: "test-id".to_string(),
             access_key_secret: "test-secret".to_string(),

--- a/src/cosh-ng/crates/cosh-core/tests/registry_protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/registry_protocol.rs
@@ -1,17 +1,69 @@
-use std::io::{Read, Write};
-use std::net::TcpListener;
+use std::io::{self, Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use serde_json::Value;
+use tokio::io::AsyncWriteExt;
+
+const SERVER_ACCEPT_TIMEOUT: Duration = Duration::from_secs(10);
+const SERVER_IO_TIMEOUT: Duration = Duration::from_secs(5);
+const REGISTRY_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn accept_with_timeout(listener: &TcpListener, timeout: Duration) -> io::Result<TcpStream> {
+    listener.set_nonblocking(true)?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        if Instant::now() >= deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "mock server did not receive the expected connection",
+            ));
+        }
+        match listener.accept() {
+            Ok((stream, _)) => {
+                stream.set_nonblocking(false)?;
+                stream.set_read_timeout(Some(SERVER_IO_TIMEOUT))?;
+                stream.set_write_timeout(Some(SERVER_IO_TIMEOUT))?;
+                return Ok(stream);
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                std::thread::sleep(
+                    Duration::from_millis(10)
+                        .min(deadline.saturating_duration_since(Instant::now())),
+                );
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[test]
+fn mock_server_without_connection_times_out() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let server = std::thread::spawn(move || {
+        let result = accept_with_timeout(&listener, Duration::from_millis(50));
+        sender.send(result.map(|_| ())).unwrap();
+    });
+
+    let error = receiver
+        .recv_timeout(Duration::from_secs(2))
+        .expect("mock server did not finish within its deadline")
+        .expect_err("mock server must fail when no client connects");
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    server.join().unwrap();
+}
 
 fn model_server() -> (String, std::thread::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let address = listener.local_addr().unwrap();
     let thread = std::thread::spawn(move || {
-        let (mut stream, _) = listener.accept().unwrap();
+        let mut stream = accept_with_timeout(&listener, SERVER_ACCEPT_TIMEOUT).unwrap();
         let mut request = [0_u8; 2048];
-        let _ = stream.read(&mut request);
+        assert!(stream.read(&mut request).unwrap() > 0);
         let body = r#"{"id":"home-model","object":"model"}"#;
         write!(
             stream,
@@ -28,9 +80,9 @@ fn rejecting_model_server(status: u16) -> (String, std::thread::JoinHandle<()>) 
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let address = listener.local_addr().unwrap();
     let thread = std::thread::spawn(move || {
-        let (mut stream, _) = listener.accept().unwrap();
+        let mut stream = accept_with_timeout(&listener, SERVER_ACCEPT_TIMEOUT).unwrap();
         let mut request = [0_u8; 2048];
-        let _ = stream.read(&mut request);
+        assert!(stream.read(&mut request).unwrap() > 0);
         let body = r#"{"error":{"code":"invalid_api_key"}}"#;
         write!(
             stream,
@@ -47,7 +99,7 @@ fn aliyun_response_server(body: &'static str) -> (String, std::thread::JoinHandl
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let address = listener.local_addr().unwrap();
     let thread = std::thread::spawn(move || {
-        let (mut stream, _) = listener.accept().unwrap();
+        let mut stream = accept_with_timeout(&listener, SERVER_ACCEPT_TIMEOUT).unwrap();
         let mut request = [0_u8; 4096];
         let count = stream.read(&mut request).unwrap();
         let request = String::from_utf8_lossy(&request[..count]);
@@ -82,7 +134,7 @@ fn aliyun_copilot_rejection_server(
                 body,
             ),
         ] {
-            let (mut stream, _) = listener.accept().unwrap();
+            let mut stream = accept_with_timeout(&listener, SERVER_ACCEPT_TIMEOUT).unwrap();
             let mut request = [0_u8; 4096];
             let count = stream.read(&mut request).unwrap();
             let request = String::from_utf8_lossy(&request[..count]);
@@ -166,6 +218,9 @@ fn run_registry_request_with_args_and_env(
         .env_remove("XDG_DATA_HOME")
         .env_remove("COSH_AI_PROVIDER")
         .env_remove("COSH_MODEL")
+        .env_remove("COSH_SYSOM_ENDPOINT")
+        .env_remove("COSH_SYSOM_VPC_PROXY_HOST")
+        .env_remove("COSH_SYSOM_PROBE_TIMEOUT_MS")
         .env_remove("OPENAI_BASE_URL")
         .env_remove("DASHSCOPE_API_KEY")
         .env_remove("OPENAI_API_KEY")
@@ -182,17 +237,27 @@ fn run_registry_request_with_args_and_env(
     registry_command_response(command, request)
 }
 
-fn registry_command_response(mut command: Command, request: Value) -> Value {
-    let mut child = command
-        .spawn()
-        .unwrap_or_else(|e| panic!("Failed to spawn registry command: {e}"));
-
-    {
-        let stdin = child.stdin.as_mut().unwrap();
-        writeln!(stdin, "{}", serde_json::to_string(&request).unwrap()).unwrap();
-    }
-
-    let output = child.wait_with_output().unwrap();
+fn registry_command_response(command: Command, request: Value) -> Value {
+    let output = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let mut child = tokio::process::Command::from(command)
+                .kill_on_drop(true)
+                .spawn()
+                .unwrap_or_else(|e| panic!("Failed to spawn registry command: {e}"));
+            let mut stdin = child.stdin.take().unwrap();
+            let request = format!("{request}\n");
+            tokio::time::timeout(REGISTRY_TIMEOUT, async move {
+                let write_request = async move { stdin.write_all(request.as_bytes()).await };
+                let (written, output) = tokio::join!(write_request, child.wait_with_output());
+                written.expect("failed to write registry request");
+                output.expect("failed to collect registry output")
+            })
+            .await
+            .expect("registry command exceeded its deadline")
+        });
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     stdout
@@ -1124,39 +1189,66 @@ fn registry_auth_preflight_rejection_is_classified_without_writing_config() {
 
 #[test]
 fn registry_auth_rejects_missing_aliyun_role_without_writing_config() {
-    let home = tempfile::tempdir().expect("temp home");
-    let config_path = home.path().join(".copilot-shell/config.toml");
-    let (base_url, server) =
-        aliyun_response_server(r#"{"code":"Success","data":{"role_exist":false}}"#);
-    let response = run_registry_request_with_context(
-        "auth",
-        "configure",
-        serde_json::json!({
-            "provider_id": "sysom-not-ready",
-            "provider_type": "aliyun",
-            "values": {
-                "base_url": base_url,
-                "access_key_id": "test-access-key",
-                "access_key_secret": "test-secret",
-                "model": "qwen-test"
-            }
-        }),
-        home.path(),
-        None,
-    );
-    server.join().unwrap();
+    for saved_profile in [true, false] {
+        let home = tempfile::tempdir().expect("temp home");
+        let config_path = home.path().join(".copilot-shell/config.toml");
+        let (sysom_endpoint, server) =
+            aliyun_response_server(r#"{"code":"Success","data":{"role_exist":false}}"#);
+        let original_config =
+            format!("[ai.providers.sysom-not-ready]\nsysom_endpoint = \"{sysom_endpoint}\"\n");
+        let env = if saved_profile {
+            std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+            std::fs::write(&config_path, &original_config).unwrap();
+            vec![]
+        } else {
+            assert!(!config_path.exists());
+            vec![("COSH_SYSOM_ENDPOINT", sysom_endpoint.as_str())]
+        };
+        let response = run_registry_request_with_args_and_env(
+            "auth",
+            "configure",
+            serde_json::json!({
+                "provider_id": "sysom-not-ready",
+                "provider_type": "aliyun",
+                "values": {
+                    "base_url": "http://127.0.0.1:1/unused-openai/v1",
+                    "access_key_id": "test-access-key",
+                    "access_key_secret": "test-secret",
+                    "model": "qwen-test"
+                }
+            }),
+            home.path(),
+            None,
+            &[],
+            &env,
+        );
+        server.join().unwrap();
 
-    assert_eq!(response["success"], false, "{response}");
-    assert_eq!(response["data"]["error_code"], "service_not_ready");
-    assert!(!config_path.exists());
-    assert!(!response.to_string().contains("test-secret"));
+        assert_eq!(response["success"], false, "{response}");
+        assert_eq!(response["data"]["error_code"], "service_not_ready");
+        if saved_profile {
+            assert_eq!(
+                std::fs::read(&config_path).unwrap(),
+                original_config.as_bytes()
+            );
+        } else {
+            assert!(!config_path.exists());
+        }
+        assert!(!response.to_string().contains("test-access-key"));
+        assert!(!response.to_string().contains("test-secret"));
+    }
 }
 
 #[test]
 fn registry_auth_rejects_unusable_aliyun_model_without_writing_config() {
     let home = tempfile::tempdir().expect("temp home");
     let config_path = home.path().join(".copilot-shell/config.toml");
-    let (base_url, server) = aliyun_copilot_rejection_server(400, r#"{"Code":"ModelNotFound"}"#);
+    let (sysom_endpoint, server) =
+        aliyun_copilot_rejection_server(400, r#"{"Code":"ModelNotFound"}"#);
+    let original_config =
+        format!("[ai.providers.sysom-bad-model]\nsysom_endpoint = \"{sysom_endpoint}\"\n");
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(&config_path, &original_config).unwrap();
     let response = run_registry_request_with_context(
         "auth",
         "configure",
@@ -1164,7 +1256,7 @@ fn registry_auth_rejects_unusable_aliyun_model_without_writing_config() {
             "provider_id": "sysom-bad-model",
             "provider_type": "aliyun",
             "values": {
-                "base_url": base_url,
+                "base_url": "http://127.0.0.1:1/unused-openai/v1",
                 "access_key_id": "test-access-key",
                 "access_key_secret": "test-secret",
                 "model": "definitely-not-a-real-sysom-model"
@@ -1177,7 +1269,11 @@ fn registry_auth_rejects_unusable_aliyun_model_without_writing_config() {
 
     assert_eq!(response["success"], false, "{response}");
     assert_eq!(response["data"]["error_code"], "model_unavailable");
-    assert!(!config_path.exists());
+    assert_eq!(
+        std::fs::read(&config_path).unwrap(),
+        original_config.as_bytes()
+    );
+    assert!(!response.to_string().contains("test-access-key"));
     assert!(!response.to_string().contains("test-secret"));
 }
 

--- a/src/cosh-ng/crates/cosh-gateway/src/runtime/installed_core_factory.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/runtime/installed_core_factory.rs
@@ -55,6 +55,7 @@ const ALLOWED_ENVIRONMENT: &[&str] = &[
     "OPENAI_ORGANIZATION",
     "OPENAI_PROJECT",
     "DASHSCOPE_API_KEY",
+    "COSH_SYSOM_ENDPOINT",
 ];
 
 /// Canonical Core launch inputs pinned before daemon socket admission.

--- a/src/cosh-ng/crates/cosh-gateway/src/runtime/installed_core_factory/tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/runtime/installed_core_factory/tests.rs
@@ -25,7 +25,7 @@ fn executable(directory: &Path, name: &str, marker: &Path) -> PathBuf {
     fs::write(
         &path,
         format!(
-            "#!/bin/sh\nprintf '%s|%s' \"$*\" \"$UNTRUSTED_SECRET\" > \"{}\"\nwhile read line; do :; done\n",
+            "#!/bin/sh\nprintf '%s|%s|%s|%s|%s' \"$*\" \"$UNTRUSTED_SECRET\" \"$COSH_SYSOM_ENDPOINT\" \"$COSH_SYSOM_VPC_PROXY_HOST\" \"$COSH_SYSOM_PROBE_TIMEOUT_MS\" > \"{}\"\nwhile read line; do :; done\n",
             marker.display()
         ),
     )
@@ -84,6 +84,18 @@ fn admitted_with_profile(
         BTreeMap::from([
             (OsString::from("HOME"), OsString::from("/tmp/test-home")),
             (
+                OsString::from("COSH_SYSOM_ENDPOINT"),
+                OsString::from("https://sysom.example.com:8443"),
+            ),
+            (
+                OsString::from("COSH_SYSOM_VPC_PROXY_HOST"),
+                OsString::from("probe.example.com:443"),
+            ),
+            (
+                OsString::from("COSH_SYSOM_PROBE_TIMEOUT_MS"),
+                OsString::from("1"),
+            ),
+            (
                 OsString::from("UNTRUSTED_SECRET"),
                 OsString::from("must-not-cross"),
             ),
@@ -137,7 +149,7 @@ fn factory_launches_only_the_exact_profile_with_filtered_environment() {
     }
     assert_eq!(
         fs::read_to_string(marker).unwrap(),
-        "--headless --execution-profile gateway-brokered-v1|"
+        "--headless --execution-profile gateway-brokered-v1||https://sysom.example.com:8443||"
     );
     drop(port);
 }
@@ -218,7 +230,7 @@ fn factory_maps_the_checkpoint_selector_to_the_private_core_launch_profile() {
     }
     assert_eq!(
         fs::read_to_string(marker).unwrap(),
-        "--headless --execution-profile gateway-brokered-checkpoint-v1|"
+        "--headless --execution-profile gateway-brokered-checkpoint-v1||https://sysom.example.com:8443||"
     );
     drop(port);
 }
@@ -259,7 +271,7 @@ fn workspace_write_profile_requires_exact_selector_manifest_and_private_argv() {
     }
     assert_eq!(
         fs::read_to_string(marker).unwrap(),
-        "--headless --execution-profile gateway-brokered-workspace-write-v1|"
+        "--headless --execution-profile gateway-brokered-workspace-write-v1||https://sysom.example.com:8443||"
     );
     drop(port);
 }


### PR DESCRIPTION
## Description

将 SysOM 端点解析收敛为预检与推理共用的入口，优先选择可达的 VPC 代理，解决无公网出口 ECS 的访问问题。使用专属 `sysom_endpoint` 配置，避免 OpenAI-compatible `base_url` 参与 ACS3 请求选路。端点结果统一提供连接策略：仅自动选中的 VPC 路由直连；显式覆盖和公网回退保留系统代理。

## Related Issue

closes #2989

## Risk and compatibility

- 优先级：`COSH_SYSOM_ENDPOINT` → `sysom_endpoint` → VPC 探测 → 公网。
- 裸 host 与 HTTP(S) URL 使用同一套端口校验与规范化；非法覆盖按未设置处理。
- 显式配置 VPC 域名也保留系统代理，需要直连时可设置 `NO_PROXY`；不修改系统或进程代理环境。
- 探测结果进程内缓存，没有请求失败后的第二端点重试。
- 推理客户端保留 3 秒建连超时及 120 秒读取空闲超时；不设置会截断健康 SSE 长流的总时长超时。

## Validation

最新修订 rebase 到 `26960330`，已验证新主干加评审补丁的完整树哈希等于最终 HEAD。

本地 macOS、生产锁文件下执行：

- `cargo fmt --all -- --check` — 通过
- `cargo clippy --locked -p cosh-core --all-targets -- -D warnings` — 通过
- `cargo test --locked -p cosh-core --lib` — 153 passed
- `cargo test --locked -p cosh-core --bin cosh-core auth::preflight::tests::` — 25 passed
- `cargo test --locked -p cosh-core --bin cosh-core sysom_endpoint` — 4 passed
- `cargo test --locked -p cosh-core --test registry_protocol -- --test-threads=4` — 31 passed

本轮机制回归：

- 真实 loopback 代理矩阵同时验证自动 VPC 直连，以及 Configured/Public 保留代理。
- registry 测试通过私有 HOME 的 `sysom_endpoint` 配置或子进程环境覆盖注入 mock，并将 `base_url` 指向不同地址；拒绝认证后配置字节保持不变。
- mock accept/读写与 registry 子进程通信均有界，stdout/stderr 持续消费，不再由遗漏连接触发永久 join。
- SSE 覆盖响应头前静默、响应头后静默、首块后停流、持续超过空闲期限的健康长流。静默必须报告 timeout，健康流必须返回完整 body。
- 新增 refresh → persist → reload 回归，防止固定端点在保存后丢失。
- 隔离副本将 read timeout 换成 total timeout 后，健康长流断言因 body timeout 失败；恢复 read timeout 后完整通过。变异未在工作树执行。

之前 Linux CI 在两个 registry Aliyun 测试中挂住并被取消，是本 PR 配置迁移遗漏了测试注入入口，不是既有的单元测试间歇失败；本轮已修复这两个入口并实际执行完整 registry 套件。当前推送重新触发 Linux CI，未将排队或运行中的检查视为通过。

### 历史 ECS 证据及边界

此前在 cn-hangzhou、无公网 IP/公网带宽为 0 的专用 ECS 上验证：显式公网端点在约 3 秒失败并指名公网 URL；显式 VPC 端点成功；仅设置公网 `base_url` 或无端点配置时，通过探测选择 VPC 并成功。判据使用 JSONL `result.is_error` 和选路日志，不使用仍可能为 0 的进程退出码。

该真机验证使用旧基线 `184093fa` 加当时补丁，不等于最新完整 PR HEAD。本轮代理策略与最终 rebase 后版本未重跑 ECS；跨 region 和可用公网回退未验证。connect timeout 的历史证据为同类失败 61 秒 → 3 秒，本 PR 尚无其确定性的本地回归断言。

## Documentation and rollback

已同步组件 `README.md` / `README_zh.md` 及双语 provider 用户指南，包括配置优先级、代理策略与空闲超时。

回滚时按逆序撤销本 PR 的完整提交集；后续提交依赖端点模块，不应仅撤销中间的端点特性提交。