### PR TITLE
ci(sight): mount securityfs before LSM check

### DIFF
--- a/.github/workflows/agentsight-runner-test.yml
+++ b/.github/workflows/agentsight-runner-test.yml
@@ -127,12 +127,16 @@ jobs:
           cat /proc/sys/kernel/unprivileged_bpf_disabled
           cat /proc/sys/kernel/perf_event_paranoid
           echo "LSM modules:"
+          # securityfs may not be mounted in container runners; try to mount it.
+          # Skip if already mounted (reused self-hosted runner).
+          mountpoint -q /sys/kernel/security 2>/dev/null || \
+            sudo mount -t securityfs securityfs /sys/kernel/security 2>/dev/null || true
           if [ -r /sys/kernel/security/lsm ]; then
             cat /sys/kernel/security/lsm
             grep -q bpf /sys/kernel/security/lsm || \
               echo "::warning::BPF-LSM is not active on this runner; enforcement e2e tests will be skipped"
           else
-            echo "::warning::securityfs not mounted; cannot determine LSM status"
+            echo "::warning::securityfs not available; cannot determine LSM status"
           fi
 
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Follow-up to #3196 (merged). The kernel runners don't have securityfs mounted, so the LSM check always falls into the "not mounted" branch.

Try to mount securityfs first (`sudo mount -t securityfs`), then check. If the mount fails (container without CAP_SYS_ADMIN or restricted seccomp), we still fall through to the warning.