### PR TITLE
feat(tokenless): bundle native qoder plugin

### DIFF
--- a/.github/workflows/tokenless-prebuilt-ci.yaml
+++ b/.github/workflows/tokenless-prebuilt-ci.yaml
@@ -60,3 +60,6 @@ jobs:
 
       - name: Run Tokenless raw package tests
         run: src/tokenless/tests/test-package-raw.sh
+
+      - name: Run standalone Qoder bundle tests
+        run: python3 src/tokenless/tests/test_qoder_bundle.py

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -81,3 +81,5 @@ anolisa adapter scan
 - [anolisa CLI reference](user-guide/en/user-entrypoint/anolisa-cli.md) — lifecycle and adapter commands
 - [Troubleshooting](user-guide/en/troubleshooting.md) — common installation and runtime failures
 - [Build from source](BUILDING.md) — developer builds only
+
+Qoder plugin publishers can also use the [standalone bundle builder](../src/tokenless/packaging/qoder/README.md); read its runtime requirements and recovery limitations before distribution.

--- a/docs/QUICKSTART_zh.md
+++ b/docs/QUICKSTART_zh.md
@@ -79,3 +79,5 @@ anolisa adapter scan
 - [anolisa CLI 参考](user-guide/zh/user-entrypoint/anolisa-cli.md)——生命周期与 Adapter 命令
 - [故障排查](user-guide/zh/troubleshooting.md)——常见安装和运行问题
 - [从源码构建](BUILDING_zh.md)——仅面向开发者构建
+
+Qoder 插件发布方也可使用[独立插件打包器](../src/tokenless/packaging/qoder/README_zh.md)，分发前请阅读运行依赖和原文恢复限制。

