### PR TITLE
feat(skillfs): add multi-source mount config

### DIFF
--- a/docs/user-guide/en/runtime/skillfs.md
+++ b/docs/user-guide/en/runtime/skillfs.md
@@ -154,6 +154,58 @@ termination, clears them, and remounts with bounded recovery retries. Default
 foreground mounts are unchanged: they still exit and unmount on `SIGTERM` or
 `Ctrl+C`.
 
+### Mount Configuration
+
+Aggregate explicit source directories with a TOML file:
+
+```toml
+mountpoint = "/mnt/skillfs"
+sources = [
+  "/path/to/workspace/skills",
+  "/path/to/managed/skills",
+  "/path/to/bundled/skills",
+]
+```
+
+```bash
+skillfs mount --config /path/to/skillfs-mount.toml
+```
+
+Sources are ordered from highest to lowest precedence. The first source containing
+a skill directory name wins as a whole, including scripts and resources; files
+from shadowed skills are not merged. Duplicate names are logged with both paths.
+The view is exposed at `/mnt/skillfs/skills`, and discovery advertises mounted
+paths. The existing directory-name identity is retained; this does not implement
+OpenClaw's frontmatter-name precedence rules.
+
+The file accepts only `mountpoint` and `sources`. Supply at least one source and
+absolute paths (no `~` or environment expansion). Sources must exist and be
+readable; canonical duplicate roots are removed, preserving order. Sources and
+the mountpoint must not contain one another. Invalid skills or a combined skill
+count above the existing limit fail startup.
+
+Multiple distinct sources automatically enable read-only mounting. A single
+source remains writable unless `--read-only` is supplied. This configuration
+always uses the flat output layout, retaining the existing flat and categorized
+source scanning depth. Only the first source's `skillfs-views.toml` is used;
+read-only configuration mounts do not update that file. Skills absent from every
+view are included in the effective default view in memory; explicitly assigned
+secondary skills keep their grouping. No source config merge,
+automatic source discovery, or hot reload is performed. Remount after changing
+the config or adding/removing skills; reads are not an immutable content snapshot.
+
+Mount configuration cannot be mixed with positional paths or security,
+activation, installation, layout, or managed-mode options. The supported optional
+flags are `--foreground`, `--allow-other`, `--read-only`, `--verbose`, and
+`--log-file`. Existing `mount SOURCE MOUNTPOINT --config security.toml` usage is
+unchanged for files without `sources` or `mountpoint`.
+
+For OpenClaw, point the intended skill loader at the mounted `skills` directory
+and verify actual loaded paths. Adding it as an extra directory alone does not
+replace higher-priority original sources. Direct source access remains outside
+this mount's coverage. Roll back by unmounting with `fusermount3 -u /mnt/skillfs`
+and returning to the existing single-source command.
+
 ## CLI Utilities
 
 ### validate

--- a/docs/user-guide/zh/runtime/skillfs.md
+++ b/docs/user-guide/zh/runtime/skillfs.md
@@ -148,6 +148,49 @@ Managed mode 还会在 worker 异常退出后检测 stale/dead FUSE endpoint，�
 有界重试重新挂载。默认 foreground mount 行为不变：收到 `SIGTERM` 或 `Ctrl+C`
 时仍会退出并 unmount。
 
