### PR TITLE
feat(sight): attach cosh plaintext tap by name

### DIFF
--- a/src/agentsight/src/bpf/sslsniff.bpf.c
+++ b/src/agentsight/src/bpf/sslsniff.bpf.c
@@ -390,82 +390,33 @@ int BPF_URETPROBE(probe_SSL_do_handshake_exit) {
     return 0;
 }
 
-/* ─── rustls plaintext taps (#3042) ──────────────────────────────────────────
+/* ─── cosh-ng plaintext tap (#3042, #3115) ──────────────────────────────
  *
- * rustls is pure Rust and exports no SSL_read/SSL_write, so every probe above
- * is unattachable on a rustls process. The hooks here are its two plaintext
- * chokepoints on `CommonState`, taken at function entry:
+ * cosh-ng links rustls, which exports no SSL_read/SSL_write, so none of the
+ * probes above can attach to it. Rather than locate rustls' internal plaintext
+ * functions, this hooks an attach point the process exports on purpose:
  *
- *   buffer_plaintext(&mut self, payload: OutboundChunks, sendable: &mut _) -> usize
- *     rdi = &mut CommonState, rsi = &OutboundChunks
- *   take_received_plaintext(&mut self, bytes: Payload)
- *     rdi = &mut CommonState, rsi = &Payload
+ *   void cosh_llm_plaintext_tap(u32 dir, const u8 *buf, usize len)
+ *     rdi = dir (1 = request, 0 = response), rsi = buf, rdx = len
  *
- * Why this layer and not the AEAD one (`MessageEncrypter/Decrypter::encrypt`,
- * which is also reachable): the encrypter and decrypter are two separate heap
- * objects, so hooking them yields a different `self` per direction. Userspace
- * keys connections on (pid, ssl_ptr), and the HTTP/2 aggregator correlates a
- * request with its response inside one connection -- with split identities the
- * request never completes and no token usage is ever extracted. Both hooks here
- * take the *same* `&mut CommonState`, so one connection stays one connection.
+ * Byte-pattern matching on rustls internals was tried first and withdrawn
+ * (#3115): the prologue bytes encode rustc's register allocation, and the
+ * release RPM is built with whatever system Rust the build host provides, so a
+ * compiler bump silently reduced capture to zero. An exported symbol is immune
+ * to that -- libbpf resolves the address at attach time, so the same name works
+ * across toolchains even though the address moves.
  *
- * Hooking above the record layer also means: application data only, so no
- * content-type filtering; independent of the negotiated cipher suite, so one
- * probe per direction instead of one per suite; and the plaintext is an
- * argument, so neither direction needs a uretprobe.
- *
- * The offsets below are NOT part of rustls' stable API. They were measured on a
- * real build with `offset_of!` and cross-checked against the disassembly rather
- * than inferred from the type declarations, because both types are niche-encoded
- * in ways the source does not show. Nothing is trusted blindly: a NULL pointer
- * or an implausible length is dropped, so a layout change degrades to capturing
- * nothing rather than to emitting garbage.
+ * Everything the old approach needed to reconstruct is now given directly: the
+ * payload is one contiguous buffer, so there is no gather-write reassembly, no
+ * struct layout to decode, and no cipher-suite variants.
  */
 
-/* OutboundChunks (write direction) is niche-encoded: eightbyte 0 is Multiple's
- * `chunks` pointer, and NULL there means the Single variant. The two variants
- * overlap, so each eightbyte has a different meaning per variant and the names
- * below are kept distinct on purpose -- reading Multiple's chunk count from
- * Single's `len` slot silently yields `start`, which is 0 in practice and makes
- * every gather write look empty.
- *
- *   Single   { tag = 0  @0, ptr @8, len   @16 }
- *   Multiple { chunks   @0, n   @8, start @16, end @24 }
- */
-#define RUSTLS_CHUNKS_TAG_OFF 0
-#define RUSTLS_SINGLE_PTR_OFF 8
-#define RUSTLS_SINGLE_LEN_OFF 16
-#define RUSTLS_MULTI_N_OFF 8
-#define RUSTLS_MULTI_START_OFF 16
-#define RUSTLS_MULTI_END_OFF 24
-/* Fat-pointer stride inside the `&[&[u8]]` array. */
-#define RUSTLS_SLICE_STRIDE 16
-/* Chunks emitted per gather write. HTTP/2 writes a frame header and its payload
- * as separate slices, so a handful covers real traffic, and the bound keeps the
- * unrolled loop inside the verifier's complexity budget. Overflow is counted
- * rather than silently dropped. */
-#define RUSTLS_MAX_GATHER_CHUNKS 4
-/* Payload (read direction) needs no variant branch: Borrowed and Owned keep the
- * slice pointer and length at the same offsets, because the discriminant is
- * niche-encoded into the eightbyte that Owned uses as Vec's capacity (Borrowed
- * stores 0x8000000000000000 there, which no real capacity can be). */
-#define RUSTLS_PAYLOAD_PTR_OFF 8
-#define RUSTLS_PAYLOAD_LEN_OFF 16
+/* Direction values are fixed by the tap's contract, not by this file. */
+#define COSH_TAP_DIR_RESPONSE 0
+#define COSH_TAP_DIR_REQUEST 1
 
