### PR TITLE
chore(memory): bump version to 0.2.7

### DIFF
--- a/src/agent-memory/CHANGELOG.md
+++ b/src/agent-memory/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2026-09-09
+
+### Fixed
+
+- **agent-memory**: Negotiates OpenClaw installer flags from host help and grants declared capabilities by default, operators can install on hosts that require consent or withhold it with `AGENT_MEMORY_ACCEPT_CAPABILITIES=0`; deprecated no-op unsafe-install flags are omitted and failures distinguish consent rejection from unwritable destinations (#3149)
+- **agent-memory**: Labels corpus hits as `agent-memory` and supplies read handles for `memory_get corpus=all`, agents can retrieve matching stored memories even when their paths overlap OpenClaw workspace memory and receive accurate `fromLine` / `lineCount` for windowed reads (#3177)
+- **agent-memory**: Validates plugin configuration before locating the binary, operators see invalid `userId` / `sessionId` errors even when `agent-memory` is not installed (#3155)
+- **agent-memory**: Declares its RPM component identity, ANOLISA can recognize the installed package as the `agent-memory` component (#2560)
+- **agent-memory**: Declares Node.js >= 20 and npm as source-build dependencies in the unified build workflow, user-mode setup provisions the tools needed to bundle the OpenClaw adapter and system-mode preflight reports missing tools before building (#3187)
+
 ## [0.2.6] - 2026-07-30
 
 ### Fixed

--- a/src/agent-memory/CHANGELOG_zh.md
+++ b/src/agent-memory/CHANGELOG_zh.md
@@ -7,6 +7,16 @@
 本文档格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 项目遵循[语义化版本](https://semver.org/lang/zh-CN/spec/v2.0.0.html)。
 
+## [0.2.7] - 2026-09-09
+
+### 修复
+
+- **agent-memory**：根据宿主帮助信息选择 OpenClaw 安装参数并默认授予插件声明的能力，用户可在要求授权的宿主上安装，也可通过 `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` 拒绝授权；不再传递已弃用且无效的 unsafe-install 参数，并区分授权拒绝与安装目录不可写的问题（#3149）
+- **agent-memory**：将 corpus 命中标记为 `agent-memory` 并提供适用于 `memory_get corpus=all` 的读取路径，Agent 可读取与 OpenClaw 工作区记忆路径重叠的存储记忆，并在分段读取时获得准确的 `fromLine` / `lineCount`（#3177）
+- **agent-memory**：在查找二进制前校验插件配置，即使尚未安装 `agent-memory`，用户也能看到无效 `userId` / `sessionId` 的具体错误（#3155）
+- **agent-memory**：声明 RPM 组件标识，ANOLISA 可将已安装的软件包识别为 `agent-memory` 组件（#2560）
+- **agent-memory**：在统一构建流程中声明 Node.js >= 20 和 npm 为源码构建依赖，用户模式自动准备构建 OpenClaw 适配器所需的工具，系统模式则在构建前提示缺失工具（#3187）
+
 ## [0.2.6] - 2026-07-30
 
 ### 修复

--- a/src/agent-memory/Cargo.lock
+++ b/src/agent-memory/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-memory"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/agent-memory/Cargo.toml
+++ b/src/agent-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-memory"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 # edition 2024 stabilised in rustc 1.85; let-chains land in 1.88 so we
 # avoid them. Anolis ships 1.86, which is fine for build but won't take

--- a/src/agent-memory/adapters/agent-memory/manifest.json
+++ b/src/agent-memory/adapters/agent-memory/manifest.json
@@ -1,6 +1,6 @@
 {
   "component": "agent-memory",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "targets": {
     "openclaw": {
       "compatibleVersions": ">=5.0.0",

--- a/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "memory-anolisa",
   "name": "Anolisa Memory",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Persistent memory backed by the agent-memory MCP server with namespace isolation and openat2 sandbox. Provides BM25 search, file read/write, observe, and context assembly tools.",
   "activation": {
     "onStartup": false

--- a/src/agent-memory/adapters/agent-memory/openclaw/package-lock.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memory-anolisa-openclaw-plugin",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memory-anolisa-openclaw-plugin",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "devDependencies": {
         "@types/node": ">=22",
         "c8": "^10.1.0",

--- a/src/agent-memory/adapters/agent-memory/openclaw/package.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memory-anolisa-openclaw-plugin",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/src/agent-memory/agent-memory.spec.in
+++ b/src/agent-memory/agent-memory.spec.in
@@ -201,6 +201,13 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Wed Sep 09 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.2.7-1
+- Negotiate OpenClaw capability consent and effective installer flags
+- Fix corpus read routing and returned line-window metadata
+- Report invalid plugin configuration before probing for the binary
+- Declare RPM component identity for ANOLISA discovery
+- Detect Node.js and npm prerequisites in the unified source-build workflow
+
 * Thu Jul 30 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.2.6-1
 - fix(memory): recall partial short-token matches with OR fallback (#2040)
 

--- a/src/agent-memory/config/mcp-server.json
+++ b/src/agent-memory/config/mcp-server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-memory",
   "description": "Agent memory — filesystem memory MCP server. 31 tools across three tiers: Tier A file ops (read/write/append/edit/list/grep/diff/mkdir/remove/promote + mem_session_log), Tier B structured (memory_search, memory_observe, memory_get_context, memory_task_save/resume/list/close, memory_forget, memory_consent, mem_export, mem_import), Tier C governance (mem_snapshot/mem_snapshot_list/mem_snapshot_restore/mem_log/mem_revert/mem_consolidate/mem_compact, memory_about, memory_auto_created). Optional Linux user-namespace isolation, SQLite FTS5 BM25 + vector hybrid background index, time-decay ranking, cold archival, episodic memory extraction, conflict detection, git versioning, tar.gz snapshots, cgroup v2 memory.max, and journald audit fan-out.",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "command": "/usr/bin/agent-memory",
   "args": [],
   "env": {},

--- a/src/anolisa/manifests/components/agent-memory/component.toml
+++ b/src/anolisa/manifests/components/agent-memory/component.toml
@@ -1,6 +1,6 @@
 [component]
 name = "agent-memory"
-version = "0.2.6"
+version = "0.2.7"
 layer = "runtime"
 domain = "state"
 display_name = "Agent Memory"


### PR DESCRIPTION
## Why

Prepare agent-memory 0.2.7 from the merged changes since the 0.2.6 release commit `796b5ac8ba04984499253a2681da41f11b86457a`. Users receive the OpenClaw installation and corpus-read fixes with consistent component, plugin, MCP, and catalog versions.

## What changed

- Synchronize 11 tracked release files: Cargo manifest/lock, adapter and OpenClaw manifests, npm manifest/lock, MCP descriptor, RPM changelog, bilingual changelogs, and the ANOLISA catalog contract.
- Keep `Cargo.toml` authoritative and use `make sync-versions generate-component-contract` for derived metadata. `.anolisa/component.toml` became an ignored build output in `c87d4a44`; the release audit permits that historical surface to be absent from the diff, and its generated version was verified as 0.2.7.
- Preserve dependency versions, including the unrelated `unicode-xid` 0.2.6 entry in `Cargo.lock`. The bump adds no runtime code changes.

## Related issue

no-issue: component release aggregation of already merged changes.

Implementing PRs: #3149, #3177, #3155, #2560, #3187.

## User / Agent impact

- OpenClaw installation negotiates supported consent and unsafe-install flags, supports explicit consent refusal, and improves failure diagnostics.
- Corpus search results route back to agent-memory even for paths overlapping workspace memory; windowed reads report the returned line range.
- Invalid plugin identifiers are reported before a missing binary; RPM component identity is discoverable; unified source builds prepare or diagnose missing Node.js/npm prerequisites.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: this PR changes versions and release documentation only. The catalog contract version moves with the component; its schema, layout, and adapter contract remain unchanged. The changelogs describe behavior already merged, including capability consent being granted by default and the `AGENT_MEMORY_ACCEPT_CAPABILITIES=0` opt-out. No data migration is introduced by the bump.

## Validation

Environment: Alibaba Cloud Linux 3, Linux x86_64, Rust 1.98.1, Node.js 24.15.0, npm 11.12.1.

From `src/agent-memory`:

- `cargo fmt --all` and `cargo fmt --all -- --check`
- `cargo check --offline` (updates only the component's Cargo lock entry), then `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`: 346 passed, 0 failed, 0 ignored; host-capability tests retain their existing conditional behavior.
- `make build`; `cargo doc --workspace --no-deps --locked`; `target/release/agent-memory --version`: `agent-memory 0.2.7`
- `make test-openclaw-install`: 41 scenarios passed.
- OpenClaw `npm run build:check` and `npm test`: 126 tests passed.
- `make smoke` with temporary memory/session directories, plus an independently asserted stdio exchange verifying the 0.2.7 handshake, write/read/append/grep/list, and path-escape rejection. The Makefile smoke target alone only produced the handshake before stdin closed, so the independent exchange supplies the actual tool-call evidence.
- OpenClaw `npm run smoke` with the built release binary first on `PATH` and a temporary memory base: all five assertions passed, but the process did not exit until its surviving MCP child was explicitly killed. This is qualified runtime evidence, not a clean shutdown pass.
- `npm pack --json`: verified the six runtime entries, manifest versions, and bundled version. A local source archive verified Cargo/MCP/adapter versions and the generated contract/plugin bundle.
- `make spec`; `rpmspec -q` and `rpmspec -q --provides`: verified 0.2.7 and `anolisa-component(agent-memory)`.
- Release audit `check_release.py --component agent-memory --scope memory --version 0.2.7 --previous 0.2.6 --bump-commit 796b5ac8ba04984499253a2681da41f11b86457a --allow-missing src/agent-memory/.anolisa/component.toml` (repository root supplied with `--repo`).

Integration checks:

- Root `python3 scripts/check-component-versions.py`: synchronized.
- Root `bash tests/test-build-all-runtime-deps.sh`: 45 scenarios passed.
- From `src/anolisa`: `cargo check --locked` and `cargo doc --no-deps --locked`.
- `git diff --check` and staged release-scope inspection.

Limits and pre-existing findings:

- No arm64 execution, full RPM build/install, or live OpenClaw gateway installation was performed. No tag or package publication is part of this PR preparation.
- RPM parsing reports an existing weekday/date mismatch in the 0.2.1 changelog row.
- The plugin smoke test's `stop()` assertion returned after two seconds while its MCP child survived for over two minutes. The existing timeout checks `ChildProcess.killed`, which indicates a signal was sent rather than that the child exited, and then drops the process reference. The release does not change this shutdown implementation; only the child created by this smoke run was terminated.
- Source-archive inspection found that the tracked `LICENSE` is a regular file containing `../../LICENSE`; the current source packaging action only expands symlinks, so the archive carries that reference instead of the license text. The license-content assertion failed; release metadata and plugin-bundle assertions passed. This pre-existing packaging issue is unchanged by the version bump.

## Documentation and rollback

Updated `CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM changelog with equivalent release coverage. Before publication, revert this atomic version commit to restore the 0.2.6 metadata; runtime changes remain in their original commits. Reinstalling an older published package is a separate rollback decision, and this metadata-only commit introduces no new data migration.