+### 挂载配置
+
+通过 TOML 文件聚合显式指定的源目录：
+
+```toml
+mountpoint = "/mnt/skillfs"
+sources = [
+  "/path/to/workspace/skills",
+  "/path/to/managed/skills",
+  "/path/to/bundled/skills",
+]
+```
+
+```bash
+skillfs mount --config /path/to/skillfs-mount.toml
+```
+
+源按优先级从高到低排列。同名 skill 目录整体选用第一个来源，包括脚本和资源；
+不合并被遮蔽 skill 的文件。重名日志记录选中和被遮蔽的路径。
+视图位于 `/mnt/skillfs/skills`，discovery 输出挂载后的路径。
+继续使用目录名作为 skill 标识，不实现 OpenClaw 的 frontmatter 名称优先级规则。
+
+文件只接受 `mountpoint` 和 `sources`。至少指定一个源，所有路径必须为绝对路径，
+不展开 `~` 或环境变量。源必须存在且可读；规范化后相同的源去重，保留原顺序。
+源与挂载点不能相互包含。无法解析的 skill 或合并后超过现有数量上限会导致启动失败。
+
+多个不同源自动启用只读挂载；单源仍可写，除非指定 `--read-only`。
+该入口固定使用 flat 输出布局，保留现有 flat/category 源目录扫描深度。
+只使用第一个源的 `skillfs-views.toml`；只读配置挂载不更新此文件。
+未分配到任何 view 的 skill 会在内存中加入有效默认视图；显式分配到 secondary
+view 的 skill 保持原有分组。
+不合并源配置，不自动发现源，也不热加载。修改配置或新增、删除 skill 后需重新挂载；
+读取结果不是不可变的内容快照。
+
+挂载配置不能与位置参数或 security、activation、installation、layout、managed
+模式参数混用。允许的可选参数为 `--foreground`、`--allow-other`、`--read-only`、
+`--verbose` 和 `--log-file`。不含 `sources` 或 `mountpoint` 的文件继续支持原有
+`mount SOURCE MOUNTPOINT --config security.toml` 用法。
+
+接入 OpenClaw 时，将所需 skill loader 指向挂载后的 `skills` 目录，并检查实际加载路径。
+仅添加 extra directory 不会替代更高优先级的原生来源；直接访问源目录仍不受此挂载覆盖。
+回退时执行 `fusermount3 -u /mnt/skillfs`，再使用原有单源命令。
+
 ## CLI 工具
 
 ### validate

--- a/src/skillfs/Cargo.lock
+++ b/src/skillfs/Cargo.lock
@@ -821,6 +821,7 @@ dependencies = [
  "skillfs-fuse",
  "tempfile",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]

--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -132,6 +132,14 @@ cargo run -p skillfs -- mount /path/to/skills /path/to/mountpoint --managed
 cargo run -p skillfs -- stop /path/to/mountpoint
 ```
 
+### Mount Configuration
+
+Use `skillfs mount --config /path/to/skillfs-mount.toml` with `mountpoint` and
+an ordered `sources` array to aggregate directories. Earlier sources win whole
+skill-name conflicts; multiple sources are read-only. Paths must be absolute.
+See the [configuration reference](../../docs/user-guide/en/runtime/skillfs.md#mount-configuration)
+for the TOML example, supported flags, and OpenClaw integration limits.
+
 ### Managed Mount Mode
 
 Default `mount`, including `--foreground`, keeps the original foreground

--- a/src/skillfs/README_zh.md
+++ b/src/skillfs/README_zh.md
@@ -123,6 +123,13 @@ cargo run -p skillfs -- mount /path/to/skills /path/to/mountpoint --managed
 cargo run -p skillfs -- stop /path/to/mountpoint
 ```
 
+### 挂载配置
+
+使用 `skillfs mount --config /path/to/skillfs-mount.toml`，通过 `mountpoint` 和
+有序 `sources` 数组聚合目录。同名 skill 整体选用较早的来源，多源挂载只读。
+路径必须为绝对路径。TOML 示例、支持的参数和 OpenClaw 接入限制见
+[配置参考](../../docs/user-guide/zh/runtime/skillfs.md#挂载配置)。
+
 ### Managed Mount 模式
 
 默认 `mount`（包括 `--foreground`）保持原有前台行为：进程阻塞，

--- a/src/skillfs/crates/skillfs-cli/Cargo.toml
+++ b/src/skillfs/crates/skillfs-cli/Cargo.toml
@@ -22,6 +22,7 @@ tracing-subscriber = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+toml = { workspace = true }
 libc = { workspace = true }
 
 [dev-dependencies]

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -13,7 +13,7 @@ fn cleanup_pid_file(pid_file: &Option<PathBuf>) {
     }
 }
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use skillfs_core::store::SkillStore;
 use skillfs_core::views::ViewsConfig;
 use skillfs_core::{ParseConfig, SharedSkillStore};
@@ -37,6 +37,7 @@ use tracing::{debug, error, info, warn};
 
 mod help_text;
 mod managed;
+mod mount_file;
 mod sls_ops;
 
 #[derive(Clone, Debug)]