-/* Gather writes (OutboundChunks::Multiple) whose chunk count exceeded
- * RUSTLS_MAX_GATHER_CHUNKS, so part of the payload was not emitted. Exposed
- * through the skeleton's .bss so the gap is measurable instead of silent. */
-__u64 rustls_gather_skips = 0;
-
-/* Emit one plaintext buffer belonging to connection `conn`.
- *
- * `len` is the caller's full plaintext, which at this layer is a whole
- * application write rather than a single TLS record, so it is bounded by the
- * capture cap and not by the record size. SSL_EMIT_TIERED clamps the copy and
- * flags truncation, exactly as it does for a large SSL_write.
- */
-static __always_inline int rustls_emit(void *conn, u64 ptr, u64 len, int rw)
-{
+SEC("uprobe/cosh_llm_plaintext_tap")
+int BPF_UPROBE(probe_cosh_plaintext_tap, u32 dir, const char *buf, u64 len) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
     u32 tid = (u32)pid_tgid;
@@ -475,192 +426,20 @@ static __always_inline int rustls_emit(void *conn, u64 ptr, u64 len, int rw)
     u32 ns_pid = trace_allowed(uid, pid);
     if (!ns_pid)
         return 0;
-    if (!ptr || len == 0 || len > MAX_BUF_SIZE)
+    if (!buf || len == 0 || len > MAX_BUF_SIZE)
         return 0;
 
-    /* Captured at function entry, so there is no paired uretprobe and hence no
-     * measurable in-function duration. */
-    SSL_EMIT_TIERED((const char *)ptr, len, rw, ts, 0, ns_pid, tid, uid, (u64)conn, 0);
-    return 0;
-}
-
-/* Largest single chunk the gather path copies. Both bounds must be compile-time
- * constants for the verifier to prove `off + take` stays inside the reservation,
- * and HTTP/2's default max frame size is 16 KiB, so a per-frame slice fits. */
-#define RUSTLS_GATHER_CHUNK_MAX SSL_TIER_SMALL
-#define RUSTLS_GATHER_TIER SSL_TIER_MEDIUM
-
-/* Concatenate a gather write's chunks into a single ring-buffer record.
- *
- * `chunks` is rustls' `&[&[u8]]` data pointer, `n` its (already bounded) length,
- * and [start,end) the logical window over the concatenation.
- *
- * Anything that would not fit is dropped whole and counted, never truncated:
- * these bytes feed a framed protocol parser, so a short copy desynchronises the
- * frame stream and produces garbage rather than partial data.
- *
- * Only one tier is used. Unrolling the copy loop once per tier multiplies
- * program size, and a gather write is one request body per LLM call rather than
- * a hot path. The medium tier is the smallest that holds a realistic chat
- * request (an 18 KiB body was observed) without reserving the 4 MiB worst case
- * that #759 removed.
- */
-static __always_inline int rustls_gather_emit(void *conn, const char *chunks, u64 n, u64 start,
-                                             u64 end)
-{
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-    u32 pid = pid_tgid >> 32;
-    u32 tid = (u32)pid_tgid;
-    u32 uid = bpf_get_current_uid_gid();
-    u64 ts = bpf_ktime_get_ns();
-
-    u32 ns_pid = trace_allowed(uid, pid);
-    if (!ns_pid)
-        return 0;
-
-    u64 total = end - start;
-    if (total == 0 || total > RUSTLS_GATHER_TIER) {
-        /* Too large for one reservation; a partial copy would corrupt framing. */
-        if (total)
-            __sync_fetch_and_add(&rustls_gather_skips, 1);
-        return 0;
-    }
-
-    struct probe_SSL_data_medium *d = bpf_ringbuf_reserve(&rb, sizeof(*d), 0);
-    if (!d)
-        return 0;
-
-    d->source = EVENT_SOURCE_SSL;
-    d->timestamp_ns = ts;
-    d->delta_ns = 0;
-    d->pid = ns_pid;
-    d->tid = tid;
-    d->uid = uid;
-    d->len = (u32)total;
-    d->rw = 1;
-    d->is_handshake = 0;
-    d->ssl_ptr = (u64)conn;
-    d->truncated = 0;
-    bpf_get_current_comm(&d->comm, sizeof(d->comm));
-
-    /* `pos` is the logical offset of the current chunk's first byte. */
-    u64 pos = 0;
-    u32 written = 0;
-    bool complete = true;
-#pragma unroll
-    for (int i = 0; i < RUSTLS_MAX_GATHER_CHUNKS; i++) {
-        if ((u64)i >= n || pos >= end)
-            break;
-
-        u64 cptr = 0;
-        u64 clen = 0;
-        const char *slot = chunks + (u64)i * RUSTLS_SLICE_STRIDE;
-        if (bpf_probe_read_user(&cptr, sizeof(cptr), slot) ||
-            bpf_probe_read_user(&clen, sizeof(clen), slot + 8)) {
-            complete = false;
-            break;
-        }
-
-        /* Intersect [pos, pos+clen) with the [start, end) window. */
-        u64 chunk_end = pos + clen;
-        u64 lo = pos > start ? pos : start;
-        u64 hi = chunk_end < end ? chunk_end : end;
-        u64 skip = lo - pos; /* bytes of this chunk before the window */
-        pos = chunk_end;
-        if (hi <= lo || !cptr)
-            continue;
-
-        u64 want = hi - lo;
-        /* Both operands of the bounds check are constants, which is what lets the
-         * verifier carry `off + take <= sizeof(buf)` across the spill that the
-         * helper call forces (same trap SSL_EMIT_ONE documents). */
-        if (want > RUSTLS_GATHER_CHUNK_MAX || written > RUSTLS_GATHER_TIER - RUSTLS_GATHER_CHUNK_MAX) {
-            complete = false;
-            break;
-        }
-        u32 off = written;
-        u32 take = (u32)want;
-        /* Re-clamp behind a barrier: the value is spilled across the call above,
-         * and the verifier reloads it as an unbounded scalar otherwise. */
-        asm volatile("" : "+r"(take));
-        if (take > RUSTLS_GATHER_CHUNK_MAX)
-            take = RUSTLS_GATHER_CHUNK_MAX;
-        asm volatile("" : "+r"(take));
-        if (take == 0)
-            continue;
-        if (bpf_probe_read_user(&d->buf[off], take, (const char *)(cptr + skip))) {
-            complete = false;
-            break;
-        }
-        written += take;
-    }
-
-    /* A hole anywhere makes the remaining bytes unparseable, so drop the record
-     * rather than hand the frame parser a corrupt stream. */
-    if (!complete || written != (u32)total) {
-        __sync_fetch_and_add(&rustls_gather_skips, 1);
-        bpf_ringbuf_discard(d, 0);
-        return 0;
-    }
-    d->buf_filled = 1;
-    d->buf_size = written;
-    bpf_ringbuf_submit(d, 0);
-    return 0;
-}
-
-SEC("uprobe/rustls_buffer_plaintext")
-int BPF_UPROBE(probe_rustls_write_plaintext, void *conn, void *chunks) {
-    u64 tag = 0;
-    if (bpf_probe_read_user(&tag, sizeof(tag), (const char *)chunks + RUSTLS_CHUNKS_TAG_OFF))
-        return 0;
-
-    if (tag == 0) {
-        u64 ptr = 0;
-        u64 len = 0;
-        if (bpf_probe_read_user(&ptr, sizeof(ptr), (const char *)chunks + RUSTLS_SINGLE_PTR_OFF))
-            return 0;
-        if (bpf_probe_read_user(&len, sizeof(len), (const char *)chunks + RUSTLS_SINGLE_LEN_OFF))
-            return 0;
-        return rustls_emit(conn, ptr, len, 1);
-    }
-
-    /* Multiple: a gather write. `tag` is the &[&[u8]] data pointer and the
-     * logical payload is the concatenation of the chunks sliced by [start,end).
+    /* The tap reports whole request bodies and whole response chunks, so a
+     * process-wide identity is enough to group them: unlike the SSL_* probes
+     * there is no per-connection handle to key on, and cosh-core issues one LLM
+     * call at a time. Using the pid keeps both directions on one connection,
+     * which is what the HTTP aggregator needs to pair them.
      *
-     * The chunks MUST be concatenated into one event rather than emitted one per
-     * chunk. HTTP/2 is framed, and `parse_ssl_event` parses each event on its
-     * own: a chunk that starts mid-frame is unparseable and degrades to RawData,
-     * which only the HTTP/1.1 path knows how to continue. Verified the hard way —
-     * per-chunk emission delivered every byte in order and still produced zero
-     * parsed frames.
-     */
-    u64 n = 0;
-    u64 start = 0;
-    u64 end = 0;
-    if (bpf_probe_read_user(&n, sizeof(n), (const char *)chunks + RUSTLS_MULTI_N_OFF))
-        return 0;
-    if (bpf_probe_read_user(&start, sizeof(start), (const char *)chunks + RUSTLS_MULTI_START_OFF))
-        return 0;
-    if (bpf_probe_read_user(&end, sizeof(end), (const char *)chunks + RUSTLS_MULTI_END_OFF))
-        return 0;
-    if (end <= start)
-        return 0;
-    if (n > RUSTLS_MAX_GATHER_CHUNKS) {
-        __sync_fetch_and_add(&rustls_gather_skips, 1);
-        n = RUSTLS_MAX_GATHER_CHUNKS;
-    }
-    return rustls_gather_emit(conn, (const char *)tag, n, start, end);
-}
-
-SEC("uprobe/rustls_take_received_plaintext")
-int BPF_UPROBE(probe_rustls_read_plaintext, void *conn, void *payload) {
-    u64 ptr = 0;
-    u64 len = 0;
-    if (bpf_probe_read_user(&ptr, sizeof(ptr), (const char *)payload + RUSTLS_PAYLOAD_PTR_OFF))
-        return 0;
-    if (bpf_probe_read_user(&len, sizeof(len), (const char *)payload + RUSTLS_PAYLOAD_LEN_OFF))
-        return 0;
-    return rustls_emit(conn, ptr, len, 0);
+     * Captured at function entry, so there is no paired uretprobe and hence no
+     * measurable duration. */
+    int rw = (dir == COSH_TAP_DIR_REQUEST) ? 1 : 0;
+    SSL_EMIT_TIERED(buf, len, rw, ts, 0, ns_pid, tid, uid, (u64)ns_pid, 0);
+    return 0;
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -474,15 +474,6 @@ impl SslSniff {
         self.stale_reattachs
     }
 
-    /// How many rustls gather writes (`OutboundChunks::Multiple`) were observed
-    /// and skipped because chunk reassembly is not implemented yet.
-    ///
-    /// A non-zero value means part of the request side of a rustls process was
-    /// not captured, so this is a coverage gap indicator rather than an error.
-    pub fn rustls_gather_skips(&self) -> u64 {
-        self.skel.bss().rustls_gather_skips
-    }
-
     /// Record a successful attach for `inode`, replacing any prior entry
     /// (whose links are dropped, detaching the old probes).
     fn record_attach(&mut self, inode: u64, links: Vec<Link>) {
@@ -507,24 +498,29 @@ impl SslSniff {
             SslLibKind::OpenSsl => attach_openssl(&mut self.skel, path, -1),
             SslLibKind::GnuTls => attach_gnutls(&mut self.skel, path, -1),
             SslLibKind::Nss => attach_nss(&mut self.skel, path, -1),
-            SslLibKind::Rustls => match find_rustls_offsets(path) {
-                Some(off) => {
-                    log::info!(
-                        "[attach_process] pid={pid}: rustls plaintext probes on {path} \
-                         (write={:x?}, read={:x?})",
-                        off.write,
-                        off.read
-                    );
-                    attach_rustls(&mut self.skel, path, &off, -1)
-                }
-                None => {
-                    log::warn!(
-                        "[attach_process] pid={pid}: rustls detection failed for {path} \
-                         (neither plaintext prologue matched -- rustls or the toolchain likely moved), skipping"
-                    );
+            SslLibKind::ExplicitTap => {
+                if !cosh_tap_present(path) {
+                    // A pre-tap cosh-ng can be deployed alongside an upgraded
+                    // AgentSight, and then its LLM calls are simply not
+                    // capturable: there is no TLS-layer API to fall back to.
+                    // Say so once per inode instead of staying silent, which
+                    // would be indistinguishable from a probe bug.
+                    if missing_tap_is_a_coverage_gap(path) {
+                        log::warn!(
+                            "[attach_process] pid={pid}: {path} exports no {COSH_TAP_SYMBOL}; \
+                             this cosh-ng predates the plaintext tap, so its LLM traffic \
+                             cannot be captured -- upgrade cosh-ng to restore coverage"
+                        );
+                    } else {
+                        log::debug!(
+                            "[attach_process] pid={pid}: {path} exports no {COSH_TAP_SYMBOL}; \
+                             only the LLM-issuing binary carries the tap"
+                        );
+                    }
                     return AttachOutcome::Untraceable;
                 }
-            },
+                attach_cosh_tap(&mut self.skel, path, -1)
+            }
             SslLibKind::Static => {
                 match attach_static_ssl_by_symbol(&mut self.skel, path, -1) {
                     Ok(ls) => Ok(ls),
@@ -970,91 +966,42 @@ fn find_static_ssl_offsets(path: &str) -> Option<StaticSslOffsets> {
     })
 }
 
-/// Offsets of rustls' two plaintext chokepoints inside a stripped binary.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-struct RustlsOffsets {
-    /// `CommonState::buffer_plaintext` — outbound application data.
-    write: Option<usize>,
-    /// `CommonState::take_received_plaintext` — inbound application data.
-    read: Option<usize>,
+/// Symbol cosh-ng exports as its plaintext observability attach point.
+///
+/// Defined by `cosh-core`'s `provider::observe` module. Resolving it by name is
+/// what makes this robust: an earlier attempt located rustls' own plaintext
+/// functions by byte pattern, which broke as soon as the release build moved to
+/// a different rustc (#3115), because those patterns encode register allocation.
+/// A symbol address is resolved by libbpf at attach time, so the same name keeps
+/// working across toolchains.
+const COSH_TAP_SYMBOL: &str = "cosh_llm_plaintext_tap";
+
+/// Whether `path` exports the plaintext tap at all.
+///
+/// Only `cosh-core` issues LLM requests; `cosh-shell`, `cosh-cli` and
+/// `cosh-gateway` match the same name rule but carry no tap. Attaching to them
+/// would fail on every discovery sweep and be retried forever, so they are
+/// recognised as legitimately untraceable instead.
+///
+/// The check looks for the symbol name in the file rather than parsing
+/// `.dynsym`: the streaming scan is bounded and already available, and a name
+/// that appears nowhere in the binary certainly is not in its symbol table. A
+/// false positive merely lets the attach proceed and report the real error.
+fn cosh_tap_present(path: &str) -> bool {
+    scan_file_patterns(path, &[COSH_TAP_SYMBOL.as_bytes()])
+        .is_some_and(|hits| hits.first().is_some_and(|h| !h.is_empty()))
 }
 
-impl RustlsOffsets {
-    /// Whether anything worth attaching was found.
-    ///
-    /// One direction alone is still attached, but it degrades HTTP/2: the
-    /// aggregator pairs a request with its response inside one connection, so a
-    /// half-captured connection never completes. `attach_rustls` warns about it.
-    fn is_usable(&self) -> bool {
-        self.write.is_some() || self.read.is_some()
-    }
-}
-
-/// Locate rustls' plaintext chokepoints in `path` by function-prologue matching.
+/// Whether a missing tap on this binary means lost LLM coverage.
 ///
-/// `CommonState::buffer_plaintext` and `CommonState::take_received_plaintext` are
-/// the narrowest pair of functions that (a) survive cosh-ng's `lto = true` build
-/// and (b) share one `&mut CommonState`, which is what keeps both directions of a
-/// connection under a single `ssl_ptr`. The obvious `Writer::write` /
-/// `Reader::read` plaintext API is inlined away and leaves no symbol, and release
-/// binaries are fully stripped, so a prologue scan is the only handle left.
-///
-/// Each pattern is the first 24 bytes of the function: the callee-saved register
-/// block, the frame setup, and the argument shuffle. The length is not arbitrary
-/// — the register-save prefix these functions share also matches dozens of
-/// unrelated Rust functions (40 hits for one of them in a real binary), while 24
-/// bytes was verified to match exactly once. A pattern hitting more than once is
-/// discarded rather than guessed at, because attaching a uprobe to the wrong
-/// function would sample unrelated memory.
-///
-/// Because these bytes encode rustc's register allocation and frame sizes, they
-/// are tied to a given rustls + toolchain combination and must be re-verified
-/// when either moves. A miss is safe: the caller reports the binary as
-/// untraceable, which is exactly the behaviour before rustls was supported.
-fn find_rustls_offsets(path: &str) -> Option<RustlsOffsets> {
-    /// `CommonState::buffer_plaintext`: push block, `sub $0x78,%rsp`, then
-    /// `mov %rdx,%r15; mov %rsi,%r14; mov 0x308(%rdi),%rbp` — the tail also
-    /// pins rdi as the `&mut CommonState` this probe reports as the connection.
-    const WRITE_PAT: &[u8] = &[
-        0x55, 0x41, 0x57, 0x41, 0x56, 0x41, 0x55, 0x41, 0x54, 0x53, 0x48, 0x83, 0xec, 0x78, 0x49,
-        0x89, 0xd7, 0x49, 0x89, 0xf6, 0x48, 0x8b, 0xaf, 0x08,
-    ];
-    /// `CommonState::take_received_plaintext`: push block, `mov %rdi,%r14`, the
-    /// inlined `temper_counters.received_app_data()` store `movb $0x20,0x32e(%rdi)`,
-    /// then `mov (%rsi),%r12` loading the first eightbyte of the `Payload`.
-    const READ_PAT: &[u8] = &[
-        0x41, 0x57, 0x41, 0x56, 0x41, 0x54, 0x53, 0x50, 0x49, 0x89, 0xfe, 0xc6, 0x87, 0x2e, 0x03,
-        0x00, 0x00, 0x20, 0x4c, 0x8b, 0x26, 0x48, 0x8b, 0x5e,
-    ];
-
-    let mut hits = scan_file_patterns(path, &[WRITE_PAT, READ_PAT])?;
-    // scan_file_patterns returns one Vec<usize> per pattern, in order.
-    let read_hits = hits.pop().unwrap_or_default();
-    let write_hits = hits.pop().unwrap_or_default();
-    let mut found = RustlsOffsets::default();
-
-    for (label, offsets, is_write) in [
-        ("CommonState::buffer_plaintext", &write_hits, true),
-        ("CommonState::take_received_plaintext", &read_hits, false),
-    ] {
-        match offsets.len() {
-            0 => log::debug!("rustls: {label} pattern not found in {path}"),
-            1 => {
-                log::debug!("rustls: {label} at {:#x} in {path}", offsets[0]);
-                if is_write {
-                    found.write = Some(offsets[0]);
-                } else {
-                    found.read = Some(offsets[0]);
-                }
-            }
-            n => log::debug!("rustls: {label} pattern has {n} matches in {path}, skipping"),
-        }
-    }
-
-    if !found.is_usable() {
-        return None;
-    }
-    Some(found)
+/// Only `cosh-core` issues LLM calls, so only there does an absent symbol mean
+/// a pre-tap build whose traffic goes unseen. The sibling binaries are mapped
+/// in the same process and never carry the tap, so their absence is expected
+/// and must not be reported as a problem.
+fn missing_tap_is_a_coverage_gap(path: &str) -> bool {
+    Path::new(path.strip_suffix(" (deleted)").unwrap_or(path))
+        .file_name()
+        .is_some_and(|name| name == "cosh-core")
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -1070,10 +1017,11 @@ enum SslLibKind {
     Nss,
     /// Statically-linked SSL (BoringSSL or OpenSSL, e.g. Node.js, Chrome, Codex CLI)
     Static,
-    /// Statically-linked rustls (pure Rust TLS, e.g. cosh-ng). Distinct from
-    /// `Static` because there is no SSL_* API to hook at all: the probes go on
-    /// rustls' AEAD layer instead, with a different calling convention.
-    Rustls,
+    /// A binary that carries an explicit observability tap and therefore needs
+    /// no TLS-layer probe at all (cosh-ng today, via cosh-core's
+    /// `cosh_llm_plaintext_tap`). Distinct from `Static` because there is no
+    /// SSL_* API to hook: the uprobe goes on the exported tap symbol instead.
+    ExplicitTap,
 }
 
 /// Classify a mapped file path into an `SslLibKind`, if it is an SSL library.
@@ -1118,7 +1066,7 @@ fn classify_ssl_lib(path: &str) -> Option<SslLibKind> {
         name.as_ref(),
         "cosh-core" | "cosh-shell" | "cosh-cli" | "cosh-gateway"
     ) {
-        return Some(SslLibKind::Rustls);
+        return Some(SslLibKind::ExplicitTap);
     }
     // uv Python statically links OpenSSL into the binary. The ELF .symtab contains
     // SSL_write/SSL_read/SSL_do_handshake as LOCAL symbols, so attach_openssl()
@@ -1199,7 +1147,7 @@ fn ssl_libs_from_maps(pid: i32) -> Result<Vec<(String, u64, SslLibKind)>> {
             // `<pid>` entry itself comes from a bind-mounted host procfs.
             let attach_path = if path_str.ends_with(" (deleted)") {
                 proc_pid_entry(pid, "exe")
-            } else if matches!(kind, SslLibKind::Static | SslLibKind::Rustls) {
+            } else if matches!(kind, SslLibKind::Static | SslLibKind::ExplicitTap) {
                 // Statically-linked SSL binary (codex, node, cosh-core, etc).
                 // <pid>/exe is a kernel-maintained symlink that stays valid
                 // even when the backing file has been replaced or unlinked,
@@ -1466,46 +1414,26 @@ fn attach_static_ssl_by_offset(
     Ok(links)
 }
 
-/// Attach the rustls plaintext probes at the offsets found by
-/// `find_rustls_offsets`.
+/// Attach the plaintext tap cosh-ng exports for observability.
 ///
-/// Both probes fire at function entry, where the plaintext is an argument, so
-/// neither direction needs a uretprobe. There is no handshake probe either:
-/// these hooks sit above the record layer and only ever see application data,
-/// so a rustls process reports no handshake timings.
-fn attach_rustls(
-    skel: &mut SslsniffSkel<'_>,
-    lib: &str,
-    off: &RustlsOffsets,
-    pid: i32,
-) -> Result<Vec<Link>> {
-    // A one-sided attach still yields data, but HTTP/2 request/response
-    // correlation needs both halves of the connection, so say so loudly.
-    if off.write.is_none() || off.read.is_none() {
-        log::warn!(
-            "rustls: only the {} direction was located in {lib}; HTTP/2 streams will not complete",
-            if off.write.is_some() { "write" } else { "read" }
-        );
-    }
-
-    let mut links = Vec::new();
-    if let Some(w) = off.write {
-        links.push(up_off!(
-            skel.progs_mut().probe_rustls_write_plaintext(),
-            pid,
-            lib,
-            w
-        )?);
-    }
-    if let Some(r) = off.read {
-        links.push(up_off!(
-            skel.progs_mut().probe_rustls_read_plaintext(),
-            pid,
-            lib,
-            r
-        )?);
-    }
-    Ok(links)
+/// One uprobe covers both directions: the tap's first argument says which way
+/// the payload is going. It fires at function entry, where the buffer is already
+/// an argument, so no uretprobe is needed. There is no handshake probe either —
+/// the tap sits at the application layer and never sees TLS records, so a
+/// cosh-ng process reports no handshake timings.
+///
+/// # Errors
+///
+/// Fails when the symbol is absent, which means the binary was built without
+/// `-Wl,--export-dynamic`: `strip = true` erases `.symtab`, so only `.dynsym`
+/// survives, and the symbol has to be promoted there deliberately.
+fn attach_cosh_tap(skel: &mut SslsniffSkel<'_>, lib: &str, pid: i32) -> Result<Vec<Link>> {
+    Ok(vec![up!(
+        skel.progs_mut().probe_cosh_plaintext_tap(),
+        pid,
+        lib,
+        COSH_TAP_SYMBOL
+    )?])
 }
 
 // ─── Codex offset table (Tier 3) ────────────────────────────────────────────
@@ -1927,28 +1855,7 @@ mod tests {
         assert_eq!(parse_maps_line(""), None);
     }
 
-    // ─── rustls detection tests (#3042) ─────────────────────────────────────
-    // Prologue literals mirror the ones inside find_rustls_offsets, for the same
-    // reason as the static-SSL fixtures above: editing a production pattern
-    // without updating these makes detection on the synthetic image fail.
-    const RUSTLS_WRITE_PAT: &[u8] = &[
-        0x55, 0x41, 0x57, 0x41, 0x56, 0x41, 0x55, 0x41, 0x54, 0x53, 0x48, 0x83, 0xec, 0x78, 0x49,
-        0x89, 0xd7, 0x49, 0x89, 0xf6, 0x48, 0x8b, 0xaf, 0x08,
-    ];
-    const RUSTLS_READ_PAT: &[u8] = &[
-        0x41, 0x57, 0x41, 0x56, 0x41, 0x54, 0x53, 0x50, 0x49, 0x89, 0xfe, 0xc6, 0x87, 0x2e, 0x03,
-        0x00, 0x00, 0x20, 0x4c, 0x8b, 0x26, 0x48, 0x8b, 0x5e,
-    ];
-
-    /// Zero-filled synthetic binary with rustls prologues planted at the given
-    /// file offsets; zeros cannot match a pattern, so matches are unambiguous.
-    fn build_rustls_image(planted: &[(usize, &[u8])]) -> Vec<u8> {
-        let mut img = vec![0u8; 0x5000];
-        for (off, pat) in planted {
-            img[*off..*off + pat.len()].copy_from_slice(pat);
-        }
-        img
-    }
+    // ─── cosh-ng tap detection tests (#3042, #3115) ──────────────────────
 
     #[test]
     fn classify_recognises_cosh_binaries_as_rustls() {
@@ -1960,8 +1867,8 @@ mod tests {
         ] {
             assert_eq!(
                 classify_ssl_lib(path),
-                Some(SslLibKind::Rustls),
-                "{path} must be probed through rustls' plaintext chokepoints"
+                Some(SslLibKind::ExplicitTap),
+                "{path} must be probed through its exported plaintext tap"
             );
         }
     }
@@ -1986,58 +1893,36 @@ mod tests {
     }
 
     #[test]
-    fn rustls_offsets_locates_both_directions() {
-        let img = build_rustls_image(&[(0x400, RUSTLS_WRITE_PAT), (0x1200, RUSTLS_READ_PAT)]);
-        with_static_ssl_fixture("rustls-both", &img, |path| {
-            let off = find_rustls_offsets(path).expect("planted prologues must be detected");
-            assert_eq!(off.write, Some(0x400));
-            assert_eq!(off.read, Some(0x1200));
-        });
+    fn cosh_tap_symbol_matches_the_exported_contract() {
+        // The name is a cross-component contract with cosh-core's
+        // `provider::observe`; renaming either side silently stops capture, so
+        // pin the literal here rather than only in the attach call.
+        assert_eq!(COSH_TAP_SYMBOL, "cosh_llm_plaintext_tap");
     }
 
+    /// A pre-tap cosh-ng deployed under an upgraded AgentSight loses coverage
+    /// with no TLS-layer fallback available, so only `cosh-core` may report the
+    /// missing symbol as a problem. Warning for the siblings, which never carry
+    /// the tap, would emit a line per process start on every healthy host.
     #[test]
-    fn rustls_offsets_usable_with_one_direction() {
-        // Half a connection is still attached (and warned about): losing it
-        // outright would mean capturing nothing at all from the process.
-        let img = build_rustls_image(&[(0x800, RUSTLS_READ_PAT)]);
-        with_static_ssl_fixture("rustls-read-only", &img, |path| {
-            let off = find_rustls_offsets(path).expect("read-only image must be usable");
-            assert_eq!(off.read, Some(0x800));
-            assert!(off.write.is_none());
-            assert!(off.is_usable());
-        });
-    }
-
-    #[test]
-    fn rustls_offsets_discards_ambiguous_pattern() {
-        // Two hits for one function means the prologue is no longer unique after
-        // a toolchain change. Guessing could point a uprobe at unrelated code and
-        // sample arbitrary memory as if it were plaintext, so the pattern is
-        // dropped instead of resolved by heuristic.
-        let img = build_rustls_image(&[
-            (0x400, RUSTLS_READ_PAT),
-            (0x2400, RUSTLS_READ_PAT),
-            (0x3000, RUSTLS_WRITE_PAT),
-        ]);
-        with_static_ssl_fixture("rustls-ambiguous", &img, |path| {
-            let off = find_rustls_offsets(path).expect("the unique write match still stands");
+    fn only_the_llm_binary_treats_a_missing_tap_as_a_coverage_gap() {
+        assert!(missing_tap_is_a_coverage_gap(
+            "/usr/libexec/anolisa/cosh-ng/cosh-core"
+        ));
+        // Still the LLM binary once its file has been unlinked mid-run.
+        assert!(missing_tap_is_a_coverage_gap(
+            "/usr/libexec/anolisa/cosh-ng/cosh-core (deleted)"
+        ));
+        for sibling in [
+            "/usr/libexec/anolisa/cosh-ng/cosh-shell",
+            "/usr/bin/cosh-cli",
+            "/usr/libexec/anolisa/cosh-ng/cosh-gateway",
+        ] {
             assert!(
-                off.read.is_none(),
-                "ambiguous read pattern must be discarded, got {:x?}",
-                off.read
+                !missing_tap_is_a_coverage_gap(sibling),
+                "{sibling} never carries the tap; a missing symbol is expected there"
             );
-            assert_eq!(off.write, Some(0x3000));
-        });
-    }
-
-    #[test]
-    fn rustls_offsets_absent_yields_none() {
-        // A non-rustls binary must report nothing so the caller marks it
-        // untraceable instead of attaching probes to arbitrary offsets.
-        let img = vec![0u8; 0x5000];
-        with_static_ssl_fixture("rustls-absent", &img, |path| {
-            assert!(find_rustls_offsets(path).is_none());
-        });
+        }
     }
 
     /// The default re-attach TTL must cover short-lived processes (#3034).


### PR DESCRIPTION
## Description

Companion to the cosh-ng change (merged as 70b45717, PR #3156): cosh-core now exports `cosh_llm_plaintext_tap`, a stable symbol that hands its LLM request and response bytes to any observer, framed as HTTP/1.1. This PR switches agentsight from locating rustls internals by byte pattern to attaching a uprobe to that symbol by name.

The byte-pattern approach was withdrawn after #3115: the prologue patterns encode rustc's register allocation, the release RPM builds with whatever system Rust the host provides, so a compiler bump silently reduced rustls capture to zero. A symbol resolved by libbpf at attach time is immune to that — the name is stable while the address moves.

## Key changes

- **One uprobe, by name.** `attach_cosh_tap` attaches `probe_cosh_plaintext_tap` to `cosh_llm_plaintext_tap`. The tap's first argument distinguishes request from response; the payload is one contiguous buffer per event, so the gather-write reassembly path is gone entirely.
- **Deleted the pattern machinery** (-479 lines net): the two 24-byte prologue signatures, `OutboundChunks`/`Payload` struct-layout decoding, the 4-chunk gather-write concatenation and its verifier barriers, and the size ceilings those bounds required (4 chunks / 16 KiB / 128 KiB). BPF shrinks from 666 to 445 lines.
- **Legitimately-untraceable siblings.** `cosh-shell` / `cosh-cli` / `cosh-gateway` match the same name rule but carry no tap; they are recognised upfront and marked `Untraceable` instead of failing every discovery sweep and being retried forever.
- **`SslLibKind::Rustls` → `ExplicitTap`.** The variant's actual meaning is "the binary carries an explicit tap", nothing rustls-specific — it survives any future TLS-backend change on the cosh side.

## Risk and compatibility

- **Dangling requests are no longer produced by cosh.** The cosh-ng side announces the response head before its success check and taps the error body, so a 401/429/5xx arrives as a complete HTTP response; the aggregator's pre-existing tolerance for unpaired requests remains as a fallback, but cosh traffic no longer exercises it.
- **Attach outcome for tapless cosh binaries is `Untraceable`** (cached, not retried), matching how agentsight already treats binaries with no SSL at all; `cosh-core` attaches normally.
- **Behaviour for every non-cosh agent is unchanged**: OpenSSL/GnuTLS/NSS/static-SSL attach paths are untouched; the h2 SSE-terminator fix stays because h2 aggregation remains the path for all other HTTP/2 agents.
- **Capture semantics slightly coarser than before**: the tap keys connection identity on the pid rather than a per-connection handle. cosh-core issues one LLM call at a time, so request/response pairing is unaffected in practice; a hypothetical future cosh that runs concurrent calls on separate connections would need the tap to grow a connection argument.

## Validation

- `cargo fmt --all --check`, `cargo clippy -p agentsight --all-targets -- -D warnings`: clean.
- `cargo test -p agentsight`: 1941 passed / 0 failed.
- `bpf_load` verifier suite: 10/10, including the new `probe_cosh_plaintext_tap` program.
- End-to-end on a live host (ALinux4, kernel 6.6, cosh-core 0.23.0 with rustls): libbpf resolves the symbol (`elf: symbol address match for 'cosh_llm_plaintext_tap' ... 0x52cee0`), and real DashScope conversations produce `token_records` / `genai_events` rows with correct model, tokens, prompt and response — repeated across headless runs and under systemd.
- Toolchain-drift check: cosh-core built with rustc 1.89 and 1.96-nightly yields different symbol addresses but the same resolvable name; the withdrawn byte patterns matched 1/1 on 1.89 and 0/0 on 1.96.

## Related Issue

Closes #3115. Relates to #3042 (original rustls gap) and the companion cosh-ng PR #3156.
