### PR TITLE
ci(sight): check BPF-LSM in kernel runner verification

### DIFF
--- a/.github/workflows/agentsight-runner-test.yml
+++ b/.github/workflows/agentsight-runner-test.yml
@@ -126,6 +126,14 @@ jobs:
           echo "BPF sysctls:"
           cat /proc/sys/kernel/unprivileged_bpf_disabled
           cat /proc/sys/kernel/perf_event_paranoid
+          echo "LSM modules:"
+          if [ -r /sys/kernel/security/lsm ]; then
+            cat /sys/kernel/security/lsm
+            grep -q bpf /sys/kernel/security/lsm || \
+              echo "::warning::BPF-LSM is not active on this runner; enforcement e2e tests will be skipped"
+          else
+            echo "::warning::securityfs not mounted; cannot determine LSM status"
+          fi
 
       - uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
Add `/sys/kernel/security/lsm` to the kernel runner verification step. This is a prerequisite for #3021 follow-up 2 (enforcement-effectiveness CI gate): the e2e test that installs a binding and asserts EPERM requires BPF-LSM to be loaded.

If BPF-LSM is not active, a `::warning::` annotation is emitted so we know the runner can't run enforcement tests.