@@ -177,12 +178,12 @@ enum Commands {
     #[command(after_help = help_text::MOUNT_AFTER_HELP)]
     Mount {
         /// Directory that stores skill folders, SKILL.md, and skillfs-views.toml.
-        #[arg(value_name = "SOURCE", help_heading = help_text::HEADING_MOUNT)]
-        source: PathBuf,
+        #[arg(value_name = "SOURCE", required_unless_present = "config", requires = "mountpoint", help_heading = help_text::HEADING_MOUNT)]
+        source: Option<PathBuf>,
 
         /// Directory where SkillFS exposes the virtual /skills view.
-        #[arg(value_name = "MOUNTPOINT", help_heading = help_text::HEADING_MOUNT)]
-        mountpoint: PathBuf,
+        #[arg(value_name = "MOUNTPOINT", required_unless_present = "config", requires = "source", help_heading = help_text::HEADING_MOUNT)]
+        mountpoint: Option<PathBuf>,
 
         /// Allow users other than the mounter to access the FUSE mount.
         #[arg(long, help_heading = help_text::HEADING_MOUNT)]
@@ -287,9 +288,9 @@ enum Commands {
         #[arg(long, value_name = "PATH", help_heading = help_text::HEADING_TRUSTED_WRITERS)]
         trusted_writer_exe: Option<PathBuf>,
 
-        /// TOML configuration file for security, activation, and logging.
+        /// TOML mount configuration (sources and mountpoint), or legacy security configuration.
         ///
-        /// CLI flags override values from this file.
+        /// Mount configuration replaces positional paths; security configuration keeps CLI overrides.
         #[arg(long, value_name = "PATH", help_heading = help_text::HEADING_CONFIG)]
         config: Option<PathBuf>,
 
@@ -585,6 +586,56 @@ async fn run(
             trusted_peer_gid,
             skill_layout,
         } => {
+            let inputs = (|| -> Result<_, Box<dyn std::error::Error>> {
+                let mount_file = config
+                    .as_deref()
+                    .map(mount_file::load)
+                    .transpose()?
+                    .flatten();
+                if mount_file.is_some() {
+                    let matches = Cli::command().try_get_matches_from(
+                        std::iter::once("skillfs".to_string()).chain(raw_args.iter().cloned()),
+                    )?;
+                    let (_, args) = matches.subcommand().ok_or("missing mount command")?;
+                    mount_file::validate_options(args)?;
+                }
+                let inputs = if let Some(file) = mount_file {
+                    let file = file.validate()?;
+                    (
+                        file.sources[0].clone(),
+                        file.mountpoint,
+                        Some(file.sources),
+                        None,
+                    )
+                } else {
+                    (
+                        source.ok_or("SOURCE is required with a security configuration")?,
+                        mountpoint.ok_or("MOUNTPOINT is required with a security configuration")?,
+                        None,
+                        config,
+                    )
+                };
+                Ok(inputs)
+            })();
+            let (source, mountpoint, sources, config) = match inputs {
+                Ok(inputs) => inputs,
+                Err(error) => {
+                    finish_sls(guard, Some(error.to_string()));
+                    return Err(error);
+                }
+            };
+            let multi_source = sources.as_ref().is_some_and(|roots| roots.len() > 1);
+            let read_only = read_only || multi_source;
+            let skill_discover_root = if sources.is_some() {
+                Some(mountpoint.join("skills"))
+            } else {
+                skill_discover_root
+            };
+            let skill_layout = if sources.is_some() {
+                Some("flat".to_string())
+            } else {
+                skill_layout
+            };
             if let Some(root) = &skill_discover_root {
                 if !root.is_absolute() {
                     let result = Err(format!(
@@ -611,6 +662,7 @@ async fn run(
             // failure; the mount-session summary writer remains untouched.
             let result = cmd_mount(
                 source,
+                sources,
                 mountpoint,
                 allow_other,
                 read_only,
@@ -843,6 +895,7 @@ fn daemon_facing_arg_under_private_tmp(path: &Path) -> bool {
 #[allow(clippy::too_many_arguments)]
 async fn cmd_mount(
     source: PathBuf,
+    sources: Option<Vec<PathBuf>>,
     mountpoint: PathBuf,
     allow_other: bool,
     read_only: bool,
@@ -1618,7 +1671,12 @@ async fn cmd_mount(
     info!("loading skills from source directory");
     let mut store = SkillStore::new();
     let config = ParseConfig::default();
-    let errors = store.load_from_directory(runtime_roots.physical_source_root(), &config);
+    let errors = if let Some(roots) = &sources {
+        store = mount_file::load_sources(roots, &config)?;
+        Vec::new()
+    } else {
+        store.load_from_directory(runtime_roots.physical_source_root(), &config)
+    };
 
     if !errors.is_empty() {
         warn!(count = errors.len(), "some skills failed to load");
@@ -1630,7 +1688,9 @@ async fn cmd_mount(
     info!(count = store.len(), "skills loaded");
 
     // Auto-assign any skills that are not yet in any view to the default view.
-    if let Some(mut views) = ViewsConfig::load(runtime_roots.physical_source_root()) {
+    if let Some(mut views) = ViewsConfig::load(runtime_roots.physical_source_root())
+        .filter(|_| !(sources.is_some() && read_only))
+    {
         let assigned = views.all_assigned_skills();
         let new_skills: Vec<String> = store
             .list()
@@ -2432,24 +2492,14 @@ async fn cmd_mount(
 
         // Build the canonical "real existing default-view skills" set.
         // Deduplicates and filters out stale/typo names not in the store.
-        let default_served: std::collections::HashSet<&str> = if let Some(ref cfg) = views_config {
-            cfg.views
-                .iter()
-                .find(|v| v.default)
-                .map(|v| {
-                    v.skills
-                        .iter()
-                        .map(|s| s.as_str())
-                        .filter(|n| store_guard.get(n).is_some())
-                        .collect()
-                })
-                .unwrap_or_else(|| {
-                    // Config exists but no default view — treat all as default.
-                    store_guard.list().into_iter().collect()
-                })
+        let default_served: std::collections::HashSet<String> = if let Some(ref cfg) = views_config
+        {
+            cfg.effective_default_skills(&store_guard)
+                .into_iter()
+                .collect()
         } else {
             // No views config => all skills are default.
-            store_guard.list().into_iter().collect()
+            store_guard.list().into_iter().map(str::to_string).collect()
         };
 
         let default_exposed_count = default_served.len() as u64;

--- a/src/skillfs/crates/skillfs-cli/src/mount_file.rs
+++ b/src/skillfs/crates/skillfs-cli/src/mount_file.rs
@@ -1,0 +1,202 @@
+//! Explicit mount sources and deterministic, whole-skill precedence.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use skillfs_core::{ParseConfig, store::SkillStore};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+/// Ordered mount inputs, separate from the legacy security configuration.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct MountFile {
+    /// Dedicated output directory, outside all sources.
+    pub(super) mountpoint: PathBuf,
+    /// Highest-precedence source first.
+    pub(super) sources: Vec<PathBuf>,
+}
+
+/// Recognize mount keys while preserving legacy security configuration files.
+pub(super) fn load(path: &Path) -> Result<Option<MountFile>> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read config '{}': {e}", path.display()))?;
+    let value: toml::Value =
+        toml::from_str(&text).map_err(|e| format!("invalid config '{}': {e}", path.display()))?;
+    if value.get("sources").is_none() && value.get("mountpoint").is_none() {
+        return Ok(None);
+    }
+    Ok(Some(value.try_into().map_err(|e| {
+        format!("invalid mount config '{}': {e}", path.display())
+    })?))
+}
+
+/// Reject flags whose single-root semantics have not been adapted.
+pub(super) fn validate_options(args: &clap::ArgMatches) -> Result<()> {
+    // Clap also reports the derive-generated Mount argument group.
+    for id in args.ids() {
+        if args.value_source(id.as_str()) == Some(clap::parser::ValueSource::CommandLine)
+            && !matches!(
+                id.as_str(),
+                "Mount"
+                    | "config"
+                    | "foreground"
+                    | "allow_other"
+                    | "read_only"
+                    | "verbose"
+                    | "log_file"
+            )
+        {
+            return Err(format!("mount configuration cannot be combined with '{}'", id).into());
+        }
+    }
+    Ok(())
+}
+
+impl MountFile {
+    /// Resolve and deduplicate roots before creating any mount resources.
+    pub(super) fn validate(mut self) -> Result<Self> {
+        if self.sources.is_empty() {
+            return Err("mount config sources must not be empty".into());
+        }
+        if !self.mountpoint.is_absolute() || self.sources.iter().any(|p| !p.is_absolute()) {
+            return Err("mount config sources and mountpoint must be absolute paths".into());
+        }
+        // Resolve existing ancestors even when the mount directory is new.
+        let mut ancestor = self.mountpoint.as_path();
+        let mut suffix = Vec::new();
+        while !ancestor.exists() {
+            suffix.push(ancestor.file_name().ok_or("invalid mountpoint")?);
+            ancestor = ancestor.parent().ok_or("invalid mountpoint parent")?;
+        }
+        let mut mountpoint = ancestor.canonicalize()?;
+        for part in suffix.into_iter().rev() {
+            mountpoint.push(part);
+        }
+        self.mountpoint = super::lexical_absolute(&mountpoint)?;
+        let mut roots = Vec::new();
+        for source in self.sources {
+            let root = source
+                .canonicalize()
+                .map_err(|e| format!("cannot resolve source '{}': {e}", source.display()))?;
+            std::fs::read_dir(&root)
+                .map_err(|e| format!("cannot read source '{}': {e}", root.display()))?;
+            if root.starts_with(&self.mountpoint) || self.mountpoint.starts_with(&root) {
+                return Err(format!(
+                    "source '{}' and mountpoint must not overlap",
+                    root.display()
+                )
+                .into());
+            }
+            if !roots.contains(&root) {
+                roots.push(root);
+            }
+        }
+        self.sources = roots;
+        Ok(self)
+    }
+}
+
+/// Merge complete skills by directory name without changing source files.
+pub(super) fn load_sources(roots: &[PathBuf], config: &ParseConfig) -> Result<SkillStore> {
+    let mut merged = SkillStore::new();
+    for root in roots {
+        let mut store = SkillStore::new();
+        let errors = store.load_from_directory(root, config);
+        if !errors.is_empty() {
+            return Err(errors
+                .iter()
+                .map(|e| format!("{}: {}", e.path.display(), e.error))
+                .collect::<Vec<_>>()
+                .join("; ")
+                .into());
+        }
+        for (name, entry) in store.iter() {
+            if let skillfs_core::ParseStatus::Error(error) = &entry.parse_status {
+                return Err(format!("{}: {error}", entry.source_path.display()).into());
+            }
+            if let Some(winner) = merged.get(name) {
+                tracing::warn!(skill = %name, selected = %winner.source_path.display(),
+                    shadowed = %entry.source_path.display(), "duplicate skill: earlier source wins");
+            } else {
+                if merged.len() >= config.max_skills {
+                    return Err(format!(
+                        "combined sources exceed max skills limit ({})",
+                        config.max_skills
+                    )
+                    .into());
+                }
+                merged.upsert(entry.clone());
+            }
+        }
+    }
+    Ok(merged)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_precedence_limits_and_invalid_skills() {
+        let temp = tempfile::tempdir().unwrap();
+        let roots: Vec<_> = ["high", "low"].map(|s| temp.path().join(s)).into();
+        for root in &roots {
+            std::fs::create_dir_all(root.join("demo")).unwrap();
+            std::fs::write(
+                root.join("demo/SKILL.md"),
+                "---\nname: demo\ndescription: test\n---\n",
+            )
+            .unwrap();
+        }
+        let store = load_sources(&roots, &ParseConfig::default()).unwrap();
+        assert_eq!(store.len(), 1);
+        assert_eq!(
+            store.get("demo").unwrap().source_path,
+            roots[0].join("demo/SKILL.md")
+        );
+        std::fs::rename(roots[1].join("demo"), roots[1].join("other")).unwrap();
+        let config = ParseConfig {
+            max_skills: 1,
+            ..ParseConfig::default()
+        };
+        assert!(
+            load_sources(&roots, &config)
+                .unwrap_err()
+                .to_string()
+                .contains("combined sources")
+        );
+        std::fs::write(
+            roots[0].join("demo/SKILL.md"),
+            "---\ndescription: [broken\n---\n",
+        )
+        .unwrap();
+        assert!(load_sources(&roots, &ParseConfig::default()).is_err());
+    }
+
+    #[test]
+    fn canonical_roots_and_mount_overlap() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("source");
+        std::fs::create_dir(&root).unwrap();
+        let alias = temp.path().join("alias");
+        std::os::unix::fs::symlink(&root, &alias).unwrap();
+        let file = MountFile {
+            mountpoint: temp.path().join("new/mount"),
+            sources: vec![root.clone(), alias.clone()],
+        }
+        .validate()
+        .unwrap();
+        assert_eq!(file.sources, vec![root.clone()]);
+        for mountpoint in [root.clone(), alias.join("mount"), temp.path().to_path_buf()] {
+            assert!(
+                MountFile {
+                    mountpoint,
+                    sources: vec![root.clone()]
+                }
+                .validate()
+                .is_err()
+            );
+        }
+    }
+}

--- a/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
@@ -3209,3 +3209,178 @@ trusted_peer_exe = "{}"
         "hermes (config) control socket server did not return an authenticated pong: {resp}"
     );
 }
+
+#[test]
+fn mount_file_rejects_invalid_configuration_and_option_mixing() {
+    let temp = tempfile::tempdir().unwrap();
+    let config = temp.path().join("mount.toml");
+    let mount = temp.path().join("mount");
+    let source = temp.path().join("source");
+    std::fs::create_dir(&source).unwrap();
+    let valid = format!("mountpoint = {:?}\nsources = [{:?}]\n", mount, source);
+    let cases = [
+        (
+            "mountpoint = '/mnt/view'\nsources = []\n".to_string(),
+            vec![],
+            "must not be empty",
+        ),
+        (
+            "mountpoint = '/mnt/view'\nsources = ['relative']\n".to_string(),
+            vec![],
+            "absolute",
+        ),
+        (
+            format!("{valid}unexpected = true\n"),
+            vec![],
+            "unknown field",
+        ),
+        (valid.clone(), vec!["--security"], "cannot be combined"),
+        (valid.clone(), vec!["--managed"], "cannot be combined"),
+        (
+            valid.clone(),
+            vec!["--skill-layout", "hermes"],
+            "cannot be combined",
+        ),
+        (
+            valid.clone(),
+            vec![source.to_str().unwrap(), mount.to_str().unwrap()],
+            "cannot be combined",
+        ),
+        ("[audit]\n".to_string(), vec![], "SOURCE is required"),
+    ];
+    for (body, extra, expected) in cases {
+        std::fs::write(&config, body).unwrap();
+        let out = Command::new(bin_path())
+            .args(["mount", "--config"])
+            .arg(&config)
+            .args(extra)
+            .output()
+            .unwrap();
+        assert!(!out.status.success());
+        assert!(
+            String::from_utf8_lossy(&out.stderr).contains(expected),
+            "{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(!mount.exists());
+    }
+}
+
+#[test]
+fn mount_file_aggregates_whole_skills_read_only() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE unavailable");
+        return;
+    }
+    let temp = tempfile::tempdir().unwrap();
+    let high = temp.path().join("high");
+    let low = temp.path().join("low");
+    let mount = temp.path().join("mount");
+    for (root, name, body) in [
+        (&high, "demo", "winner"),
+        (&low, "demo", "shadowed"),
+        (&low, "other", "second source"),
+        (&low, "reserve", "secondary view"),
+        (&low, "unassigned", "not assigned to a view"),
+    ] {
+        std::fs::create_dir_all(root.join(name)).unwrap();
+        std::fs::write(
+            root.join(name).join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: fixture\n---\n{body}\n"),
+        )
+        .unwrap();
+        std::fs::write(root.join(name).join("resource.txt"), body).unwrap();
+    }
+    let views = "[[view]]\nname = 'default'\ndefault = true\nskills = ['demo', 'other']\n[[view]]\nname = 'reserve'\nskills = ['reserve']\n";
+    std::fs::write(high.join("skillfs-views.toml"), views).unwrap();
+    std::fs::write(
+        low.join("skillfs-views.toml"),
+        "[[view]]\nname = 'default'\ndefault = true\nskills = []\n",
+    )
+    .unwrap();
+    std::fs::write(low.join("demo/low-only.txt"), "must not merge").unwrap();
+    let config = temp.path().join("mount.toml");
+    std::fs::write(
+        &config,
+        format!(
+            "mountpoint = {:?}\nsources = [{:?}, {:?}]\n",
+            mount, high, low
+        ),
+    )
+    .unwrap();
+    struct RunningMount(Child, std::path::PathBuf);
+    impl Drop for RunningMount {
+        fn drop(&mut self) {
+            stop_mount_child(&mut self.0, &self.1);
+            let _ = self.0.wait();
+        }
+    }
+    let log = std::fs::File::create(temp.path().join("mount.log")).unwrap();
+    let mut child = RunningMount(
+        Command::new(bin_path())
+            .args(["mount", "--config"])
+            .arg(&config)
+            .arg("--foreground")
+            .stderr(log)
+            .stdout(std::process::Stdio::null())
+            .spawn()
+            .unwrap(),
+        mount.clone(),
+    );
+    for _ in 0..100 {
+        if is_mounted(&mount) || child.0.try_wait().unwrap().is_some() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        is_mounted(&mount),
+        "{}",
+        std::fs::read_to_string(temp.path().join("mount.log")).unwrap()
+    );
+    let skill = mount.join("skills/demo");
+    assert!(
+        std::fs::read_to_string(skill.join("SKILL.md"))
+            .unwrap()
+            .contains("winner")
+    );
+    assert_eq!(
+        std::fs::read_to_string(skill.join("resource.txt")).unwrap(),
+        "winner"
+    );
+    assert_eq!(
+        std::fs::read_to_string(mount.join("skills/other/resource.txt")).unwrap(),
+        "second source"
+    );
+    assert!(!skill.join("low-only.txt").exists());
+    let visible: Vec<_> = std::fs::read_dir(mount.join("skills"))
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect();
+    assert!(visible.iter().any(|name| name == "unassigned"));
+    assert!(!visible.iter().any(|name| name == "reserve"));
+    assert_eq!(
+        std::fs::read_to_string(mount.join("skills/unassigned/resource.txt")).unwrap(),
+        "not assigned to a view"
+    );
+    assert_eq!(
+        std::fs::read_to_string(high.join("skillfs-views.toml")).unwrap(),
+        views
+    );
+    let discovery = std::fs::read_to_string(mount.join("skills/skill-discover/SKILL.md")).unwrap();
+    assert!(discovery.contains(&mount.join("skills/reserve").display().to_string()));
+    for result in [
+        std::fs::write(skill.join("resource.txt"), "changed"),
+        std::fs::remove_file(skill.join("resource.txt")),
+        std::fs::create_dir(mount.join("skills/new")),
+        std::fs::rename(skill.join("resource.txt"), skill.join("renamed")),
+    ] {
+        assert_eq!(result.unwrap_err().raw_os_error(), Some(libc::EROFS));
+    }
+    assert_eq!(
+        std::fs::read_to_string(high.join("demo/resource.txt")).unwrap(),
+        "winner"
+    );
+    drop(child);
+    assert!(!is_mounted(&mount));
+}

--- a/src/skillfs/crates/skillfs-cli/tests/sls_ops_cli_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/sls_ops_cli_tests.rs
@@ -509,3 +509,22 @@ fn mount_writes_one_record_when_merged_output_closes_early() {
     assert_eq!(records[0]["ops_name"], "mount");
     assert_eq!(records[0]["err_reason"], "panic");
 }
+
+#[test]
+fn mount_file_validation_logs_actual_error_once() {
+    if skip_if_telemetry_disabled() {
+        return;
+    }
+    let temp = tempfile::tempdir().unwrap();
+    let config = temp.path().join("mount.toml");
+    std::fs::write(&config, "mountpoint = '/mnt/skillfs'\nsources = []\n").unwrap();
+    let log = make_ops_log(temp.path());
+    let output = run_skillfs(&["mount", "--config", config.to_str().unwrap()], &log);
+    assert!(!output.status.success());
+    let records = read_records(&log);
+    assert_eq!(records.len(), 1);
+    assert_eq!(
+        records[0]["err_reason"],
+        "mount config sources must not be empty"
+    );
+}

--- a/src/skillfs/crates/skillfs-core/src/views.rs
+++ b/src/skillfs/crates/skillfs-core/src/views.rs
@@ -94,6 +94,24 @@ impl ViewsConfig {
             .unwrap_or_default()
     }
 
+    /// Return existing default-view skills plus skills not assigned to any view.
+    ///
+    /// Resolve automatic membership in memory so read-only mounts need not
+    /// rewrite the source configuration. Explicit secondary assignments remain
+    /// excluded, including when the file has no default view.
+    pub fn effective_default_skills(&self, store: &crate::store::SkillStore) -> Vec<String> {
+        let (mut primary, _) = store.split_primary(Some(&self.default_skills()));
+        let assigned = self.all_assigned_skills();
+        primary.extend(
+            store
+                .list()
+                .into_iter()
+                .filter(|name| !assigned.contains(*name))
+                .map(str::to_string),
+        );
+        primary
+    }
+
     /// Return all skill names assigned to any view.
     pub fn all_assigned_skills(&self) -> HashSet<String> {
         self.views
@@ -217,6 +235,23 @@ mod tests {
 
         let loaded = ViewsConfig::load(dir.path()).unwrap();
         assert!(loaded.default_skills().contains(&"new-skill".to_string()));
+    }
+
+    #[test]
+    fn effective_default_includes_unassigned_without_changing_views() {
+        let mut cfg = make_config();
+        let original = cfg.default_skills();
+        let mut store = crate::store::SkillStore::new();
+        for name in ["github", "apple-notes", "new-skill"] {
+            store.upsert(crate::parser::parse_skill_md("# Fixture", name));
+        }
+        assert_eq!(
+            cfg.effective_default_skills(&store),
+            vec!["github", "new-skill"]
+        );
+        assert_eq!(cfg.default_skills(), original);
+        cfg.views[0].default = false;
+        assert_eq!(cfg.effective_default_skills(&store), vec!["new-skill"]);
     }
 
     #[test]

--- a/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
@@ -138,14 +138,11 @@ impl SkillFs {
 
     /// Return the list of skill names to show in /skills (default view).
     ///
-    /// If views config is present, returns the default view's skills
-    /// (filtered to those actually in the store). Otherwise returns all skills.
+    /// Include unassigned skills without persisting view changes; explicit
+    /// secondary assignments stay hidden. Without a config, return all skills.
     pub(super) fn primary_skill_names(&self) -> Vec<String> {
         if let Some(cfg) = &self.views_config {
-            let primary = cfg.default_skills();
-            let store = self.store.read();
-            let (primary, _) = store.split_primary(Some(&primary));
-            primary
+            cfg.effective_default_skills(&self.store.read())
         } else {
             let store = self.store.read();
             store.list().iter().map(|s| s.to_string()).collect()


### PR DESCRIPTION
## Why

SkillFS currently requires users to combine skill directories themselves before
mounting one source. OpenClaw installations commonly have several sources.

## What changed

Add `skillfs mount --config mount.toml` with an absolute `mountpoint` and an
ordered `sources` array. Reuse the existing store and physical read paths:
earlier sources win whole skill directories and multiple distinct sources
use the existing read-only mount support. Canonical roots are deduplicated,
overlapping source/mount paths and incompatible options are rejected, and
combined skill limits and load failures are enforced.

Only the first source's views configuration is used; read-only config mounts
do not rewrite it. Unassigned skills join the effective default view in memory,
while explicit secondary assignments remain hidden. Visibility statistics reuse
the same effective membership. Discovery advertises mounted paths. Existing positional
single-source mounts and legacy security configuration remain supported.

## Related issue

closes #1260

## User / Agent impact

```toml
mountpoint = "/mnt/skillfs"
sources = ["/path/to/workspace/skills", "/path/to/managed/skills"]
```

Run `skillfs mount --config /path/to/skillfs-mount.toml`.
No manual copying or symlink aggregation is required.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Migration or rollback guidance is needed

The new config schema is separate from legacy security configuration and
cannot be combined with positional paths or security/activation/installer,
layout, or managed-mode flags. Multi-source mounts are read-only; source
updates and precedence changes require remounting. Existing directory-name
identity and scan depth remain unchanged. OpenClaw users must verify that
loaded paths use the mount; adding an extra directory alone does not replace
higher-priority native sources or provide security enforcement on source paths.

## Validation

Linux aarch64, Rust 1.86.0:

- `cargo +1.86.0 fmt --all -- --check` — passed.
- `cargo +1.86.0 clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo +1.86.0 test --workspace` — 1606 passed, 0 failed, 7 existing ignored
  tests (6 watcher timing cases and 1 privileged bind-mount case).
- `cargo +1.86.0 doc --workspace --no-deps` — completed; existing rustdoc
  warnings in unchanged files remain.
- `RUSTUP_TOOLCHAIN=1.86.0 scripts/test.sh` — passed, including managed mount
  recovery and cleanup.
- New coverage exercises canonical deduplication/overlap, config validation,
  incompatible flags, whole-skill precedence, total limits, invalid manifests,
  real FUSE resource reads and EROFS mutations, primary views preservation,
  mounted discovery paths, unassigned skill visibility without source writes,
  preserved secondary grouping, and one accurate ops record on configuration errors.

## Documentation and rollback

Updated English and Chinese component README summaries and user-guide references.
Unmount using `fusermount3 -u /mnt/skillfs` and return to the existing positional
single-source command to disable the new mode; no source migration is required.

