### PR TITLE
chore(tokenless): bump version to 0.8.1

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/sdk.md
+++ b/docs/user-guide/en/token-saving/tokenless/sdk.md
@@ -34,14 +34,14 @@ CPython 3.11 or later. Select the native `anolisa-tokenless` wheel for the targe
 | Linux aarch64 | `anolisa_tokenless-<version>-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl` |
 | macOS Apple silicon | `anolisa_tokenless-<version>-cp311-abi3-macosx_11_0_arm64.whl` |
 
-The lifecycle API examples below require Tokenless 0.8.0. Install v0.8.0 on Linux x86_64
+The lifecycle API examples below require Tokenless 0.8.0. Install v0.8.1 on Linux x86_64
 into a virtual environment:
 
 ```bash
 python3 -m venv .venv
 . .venv/bin/activate
 python -m pip install \
-  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.8.0/anolisa_tokenless-0.8.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.8.1/anolisa_tokenless-0.8.1-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
 ```
 
 The Linux assets target glibc-based distributions compatible with `manylinux_2_17`; they do not

--- a/docs/user-guide/en/token-saving/tokenless/sdk/agentscope.md
+++ b/docs/user-guide/en/token-saving/tokenless/sdk/agentscope.md
@@ -22,14 +22,14 @@ AgentScope layer. Product adapters such as Claude Code and OpenCode are document
 
 The AgentScope integration wheel requires the exact same version of the native Runtime wheel.
 Install both assets from the same Tokenless GitHub Release in one command. For example, install
