### PR TITLE
chore(anolisa): bump version to 0.3.11

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -9,6 +9,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.11] - 2026-09-09
+
+### Added
+
+- Register `ktuner` in both component catalogs for Linux x86_64 RPM
+  discovery and installation when the configured repository provides it
+  ([#2084](https://github.com/alibaba/anolisa/pull/2084)).
+
+### Changed
+
+- `anolisa adapter enable <component> openclaw` now accepts the plugin's
+  declared capabilities when the host advertises `--accept-capabilities`.
+  Unsafe-install bypass still requires separate explicit authorization
+  ([#3126](https://github.com/alibaba/anolisa/pull/3126)).
+- `status` and `doctor` now allow content edits to raw-installed
+  `type = "config"` files, including directory-expanded files, while still
+  checking presence, file type, path safety, permissions, and capabilities.
+  Legacy state recovers config kinds where the installed manifest is
+  unambiguous. Update and uninstall behavior is unchanged; back up edited
+  configs before those operations. Older CLI versions cannot read the new
+  `kind = "config"` state: before downgrading, back up state and change those
+  owned-file entries to `kind = "file"`, restoring content digest checks
+  ([#3142](https://github.com/alibaba/anolisa/pull/3142)).
+
+### Fixed
+
+- OpenClaw adapter cleanup can now finish when uninstall reports no tracked
+  package and `plugins list --json` confirms the plugin is absent with clean
+  diagnostics. Inconclusive results retain cleanup ownership for a retry
+  ([#3118](https://github.com/alibaba/anolisa/pull/3118)).
+- Component index reads now use a temporary private cache when the system
+  cache is not writable, allowing ordinary users to resolve components for
+  previews while retaining index validation. RPM install preflight still
+  requires root with DNF 4
+  ([#3127](https://github.com/alibaba/anolisa/pull/3127)).
+- Fresh raw installs now record file digests after `post_install` and
+  `post_enable` hooks, avoiding false corruption reports for hook-written
+  content while detecting subsequent changes to immutable files. Repair and
+  update still restore the package payload without replaying install hooks
+  ([#3141](https://github.com/alibaba/anolisa/pull/3141)).
+- RPM installs, including `--dry-run` and merged `install --all` transactions,
+  now check DNF conflicts before creating recovery journals, so solver
+  refusals no longer leave false pending operations. Use `sudo` for RPM
+  `--dry-run` with DNF 4; the check may refresh repository metadata
+  ([#3158](https://github.com/alibaba/anolisa/pull/3158)).
+- `anolisa list` now uses the same authoritative RPM package mapping as
+  install, preventing legacy aliases or stale provider declarations from
+  showing the wrong component as installed
+  ([#3158](https://github.com/alibaba/anolisa/pull/3158)).
+- `anolisa forget` now directs journal-only pending operations to
+  `anolisa repair <component>` instead of reporting nothing to forget,
+  preserving the recovery evidence
+  ([#3158](https://github.com/alibaba/anolisa/pull/3158)).
+
 ## [0.3.10] - 2026-09-06
 
 ### Added

--- a/src/anolisa/CHANGELOG_zh.md
+++ b/src/anolisa/CHANGELOG_zh.md
@@ -9,6 +9,53 @@
 
 ## [未发布]
 
+## [0.3.11] - 2026-09-09
+
+### 新增
+
+- 在两版组件目录中注册 `ktuner`，配置的仓库提供该软件包时，可在
+  Linux x86_64 上发现并通过 RPM 安装
+  ([#2084](https://github.com/alibaba/anolisa/pull/2084))。
+
+### 变更
+
+- 执行 `anolisa adapter enable <component> openclaw` 时，若宿主声明支持
+  `--accept-capabilities`，现在会接受插件声明的能力。
+  绕过不安全安装检查仍需要单独明确授权
+  ([#3126](https://github.com/alibaba/anolisa/pull/3126))。
+- `status` 和 `doctor` 现在允许修改 Raw 安装的 `type = "config"` 文件内容，
+  包括从目录展开的文件，同时继续检查文件存在性、类型、路径安全、权限及
+  capabilities。旧状态会在已安装清单能够明确判定时恢复配置文件类型。
+  更新和卸载行为保持不变，执行这些操作前应备份编辑过的配置。
+  旧版 CLI 无法读取新的 `kind = "config"` 状态：降级前应备份状态，
+  将这些受管文件条目改为 `kind = "file"`，恢复内容摘要检查
+  ([#3142](https://github.com/alibaba/anolisa/pull/3142))。
+
+### 修复
+
+- OpenClaw 卸载报告没有受跟踪的软件包时，若 `plugins list --json`
+  确认插件已不存在且诊断正常，适配器清理现在可以完成；
+  无法确认时保留清理归属记录，供后续重试
+  ([#3118](https://github.com/alibaba/anolisa/pull/3118))。
+- 系统缓存不可写时，组件索引读取现在改用临时私有缓存，
+  使普通用户能够解析组件并进行预览，同时保留索引校验。
+  使用 DNF 4 的 RPM 安装预检仍需要 root 权限
+  ([#3127](https://github.com/alibaba/anolisa/pull/3127))。
+- 全新 Raw 安装现在会在 `post_install` 和 `post_enable` hook 执行后
+  记录文件摘要，避免将 hook 写入的内容误报为损坏，并继续检测不可变文件的后续修改。
+  修复和更新仍恢复软件包内容，不会重新执行安装 hook
+  ([#3141](https://github.com/alibaba/anolisa/pull/3141))。
+- RPM 安装现在会在创建恢复日志前检查 DNF 冲突，覆盖 `--dry-run` 及合并的
+  `install --all` 事务，避免依赖求解被拒绝后留下虚假的待恢复操作。
+  使用 DNF 4 时，RPM `--dry-run` 需要加 `sudo`，检查可能刷新仓库元数据
+  ([#3158](https://github.com/alibaba/anolisa/pull/3158))。
+- `anolisa list` 现在与安装使用相同的权威 RPM 软件包映射，
+  避免历史别名或过期的 provider 声明导致错误地显示组件已安装
+  ([#3158](https://github.com/alibaba/anolisa/pull/3158))。
+- 对于仅留下恢复日志的待处理操作，`anolisa forget` 现在会引导执行
+  `anolisa repair <component>`，而不是报告没有可遗忘的记录，并保留恢复证据
+  ([#3158](https://github.com/alibaba/anolisa/pull/3158))。
+
 ## [0.3.10] - 2026-09-06
 
 ### 新增

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "chrono",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.10"
+version = "0.3.11"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.93"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,13 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Sun Sep 06 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Wed Sep 09 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Allow editable raw configs and record post-hook file digests.
+- Accept OpenClaw capability consent and recover verified plugin cleanup.
+- Preflight RPM conflicts and align installed package observations with the catalog.
+- Allow index previews with a private cache and register ktuner in both catalogs.
+
+* Sun Sep 06 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.3.10-1
 - Manage QwenPaw plugin adapters through the framework CLI with verified cleanup.
 - Log limits now return recent matches without blocking new log appends during scans.
 

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.3.10",
-    "@anolisa/cli-linux-arm64": "0.3.10",
-    "@anolisa/cli-darwin-arm64": "0.3.10"
+    "@anolisa/cli-linux-x64": "0.3.11",
+    "@anolisa/cli-linux-arm64": "0.3.11",
+    "@anolisa/cli-darwin-arm64": "0.3.11"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

Prepare ANOLISA CLI 0.3.11 from the merged changes after the 0.3.10 release
(`fba8720b`). Cargo, npm native packages, and RPM release metadata must agree
before the release can be packaged.

## What changed

Synchronize the five-crate Cargo workspace and lockfile, the npm root package
and three platform templates, and the RPM changelog boundary at 0.3.11.
Add equivalent English and Chinese changelog entries from the final behavior
of #2084, #3118, #3126, #3127, #3141, #3142, and #3158. This atomic release
commit changes nine files and adds no runtime implementation.

## Related issue

no-issue: component release metadata and changelog aggregation for already merged work.

## User / Agent impact

- Discover ktuner through the configured RPM catalog on Linux x86_64.
- Edit raw config contents without false integrity failures; record immutable
  file digests after installation hooks.
- Accept OpenClaw plugin capabilities when supported and complete cleanup after
  verified absence of an untracked plugin.
- Resolve indexes without write access to the system cache.
- Reject RPM conflicts before recovery journals, align `list` with install's
  package mapping, and direct journal-only `forget` requests to repair.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

These boxes describe the released range; this PR itself changes release
metadata and changelogs only. OpenClaw capability consent does not authorize
an unsafe-install bypass. DNF 4 RPM preflight requires root even for dry-run
and may refresh repository metadata; it does not prove later downloads or
scriptlets will succeed. Config content remains mutable while path, type,
permission, and capability checks still apply. Update and uninstall do not
gain config-preservation behavior.

New owned-file `kind = "config"` records cannot be read by 0.3.10. Before
binary downgrade, back up state and edited configs and change these entries
to `kind = "file"`; older digest-check behavior then resumes. Legacy records
with ambiguous mixed directory mappings retain digest checks; back up edited
configs before reinstalling to record their kinds accurately.

## Validation

Host: Linux x86_64, unprivileged user; Rust 1.93.1 and Node 20.20.2 for website checks.

- `cargo fmt --all` and `cargo fmt --all -- --check`
- `cargo check --workspace --offline` (native lockfile refresh; only five workspace versions changed)
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`: 2512 passed, 0 failed, 1 ignored child-test
  entry (invoked by its parent regression); includes doc tests.
- `cargo doc --workspace --no-deps --locked`
- `cargo build --release --locked -p anolisa-cli`; binary reports `anolisa 0.3.11`.
- `node npm/tests/platforms.test.js`; `node npm/scripts/package-npm.js --validate`
- `node npm/scripts/package-npm.js --target linux-x64`; install both local
  tarballs into a temporary npm project; launcher reports `anolisa 0.3.11`.
- `bash tests/test-package-prebuilt.sh`; from repository root,
  `bash .github/actions/build-anolisa-prebuilt/test.sh`
- Package the real Linux x86_64 binary with `packaging/prebuilt/package.sh`,
  extract it, compare bytes, and confirm `anolisa 0.3.11`.
- Render `anolisa.spec.in` with 0.3.11; `rpmspec -P` and `rpmspec -q` pass.
- Nightly harness syntax, `--list`, and isolated `--configure-repo` checks.
- `bash scripts/docs-lint.sh`; `python3 scripts/docs-link-check.py`
- Website under Node 20.20.2: `npm run build`, `npm run typecheck`,
  `npm run check:links`; both locales and 192 HTML files pass.
- Release audit with `check_release.py --component anolisa --scope anolisa
  --version 0.3.11 --previous 0.3.10 --bump-commit fba8720b62fe21365a6d332fa788ad10f628d5ec`;
  `git diff --check`.

Linux arm64 and macOS arm64 were validated through templates and synthetic
prebuilt package contracts, not native execution. No live DNF installation,
full RPM build, or hosted nightly lifecycle run was performed.

## Documentation and rollback

Updated paired `CHANGELOG.md` / `CHANGELOG_zh.md` and the RPM changelog.
Existing README, user-guide, and component contract documentation already
cover the merged behaviors. Revert this atomic bump before publication to
restore release metadata; deployed downgrades require the config-state steps
above. Existing untracked release notes and self-test report are preserved.