--- a/docs/user-guide/en/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/en/token-saving/tokenless/framework-integration.md
@@ -377,3 +377,9 @@ Then execute a tool task with visible output in the target agent. If `stats list
 - [Measuring savings](measuring-savings.md)
 - [Configuration and data privacy](configuration-and-privacy.md)
 - [Troubleshooting](troubleshooting.md)
+
+## Standalone Qoder bundles
+
+For publisher-built bundles, see [packaging and limitations](../../../../../src/tokenless/packaging/qoder/README.md).
+Bash and Python 3.10+ are required; shell-recovery-dependent Marker compression is disabled.
+Use Qoder native plugin disable/uninstall for rollback; avoid enabling duplicate copies.

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -377,3 +377,9 @@ tokenless stats list --limit 5
 - [效果度量](measuring-savings.md)
 - [配置与数据隐私](configuration-and-privacy.md)
 - [故障排查](troubleshooting.md)
+
+## Qoder 独立插件包
+
+发布方构建的独立插件参见[打包方法和限制](../../../../../src/tokenless/packaging/qoder/README_zh.md)。
+运行需要 Bash 和 Python 3.10+；关闭依赖 Shell 原文恢复的 Marker 压缩。
+通过 Qoder 原生插件管理器禁用或卸载即可回退，请避免同时启用多个副本。

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -289,6 +289,7 @@ test-adapters: build-openclaw-plugin build-dsh-plugin
 	bash tests/test-dsh-adapter.sh
 	@echo "==> Testing qoder adapter installer..."
 	bash tests/test-qoder-adapter-install.sh
+	python3 tests/test_qoder_bundle.py
 	@echo "==> Testing OpenCode adapter..."
 	bash tests/test-opencode-adapter-install.sh
 	node tests/test-opencode-plugin.mjs

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -993,3 +993,9 @@ layout and single-target interface.
 ## License
 
 Apache License 2.0 — see [LICENSE](LICENSE).
+
+### Standalone Qoder distribution
+
+Publishers can assemble a plugin containing native binaries and shared hooks with
+the [Qoder packaging entry point](packaging/qoder/README.md). It requires Python
+3.10+ and disables shell-recovery-dependent Marker compression in standalone mode.

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -581,3 +581,8 @@ tokenless env-check --tool Shell --fix
 ## 许可证
 
 Apache License 2.0 — 详见 [LICENSE](../../LICENSE)。
+
+### Qoder 独立插件分发
+
+发布方可通过 [Qoder 打包入口](packaging/qoder/README_zh.md)组装包含二进制和共享
+Hooks 的插件。运行需要 Python 3.10+；独立模式关闭依赖 Shell 原文恢复的 Marker 压缩。

--- a/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
@@ -210,7 +210,10 @@ _TOKENLESS_RETRIEVE_COMMAND_RE = re.compile(
 
 def tokenless_retrieve_command_available() -> bool:
     """Return whether a Marker command can invoke bare ``tokenless``."""
-    return shutil.which("tokenless") is not None
+    return (
+        os.environ.get("TOKENLESS_DISABLE_SHELL_RECOVERY") != "1"
+        and shutil.which("tokenless") is not None
+    )
 
 
 def is_tokenless_retrieve_command(tool_name: str, arguments: object) -> bool:

--- a/src/tokenless/adapters/tokenless/qoder/hooks/run-hook.sh
+++ b/src/tokenless/adapters/tokenless/qoder/hooks/run-hook.sh
@@ -20,6 +20,32 @@ case "$SCRIPT" in
     *) fail_open ;;
 esac
 
+# Standalone bundles own their dependencies and must not fall back to another
+# installed version when an asset is missing.
+if [ -d "${SCRIPT_DIR}/../bin" ]; then
+    PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
+    if ! bash "${PLUGIN_ROOT}/bin/tokenless" --check >/dev/null; then
+        fail_open
+    fi
+    if ! python3 -c 'import sys; sys.exit(sys.version_info < (3, 10))' 2>/dev/null; then
+        echo "[tokenless] Python 3.10+ is required; hook disabled." >&2
+        fail_open
+    fi
+    export PATH="${PLUGIN_ROOT}/bin:${PATH}"
+    # A hook-local PATH does not make the bare recovery command available
+    # inside the agent's shell. Never advertise an unusable recovery path.
+    export TOKENLESS_DISABLE_SHELL_RECOVERY=1
+    candidate="${PLUGIN_ROOT}/common/hooks/${SCRIPT}"
+    if [ ! -f "$candidate" ]; then
+        echo "[tokenless] Missing bundled hook: ${SCRIPT}" >&2
+        fail_open
+    fi
+    case "$candidate" in
+        *.py) exec python3 "$candidate" "$@" ;;
+        *.sh) exec bash "$candidate" "$@" ;;
+    esac
+fi
+
 CANDIDATES=(
     "${SCRIPT_DIR}/../../common/hooks/${SCRIPT}"
     "/usr/local/share/anolisa/adapters/tokenless/common/hooks/${SCRIPT}"

--- a/src/tokenless/packaging/qoder/README.md
+++ b/src/tokenless/packaging/qoder/README.md
@@ -1,0 +1,58 @@
+# Standalone Qoder plugin packaging
+
+[中文版](README_zh.md)
+
+Build a Qoder plugin that carries its own Tokenless runtime and shared hooks.
+This developer packaging entry point does not install software or publish a package.
+Normal component installation remains `anolisa install tokenless` followed by
+`anolisa adapter enable tokenless qoder`.
+
+## Build
+
+Use trusted, checksum-verified prebuilt binaries from the same Tokenless release
+as the source checkout. Each selected directory contains `tokenless`, `rtk`, and
+`version.txt` (the Tokenless release version). Binary architecture is checked;
+`version.txt` is caller-supplied provenance, not proof of binary identity.
+The publisher must pin source commits and archive checksums. Do not build on macOS.
+
+```text
+prebuilt/
+  linux-x64/{tokenless,rtk,version.txt}
+  linux-arm64/{tokenless,rtk,version.txt}
+  darwin-arm64/{tokenless,rtk,version.txt}
+```
+
+```bash
+python3 packaging/qoder/package.py --prebuilt-root /path/to/prebuilt \
+  --target linux-x64 --target linux-arm64 --target darwin-arm64 \
+  --output /path/to/new-plugin-directory
+qodercli plugins validate /path/to/new-plugin-directory
+qodercli plugins install /path/to/new-plugin-directory --scope user
+```
+
+The output must not exist. Select only platforms for which verified binaries are
+available. `darwin-x64` is accepted for separately built assets; this does not
+imply a published Intel Mac release. Output includes a stamped native manifest,
+shared hooks, native binaries, a platform launcher, licenses and SHA-256 inventory.
+No npm install lifecycle script or model-invoked Skill is required.
+
+## Runtime and limitations
+
+Restart Qoder CLI or run `/plugins reload` after installation. Bash and Python
+3.10+ are required. Missing dependencies emit a diagnostic to stderr and pass
+through the original tool result. The plugin never downloads code on tool calls
+or changes the user's shell configuration. It uses its own binary version even
+when another Tokenless is on PATH. The legacy Tool Ready hook remains disabled.
+
+The standalone bundle sets `TOKENLESS_DISABLE_SHELL_RECOVERY=1` only for its
+hooks. Its private PATH is not inherited by Qoder's shell, so Marker-based
+compression requiring `tokenless retrieve` is disabled, including table sampling
+that needs recovery. Command rewriting and compression that does not require
+recovery remain available. Existing ANOLISA-installed adapters retain recovery.
+The standalone bundle omits the global `tokenless-stats` slash command; run
+`/path/to/new-plugin-directory/bin/tokenless stats` explicitly instead.
+
+For rollback, disable or uninstall the plugin with Qoder's native plugin manager.
+Do not enable a standalone copy and an ANOLISA-installed copy simultaneously.
+Validate real model-visible output separately: structural validation and mock
+contract tests alone do not establish end-to-end savings.

--- a/src/tokenless/packaging/qoder/README_zh.md
+++ b/src/tokenless/packaging/qoder/README_zh.md
@@ -1,0 +1,52 @@
+# Qoder 独立插件打包
+
+[English](README.md)
+
+构建包含 Tokenless 运行时和共享 Hooks 的 Qoder 插件。
+这个开发者打包入口不会安装软件或发布插件。普通组件安装仍优先使用
+`anolisa install tokenless`，再执行 `anolisa adapter enable tokenless qoder`。
+
+## 构建
+
+使用与源码版本一致、来源可信且已校验 SHA-256 的预编译发行二进制。
+每个平台目录包含 `tokenless`、`rtk` 和记录 Tokenless 发行版本的 `version.txt`。
+打包器检查二进制架构；`version.txt` 是调用方提供的来源信息，不能证明二进制身份。
+发布方必须锁定源码提交和发行包校验和。不要在 macOS 上编译。
+
+```text
+prebuilt/
+  linux-x64/{tokenless,rtk,version.txt}
+  linux-arm64/{tokenless,rtk,version.txt}
+  darwin-arm64/{tokenless,rtk,version.txt}
+```
+
+```bash
+python3 packaging/qoder/package.py --prebuilt-root /path/to/prebuilt \
+  --target linux-x64 --target linux-arm64 --target darwin-arm64 \
+  --output /path/to/new-plugin-directory
+qodercli plugins validate /path/to/new-plugin-directory
+qodercli plugins install /path/to/new-plugin-directory --scope user
+```
+
+输出目录必须不存在。仅选择已取得可信二进制的平台。可用独立构建的产物选择
+`darwin-x64`，这不代表已有 Intel Mac 正式发行包。产物包含写入版本的原生
+manifest、共享 Hooks、二进制、平台启动器、许可证和 SHA-256 清单。
+不依赖 npm 安装生命周期脚本，也不需要模型调用 Skill。
+
+## 运行与限制
+
+安装后重启 Qoder CLI 或执行 `/plugins reload`。需要 Bash 和 Python 3.10+。
+缺少依赖时向 stderr 输出诊断并保留原始工具结果。插件不会在工具调用期间下载
+代码，也不会修改用户 Shell 配置。即使 PATH 上存在其他 Tokenless，也使用包内
+版本。旧 Tool Ready Hook 保持关闭。
+
+独立包仅为自己的 Hooks 设置 `TOKENLESS_DISABLE_SHELL_RECOVERY=1`。Hook 私有
+PATH 不会传给 Qoder 的 Shell，因此关闭依赖 `tokenless retrieve` 的 Marker
+压缩，包括需要原文恢复的表格采样。命令重写和不依赖恢复的压缩继续可用。
+ANOLISA 安装的现有 adapter 保留原文恢复能力。独立包不包含依赖全局命令的
+`tokenless-stats` 斜杠命令；可直接运行
+`/path/to/new-plugin-directory/bin/tokenless stats`。
+
+回退时使用 Qoder 原生插件管理器禁用或卸载插件。不要同时启用独立包和
+ANOLISA 安装的副本。需要另行验证实际进入模型上下文的输出；结构校验和
+模拟协议测试无法单独证明端到端节省效果。

--- a/src/tokenless/packaging/qoder/package.py
+++ b/src/tokenless/packaging/qoder/package.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Assemble a standalone Qoder plugin from version-matched prebuilt binaries."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+TARGETS = {
+    "linux-x64": ("linux", "x86_64"),
+    "linux-arm64": ("linux", "aarch64"),
+    "darwin-arm64": ("macos", "aarch64"),
+    "darwin-x64": ("macos", "x86_64"),
+}
+
+
+def main() -> None:
+    """Validate all inputs before creating a fresh plugin output directory."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prebuilt-root", type=Path, required=True)
+    parser.add_argument("--target", choices=TARGETS, action="append", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    version = re.search(r'^version = "([^"]+)"', (ROOT / "Cargo.toml").read_text(), re.M)[1]
+    if args.output.exists():
+        parser.error("output already exists; choose a fresh directory")
+    for target in dict.fromkeys(args.target):
+        source = args.prebuilt_root / target
+        if (source / "version.txt").read_text().strip() != version:
+            parser.error(f"{target}/version.txt must match source version {version}")
+        system, arch = TARGETS[target]
+        subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "packaging/raw/verify-binaries.py"),
+                "--os",
+                system,
+                "--arch",
+                arch,
+                str(source / "tokenless"),
+                str(source / "rtk"),
+            ],
+            check=True,
+        )
+    adapter = ROOT / "adapters/tokenless"
+    shutil.copytree(
+        adapter / "qoder", args.output, ignore=shutil.ignore_patterns("*.in", "scripts", "commands")
+    )
+    manifest = (adapter / "qoder/.qoder-plugin/plugin.json.in").read_text()
+    (args.output / ".qoder-plugin/plugin.json").write_text(manifest.replace("@VERSION@", version))
+    shutil.copytree(
+        adapter / "common/hooks",
+        args.output / "common/hooks",
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+    )
+    (args.output / "bin").mkdir()
+    launcher = args.output / "bin/tokenless"
+    shutil.copy2(Path(__file__).with_name("tokenless"), launcher)
+    launcher.chmod(0o755)
+    checksums = {}
+    for target in dict.fromkeys(args.target):
+        for name in ("tokenless", "rtk"):
+            dest = args.output / "native" / target / name
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(args.prebuilt_root / target / name, dest)
+            dest.chmod(0o755)
+            checksums[str(dest.relative_to(args.output))] = hashlib.sha256(
+                dest.read_bytes()
+            ).hexdigest()
+    (args.output / "bundle.json").write_text(
+        json.dumps({"version": version, "sha256": checksums}, indent=2) + "\n"
+    )
+    shutil.copy2(ROOT / "LICENSE", args.output / "LICENSE")
+    shutil.copy2(ROOT.parents[1] / "NOTICE", args.output / "NOTICE")
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tokenless/packaging/qoder/tokenless
+++ b/src/tokenless/packaging/qoder/tokenless
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Dispatch only to the platform binaries shipped in this plugin.
+set -euo pipefail
+ROOT="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64) target=linux-x64 ;;
+    Linux-aarch64|Linux-arm64) target=linux-arm64 ;;
+    Darwin-arm64) target=darwin-arm64 ;;
+    Darwin-x86_64) target=darwin-x64 ;;
+    *) echo "[tokenless] Unsupported platform" >&2; exit 1 ;;
+esac
+for name in tokenless rtk; do
+    if [ ! -x "${ROOT}/native/${target}/${name}" ]; then
+        echo "[tokenless] Missing bundled executable: ${target}/${name}" >&2
+        exit 1
+    fi
+done
+if [ "${1:-}" = "--check" ]; then exit 0; fi
+export PATH="${ROOT}/native/${target}:${PATH}"
+exec "${ROOT}/native/${target}/tokenless" "$@"

--- a/src/tokenless/tests/test_qoder_bundle.py
+++ b/src/tokenless/tests/test_qoder_bundle.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Exercise standalone package validation and detached-cache dispatch."""
+
+import importlib.util
+import json
+import os
+import platform
+import re
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class QoderBundleTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="qoder bundle ")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.prebuilt = self.root / "prebuilt"
+        system = "darwin" if platform.system() == "Darwin" else "linux"
+        arch = "arm64" if platform.machine() in ("arm64", "aarch64") else "x64"
+        self.target = f"{system}-{arch}"
+        self.source = self.prebuilt / self.target
+        self.source.mkdir(parents=True)
+        self.version = re.search(r'^version = "([^"]+)"', (ROOT / "Cargo.toml").read_text(), re.M)[
+            1
+        ]
+        (self.source / "version.txt").write_text(self.version)
+        header = bytearray(64)
+        if system == "darwin":
+            header[:4] = b"\xcf\xfa\xed\xfe"
+            struct.pack_into("<I", header, 4, 0x0100000C if arch == "arm64" else 0x01000007)
+        else:
+            header[:6] = b"\x7fELF\x02\x01"
+            struct.pack_into("<H", header, 18, 183 if arch == "arm64" else 62)
+        for name in ("tokenless", "rtk"):
+            (self.source / name).write_bytes(header)
+        self.output = self.root / "detached cache"
+
+    def package(self):
+        return subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "packaging/qoder/package.py"),
+                "--prebuilt-root",
+                str(self.prebuilt),
+                "--target",
+                self.target,
+                "--output",
+                str(self.output),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_detached_bundle_uses_own_binaries_and_disables_recovery(self):
+        result = self.package()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        native = self.output / "native" / self.target
+        (native / "tokenless").write_text("#!/bin/sh\necho bundled\n")
+        (native / "rtk").write_text("#!/bin/sh\necho rtk\n")
+        hook = self.output / "common/hooks/compress_response_hook.py"
+        hook.write_text(
+            "import json, os, subprocess\n"
+            "print(json.dumps({'binary': subprocess.check_output(['tokenless']).decode().strip(),"
+            "'recovery': os.environ.get('TOKENLESS_DISABLE_SHELL_RECOVERY')}))\n"
+        )
+        env = dict(os.environ, HOME=str(self.root / "empty-home"))
+        result = subprocess.run(
+            ["bash", str(self.output / "hooks/run-hook.sh"), "compress_response_hook.py"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout), {"binary": "bundled", "recovery": "1"})
+        (native / "tokenless").unlink()
+        result = subprocess.run(
+            ["bash", str(self.output / "hooks/run-hook.sh"), "compress_response_hook.py"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.stdout.strip(), "{}")
+        self.assertIn("Missing bundled executable", result.stderr)
+
+    def test_rejects_wrong_version_before_creating_output(self):
+        (self.source / "version.txt").write_text("wrong")
+        self.assertNotEqual(self.package().returncode, 0)
+        self.assertFalse(self.output.exists())
+
+    def test_rejects_wrong_architecture_and_missing_binary(self):
+        (self.source / "rtk").write_bytes(b"not a native binary")
+        self.assertNotEqual(self.package().returncode, 0)
+        self.assertFalse(self.output.exists())
+        (self.source / "rtk").unlink()
+        self.assertNotEqual(self.package().returncode, 0)
+        self.assertFalse(self.output.exists())
+
+    def test_refuses_to_overwrite_existing_output(self):
+        self.output.mkdir()
+        marker = self.output / "keep"
+        marker.write_text("keep")
+        self.assertNotEqual(self.package().returncode, 0)
+        self.assertEqual(marker.read_text(), "keep")
+
+    def test_bundle_does_not_advertise_shell_recovery(self):
+        spec = importlib.util.spec_from_file_location(
+            "bundle_hook_utils", ROOT / "adapters/tokenless/common/hooks/hook_utils.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        with patch.object(module.shutil, "which", return_value="/bin/tokenless"):
+            with patch.dict(os.environ, {"TOKENLESS_DISABLE_SHELL_RECOVERY": "1"}):
+                self.assertFalse(module.tokenless_retrieve_command_available())
+            with patch.dict(os.environ, {"TOKENLESS_DISABLE_SHELL_RECOVERY": "0"}):
+                self.assertTrue(module.tokenless_retrieve_command_available())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Installing the Qoder adapter directory alone loads its hooks but leaves the shared scripts and
native runtime outside the plugin cache. A clean machine can therefore install the plugin
successfully without obtaining compression.

## What changed

Add a standalone bundle builder that packages shared hooks and caller-verified, version-matched
platform binaries. A plugin-local launcher selects the platform and keeps runtime resolution
inside the bundle; existing ANOLISA adapter installations keep their fallback behavior.

Standalone hooks disable shell-dependent Marker recovery because their private PATH is not
inherited by Qoder's shell. Table sampling that requires recovery is consequently bypassed.
The bundle omits the stats slash command that requires a global executable.

## Related issue

no-issue: standalone distribution for the existing native Qoder adapter

## User / Agent impact

Publishers can produce a plugin requiring Bash and Python 3.10+, without npm lifecycle scripts
or an installation Skill. Missing runtime dependencies warn and preserve original tool output.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The builder checks architecture and supplied version metadata, but publishers must independently
verify binary provenance and checksums. Do not enable standalone and ANOLISA copies together.
No Rust implementation changes or version bump.

## Validation

- New standalone bundle tests: 5 passed.
- Qoder adapter lifecycle regression: 17 passed; install-scope regression passed.
- Shared hook contract suite: 17 passed (mock runtime).
- Bash syntax and git diff whitespace checks passed; new Python files formatted with Black.
- Qoder CLI 1.1.3: native validation, installation, enabled hook inventory and uninstallation
  passed in an isolated HOME.
- SHA-256-verified macOS ARM64 Tokenless 0.8.1 binary: real PostTool hooks replaced API records,
  build logs and large JSON; plain text and recovery-dependent table sampling passed through.
- Pending: complete model-session acceptance, Linux runtime checks and marketplace publication.

## Documentation and rollback

Update bilingual packaging instructions, component READMEs, quick starts and framework integration.
Disable or uninstall through Qoder's native plugin manager to roll back. This draft is reviewable;
keep it unmerged until end-to-end acceptance is complete.