-[v0.8.0](https://github.com/alibaba/anolisa/releases/tag/tokenless/v0.8.0) on Linux x86_64:
+[v0.8.1](https://github.com/alibaba/anolisa/releases/tag/tokenless/v0.8.1) on Linux x86_64:
 
 ```bash
 python3 -m venv .venv
 . .venv/bin/activate
 python -m pip install \
-  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.8.0/anolisa_tokenless-0.8.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" \
-  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.8.0/anolisa_tokenless_agentscope-0.8.0-py3-none-any.whl"
+  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.8.1/anolisa_tokenless-0.8.1-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" \
+  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.8.1/anolisa_tokenless_agentscope-0.8.1-py3-none-any.whl"
 ```
 
 For Linux aarch64 or macOS Apple silicon, replace the native Runtime URL with the matching asset

--- a/docs/user-guide/zh/token-saving/tokenless/sdk.md
+++ b/docs/user-guide/zh/token-saving/tokenless/sdk.md
@@ -33,13 +33,13 @@ Tokenless GitHub Release 会附带官方 SDK Wheel。Wheel 需要 CPython 3.11 �
 | Linux aarch64 | `anolisa_tokenless-<version>-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl` |
 | macOS Apple 芯片 | `anolisa_tokenless-<version>-cp311-abi3-macosx_11_0_arm64.whl` |
 
-下文的生命周期 API 示例要求 Tokenless 0.8.0。在 Linux x86_64 上把 v0.8.0 安装到虚拟环境：
+下文的生命周期 API 示例要求 Tokenless 0.8.0。在 Linux x86_64 上把 v0.8.1 安装到虚拟环境：
 
 ```bash
 python3 -m venv .venv
 . .venv/bin/activate
 python -m pip install \
-  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.8.0/anolisa_tokenless-0.8.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.8.1/anolisa_tokenless-0.8.1-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
 ```
 
 Linux 产物面向兼容 `manylinux_2_17` 的 glibc 发行版，不支持 Alpine Linux 等 musl 发行版。

--- a/docs/user-guide/zh/token-saving/tokenless/sdk/agentscope.md
+++ b/docs/user-guide/zh/token-saving/tokenless/sdk/agentscope.md
@@ -21,14 +21,14 @@ OpenCode 等产品 Adapter 单独记录在 [Agent 集成](../framework-integrati
 
 AgentScope 集成 Wheel 要求原生 Runtime Wheel 的版本与它完全相同。请从同一个
 Tokenless GitHub Release 同时安装两个产物。例如，在 Linux x86_64 上安装
-[v0.8.0](https://github.com/alibaba/anolisa/releases/tag/tokenless/v0.8.0)：
+[v0.8.1](https://github.com/alibaba/anolisa/releases/tag/tokenless/v0.8.1)：
 
 ```bash
 python3 -m venv .venv
 . .venv/bin/activate
 python -m pip install \
-  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.8.0/anolisa_tokenless-0.8.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" \
-  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.8.0/anolisa_tokenless_agentscope-0.8.0-py3-none-any.whl"
+  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.8.1/anolisa_tokenless-0.8.1-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" \
+  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.8.1/anolisa_tokenless_agentscope-0.8.1-py3-none-any.whl"
 ```
 
 在 Linux aarch64 或 macOS Apple 芯片上，请按 [SDK 概览](../sdk.md) 替换原生 Runtime

--- a/src/anolisa/manifests/components/tokenless/component.toml
+++ b/src/anolisa/manifests/components/tokenless/component.toml
@@ -1,6 +1,6 @@
 [component]
 name = "tokenless"
-version = "0.8.0"
+version = "0.8.1"
 layer = "runtime"
 domain = "optimization"
 display_name = "Tokenless"

--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -9,6 +9,19 @@ Releases from 0.7.2 onward follow
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-09-09
+
+### Added
+
+- CSV/TSV tool output can now preserve all cells through quoting and line-ending compaction, or reduce larger tables to boundary rows, diagnostic rows, and a representative sample when recovery is available. Reduced views identify omitted rows and provide byte-exact original retrieval; complete enumeration or calculations require the original table. File reads and hosts without a text replacement slot pass through unchanged ([#3089](https://github.com/alibaba/anolisa/pull/3089)).
+- SLS records can now carry `tokenless.trace_id` and `tokenless.span_id` from `TOKENLESS_TRACEPARENT` or `TRACEPARENT`, so observability backends can correlate token savings with a host trace. The launching host or adapter must inject the context; without a usable value, records remain uncorrelated, and local `stats.db` data is unchanged ([#3094](https://github.com/alibaba/anolisa/pull/3094)).
+
+### Fixed
+
+- Claude Code detection now briefly re-lists a staged plugin missing from the first successful registry scan, avoiding false “not installed” results immediately after installation ([#3085](https://github.com/alibaba/anolisa/pull/3085)).
+- Hermes now skips trusted shared hook modules whose APIs or call signatures are incompatible with the adapter, tries later compatible candidates, and reports rejected candidates when none work. This prevents stale installations or cached modules from breaking lifecycle hooks ([#2249](https://github.com/alibaba/anolisa/pull/2249)).
+- OpenClaw installation now accepts declared capabilities when the host supports that option and sends the unsafe-install flag only when the host advertises it as effective. Hosts marking it as a no-op receive no bypass flag, and rejected installs point operators to `security.installPolicy` ([#3126](https://github.com/alibaba/anolisa/pull/3126), [#3152](https://github.com/alibaba/anolisa/pull/3152)).
+
 ## [0.8.0] - 2026-09-06
 
 ### Added

--- a/src/tokenless/CHANGELOG_zh.md
+++ b/src/tokenless/CHANGELOG_zh.md
@@ -9,6 +9,19 @@ Tokenless 的所有重要变更都会记录在此文件中。
 
 ## [未发布]
 
+## [0.8.1] - 2026-09-09
+
+### 新增
+
+- CSV/TSV 工具输出现在可以通过精简引号和行结束符保留全部单元格；具备恢复能力时，较大的表格可以保留首尾行、诊断行及代表性采样。缩减视图会标明省略情况，并提供逐字节恢复原文的入口；完整枚举或计算必须使用原始表格。文件读取和缺少文本替换能力的宿主保持原样 ([#3089](https://github.com/alibaba/anolisa/pull/3089))。
+- SLS 记录现在可以从 `TOKENLESS_TRACEPARENT` 或 `TRACEPARENT` 携带 `tokenless.trace_id` 和 `tokenless.span_id`，让可观测后端将 Token 节省关联到宿主 trace。上下文必须由启动 Tokenless 的宿主或适配器注入；没有有效值时记录保持未关联状态，本地 `stats.db` 数据不变 ([#3094](https://github.com/alibaba/anolisa/pull/3094))。
+
+### 修复
+
+- Claude Code 检测现在会在首次成功查询注册表却未列出已准备好的插件时进行短暂重试，避免刚安装后误报“未安装” ([#3085](https://github.com/alibaba/anolisa/pull/3085))。
+- Hermes 现在会跳过 API 或调用签名与适配器不兼容的可信共享 hook 模块，继续寻找兼容候选；全部失败时会列出拒绝原因，避免旧安装或缓存模块破坏生命周期 hook ([#2249](https://github.com/alibaba/anolisa/pull/2249))。
+- OpenClaw 安装现在会在宿主支持相应选项时接受声明的能力，并且仅在宿主声明 unsafe-install 标志仍有效时传入该标志。将其标记为 no-op 的宿主不会收到绕过标志，安装被拒绝时会提示检查 `security.installPolicy` ([#3126](https://github.com/alibaba/anolisa/pull/3126), [#3152](https://github.com/alibaba/anolisa/pull/3152))。
+
 ## [0.8.0] - 2026-09-06
 
 ### 新增

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "clap",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-compressors"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "csv",
  "serde_json",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-protocol"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-python"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "pyo3",
  "serde",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-runtime"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "rusqlite",
  "serde",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "regex",
  "serde_json",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-stats"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "dirs",

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/src/tokenless/adapters/tokenless/common/cosh-extension.json
+++ b/src/tokenless/adapters/tokenless/common/cosh-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenless",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "contextFileName": "COPILOT.md",
   "hooks": {
     "PreToolUse": [

--- a/src/tokenless/adapters/tokenless/openclaw/package-lock.json
+++ b/src/tokenless/adapters/tokenless/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokenless/openclaw-plugin",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokenless/openclaw-plugin",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": ">=22",

--- a/src/tokenless/benchmark/l1-compressor/Cargo.lock
+++ b/src/tokenless/benchmark/l1-compressor/Cargo.lock
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-compressors"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "csv",
  "serde_json",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-protocol"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/benchmark/l2-module/Cargo.lock
+++ b/src/tokenless/benchmark/l2-module/Cargo.lock
@@ -1212,7 +1212,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "blake3",
  "thiserror",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-compressors"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "csv",
  "serde_json",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-protocol"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/src/tokenless/npm/package.json
+++ b/src/tokenless/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anolisa-tokenless",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "Token-Less — LLM token optimization toolkit (schema/response compression, command rewriting, tool readiness)",
   "type": "module",
@@ -44,9 +44,9 @@
     "arm64"
   ],
   "optionalDependencies": {
-    "@anolisa/tokenless-linux-x64": "0.8.0",
-    "@anolisa/tokenless-linux-arm64": "0.8.0",
-    "@anolisa/tokenless-darwin-x64": "0.8.0",
-    "@anolisa/tokenless-darwin-arm64": "0.8.0"
+    "@anolisa/tokenless-linux-x64": "0.8.1",
+    "@anolisa/tokenless-linux-arm64": "0.8.1",
+    "@anolisa/tokenless-darwin-x64": "0.8.1",
+    "@anolisa/tokenless-darwin-arm64": "0.8.1"
   }
 }

--- a/src/tokenless/npm/platforms/darwin-arm64/package.json
+++ b/src/tokenless/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-arm64",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "Token-Less native binaries for macOS aarch64 (Apple Silicon)",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/darwin-x64/package.json
+++ b/src/tokenless/npm/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-x64",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "Token-Less native binaries for macOS x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-arm64/package.json
+++ b/src/tokenless/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-arm64",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "Token-Less native binaries for Linux aarch64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-x64/package.json
+++ b/src/tokenless/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-x64",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "Token-Less native binaries for Linux x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -504,6 +504,11 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Wed Sep 09 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.8.1-1
+- Add recoverable CSV/TSV compression and host trace correlation in SLS records
+- Fix Claude Code detection and Hermes shared hook API compatibility
+- Negotiate OpenClaw capability consent and effective unsafe-install options
+
 * Sun Sep 06 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.8.0-1
 - Migrate CLI, Python SDK and adapters to Protocol v2 lifecycle requests
 - Add recoverable JSON record reduction and build/test log compression


### PR DESCRIPTION
## Why

Prepare Tokenless 0.8.1 from the merged changes since the 0.8.0 release commit
`5cf1005d85deb185e928608ed6fd29e4e8007fd9`. Package consumers need matching
component, npm, adapter, and SDK versions for this release.

## What changed

Synchronize workspace and benchmark lockfiles, npm packages and native optional
dependencies, the component catalog, Cosh extension, and OpenClaw package lock.
Add paired release changelogs and an RPM changelog entry, and update paired SDK
installation examples. Generated adapter contracts and Python package metadata
continue to derive from the workspace version. This bump adds no runtime behavior.

## Related issue

no-issue: routine component release aggregation; implementing PRs are linked in both changelogs.

## User / Agent impact

The release includes recoverable CSV/TSV compression, optional SLS host trace
correlation, and compatibility fixes for Claude Code detection, Hermes shared
hooks, and OpenClaw installation. Full table enumeration or calculations require
retrieving the original; trace correlation requires launcher-provided context.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: this PR changes release metadata and documentation only. Existing
Protocol v2 contracts and third-party dependency versions are preserved. The
OpenClaw behavior described in the notes comes from already merged changes;
this PR adds no installer or policy changes.

## Validation

Environment: Alibaba Cloud Linux 3 x86_64, Rust 1.98.1, Python 3.11.13, Node 24.15.0.
Cargo commands used `RUSTC_WRAPPER= CARGO_BUILD_RUSTC_WRAPPER=`; benchmark tests used
`RUST_MIN_STACK=16777216`. All commands below passed.

- `make build`; `cargo fmt --all -- --check`;
  `cargo clippy --workspace --all-targets --locked -- -D warnings`;
  `cargo doc --workspace --no-deps --locked`.
- `make test-tokenless`: 776 passed, 3 ignored, zero failures. The remaining
  `make test` prerequisites were run explicitly: `make test-integration
  test-hook-parity` and `make test-hooks test-adapters test-claude-code-detect
  test-raw-package test-npm-package test-toon-cleanup`. Hook checks used the
  freshly built CLI/RTK on PATH and an isolated `TOKENLESS_DATA_DIR`.
- `cargo test --release --locked --manifest-path benchmark/l1-compressor/Cargo.toml`:
  97 passed; the equivalent `benchmark/l2-module/Cargo.toml` command: 42 passed.
- `make python-wheel agentscope-wheel`; `bash tests/test-python-runtime.sh`:
  27 passed with installed 0.8.1 wheel; `bash tests/test-agentscope-integration.sh`:
  1.0.11, 1.0.21, 2.0.0, 2.0.1, 2.0.2, 2.0.3, and 2.0.8 passed.
- `make npm-package`; `make package-raw BIN_DIR="$PWD/target/npm-prebuilt/linux-x64"`.
  An offline disposable container installed the two local npm tarballs and
  extracted the raw archive. Both binaries reported 0.8.1 and matched the source
  binary SHA-256; CSV/TSV row reduction, byte-exact retrieval, and file-content
  bypass passed. The temporary smoke fixture initially used invalid origin
  `file`; correcting it to the protocol value `file_content` passed without
  changing product code.
- Stamped `rpmspec -P`, metadata consistency checks, unchanged third-party lock
  dependencies, `bash scripts/docs-lint.sh`, `python3 scripts/docs-link-check.py`,
  `git diff --check`, and the history-derived component release audit passed.

Local native packaging warned that CLI/RTK require GLIBC_2.32, above the published
GLIBC_2.17 baseline. The local wheel is manylinux_2_31. These artifacts validate
native installation only and are not publication artifacts. Minimum-glibc,
aarch64/macOS execution, full RPM build/install, live model runs, and public
registry publication were not validated here; release CI owns distribution builds.

## Documentation and rollback

English and Chinese changelogs and SDK installation examples are synchronized.
The history-derived audit allows the unchanged Chinese framework-integration
guide: its 0.8.0 reference identifies when QwenPaw recovery APIs were introduced,
not the current release version. The matching English reference also remains
historical. Remaining 0.8.0 lock assignments belong to third-party `bit-set` and
`bit-vec`, not Tokenless.

Revert this atomic bump before publication to restore the 0.8.0 metadata. Once
published, retain immutable artifacts and use a subsequent patch release for
corrections. Installation links in this PR become usable when 0.8.1 is published.
