### PR TITLE
feat(skillfs): cache transformed SKILL.md reads

### DIFF
--- a/src/skillfs/crates/skillfs-core/src/transform.rs
+++ b/src/skillfs/crates/skillfs-core/src/transform.rs
@@ -21,6 +21,8 @@
 //! once at mount startup; the per-read hot path does no YAML parsing, OS
 //! detection, subprocess execution, network access, or LLM calls.
 
+use sha2::{Digest, Sha256};
+
 use crate::compiler;
 use crate::env::EnvironmentProfile;
 use crate::os_adapter::OsAdapterStage;
@@ -95,6 +97,7 @@ impl OsAdapterMetadata<'_> {
 pub struct TransformPipeline {
     directive: Option<DirectiveStage>,
     os_adapter: Option<OsAdapterStage>,
+    identity: [u8; 32],
 }
 
 impl TransformPipeline {
@@ -109,10 +112,9 @@ impl TransformPipeline {
     /// With no adapter set, [`Self::run`] is byte-for-byte equivalent to calling
     /// [`compiler::compile`] directly.
     pub fn directive_only(env: EnvironmentProfile) -> Self {
-        Self {
-            directive: Some(DirectiveStage::new(env)),
-            os_adapter: None,
-        }
+        let mut pipeline = Self::empty();
+        pipeline.set_directive(Some(DirectiveStage::new(env)));
+        pipeline
     }
 
     /// Set or clear the directive stage.
@@ -123,6 +125,7 @@ impl TransformPipeline {
     /// a stage can never be present more than once.
     pub fn set_directive(&mut self, stage: Option<DirectiveStage>) {
         self.directive = stage;
+        self.update_identity();
     }
 
     /// Set (or replace) the OS adapter stage. Idempotent — the adapter can never
@@ -130,6 +133,51 @@ impl TransformPipeline {
     /// order.
     pub fn set_os_adapter(&mut self, stage: OsAdapterStage) {
         self.os_adapter = Some(stage);
+        self.update_identity();
+    }
+
+    /// Content-free fingerprint of all enabled stages and their captured inputs.
+    ///
+    /// Recomputed only when configuring stages; environment values are never
+    /// exposed. Empty pipelines share the all-zero identity.
+    pub fn identity(&self) -> [u8; 32] {
+        self.identity
+    }
+
+    fn update_identity(&mut self) {
+        if self.is_empty() {
+            self.identity = [0; 32];
+            return;
+        }
+        let mut digest = Sha256::new();
+        // Length-prefix every field so different partitions cannot collide.
+        let mut field = |value: &str| {
+            digest.update((value.len() as u64).to_le_bytes());
+            digest.update(value.as_bytes());
+        };
+        if let Some(stage) = &self.directive {
+            field("directive");
+            field(stage.env.os.as_str());
+            let mut commands: Vec<_> = stage.env.available_commands.iter().collect();
+            commands.sort();
+            field(&commands.len().to_string());
+            for command in commands {
+                field(command);
+            }
+            let mut vars: Vec<_> = stage.env.env_vars.iter().collect();
+            vars.sort();
+            field(&vars.len().to_string());
+            for (key, value) in vars {
+                field(key);
+                field(value);
+            }
+        }
+        if let Some(stage) = &self.os_adapter {
+            field("os_adapter");
+            field(stage.target().as_str());
+            field(stage.rule_digest());
+        }
+        self.identity = digest.finalize().into();
     }
 
     /// Whether reads bypass all transformation stages.
@@ -196,6 +244,66 @@ mod tests {
     fn apt_adapter() -> OsAdapterStage {
         let yaml = "- ubuntu: \"apt-get install -y \"\n  alinux: \"dnf install -y \"\n  direction: bidirectional\n  auto_apply: always\n";
         OsAdapterStage::from_bytes(yaml.as_bytes(), OsTarget::Alinux, Path::new("t.yaml")).unwrap()
+    }
+
+    #[test]
+    fn identity_covers_environment_and_ordered_stages() {
+        let mut env = plain_env();
+        env.available_commands.extend(["uv".into(), "pip".into()]);
+        env.env_vars
+            .extend([("A".into(), "a".into()), ("B".into(), "b".into())]);
+        let baseline = TransformPipeline::directive_only(env.clone()).identity();
+        let mut reordered = plain_env();
+        reordered
+            .available_commands
+            .extend(["pip".into(), "uv".into()]);
+        reordered
+            .env_vars
+            .extend([("B".into(), "b".into()), ("A".into(), "a".into())]);
+        assert_eq!(
+            baseline,
+            TransformPipeline::directive_only(reordered).identity()
+        );
+        let mut changed = env.clone();
+        changed.os = OsKind::Darwin;
+        assert_ne!(
+            baseline,
+            TransformPipeline::directive_only(changed).identity()
+        );
+        let mut changed = env.clone();
+        changed.available_commands.remove("uv");
+        assert_ne!(
+            baseline,
+            TransformPipeline::directive_only(changed).identity()
+        );
+        let mut changed = env.clone();
+        changed.env_vars.insert("A".into(), "changed".into());
+        assert_ne!(
+            baseline,
+            TransformPipeline::directive_only(changed).identity()
+        );
+        let mut pipeline = TransformPipeline::directive_only(env);
+        pipeline.set_os_adapter(apt_adapter());
+        let combined = pipeline.identity();
+        assert_ne!(baseline, combined);
+        pipeline.set_directive(None);
+        assert_ne!(combined, pipeline.identity());
+        assert_ne!(TransformPipeline::empty().identity(), pipeline.identity());
+        let alinux = pipeline.identity();
+        let rules =
+            b"- ubuntu: apt-get\n  alinux: dnf\n  direction: bidirectional\n  auto_apply: always\n";
+        pipeline.set_os_adapter(
+            OsAdapterStage::from_bytes(rules, OsTarget::Alinux, Path::new("t.yaml")).unwrap(),
+        );
+        assert_ne!(alinux, pipeline.identity(), "rule digest participates");
+        let rules_identity = pipeline.identity();
+        pipeline.set_os_adapter(
+            OsAdapterStage::from_bytes(rules, OsTarget::Ubuntu, Path::new("t.yaml")).unwrap(),
+        );
+        assert_ne!(rules_identity, pipeline.identity(), "target participates");
+        let mut pipeline = TransformPipeline::directive_only(plain_env());
+        pipeline.set_directive(None);
+        assert_eq!(pipeline.identity(), TransformPipeline::empty().identity());
     }
 
     #[test]

--- a/src/skillfs/crates/skillfs-core/src/transform.rs
+++ b/src/skillfs/crates/skillfs-core/src/transform.rs
@@ -132,6 +132,11 @@ impl TransformPipeline {
         self.os_adapter = Some(stage);
     }
 
+    /// Whether reads bypass all transformation stages.
+    pub fn is_empty(&self) -> bool {
+        self.directive.is_none() && self.os_adapter.is_none()
+    }
+
     /// Run every enabled stage in order and return the final Agent-visible
     /// bytes. Returns the input unchanged when no stage is enabled.
     pub fn run(&self, input: &str) -> String {

--- a/src/skillfs/crates/skillfs-fuse/src/fs.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs.rs
@@ -35,6 +35,7 @@ mod events;
 mod paths;
 mod policy;
 mod read_resolution;
+mod transform_cache;
 
 // ---------------------------------------------------------------------------
 // Filesystem Implementation
@@ -59,6 +60,7 @@ pub struct SkillFs {
     /// runs in-memory string work. Environment detection happens only when the
     /// directive stage is enabled.
     transform_pipeline: TransformPipeline,
+    transform_cache: transform_cache::TransformCache,
     /// View configuration loaded from skillfs-views.toml (if present).
     views_config: Option<ViewsConfig>,
     /// Optional reader-visible root for paths emitted by `skill-discover`.
@@ -213,6 +215,7 @@ impl SkillFs {
             handles: HandleManager::new(),
             inodes: InodeManager::new(),
             transform_pipeline,
+            transform_cache: transform_cache::TransformCache::default(),
             views_config,
             skill_discover_root: None,
             source_dirfd,

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
@@ -159,44 +159,13 @@ impl SkillFs {
                     }
                     return;
                 }
-                // D1.1: hidden skills also hide their virtual SKILL.md.
-                // `compiled_skill_md` already returns `None` for
-                // `ReadResolution::Hidden`, but short-circuiting here
-                // keeps the lookup path uniform with the SkillDir branch
-                // and avoids an extra read attempt.
-                if matches!(self.resolve_skill_read(&skill_name), ReadResolution::Hidden) {
-                    reply.error(libc::ENOENT);
-                    return;
-                }
-                match self.compiled_skill_md(&skill_name) {
-                    Some(compiled) => {
+                match self.transformed_skill_attr(&skill_name, None) {
+                    Some(mut attr) => {
                         let ino = self
                             .inodes
                             .allocate(&path_str, FileType::RegularFile, parent);
-                        // Fetch metadata via fd-safe path to avoid FUSE re-entry.
-                        // For snapshots the size projection is read from the
-                        // snapshot SKILL.md so attr.size matches the compiled
-                        // payload the kernel will see on the next `read`.
-                        let mut attr = if skill_name == "skill-discover" {
-                            self.virtual_file_attr(compiled.len() as u64)
-                        } else {
-                            let md_phys = self
-                                .skill_read_dir(&skill_name)
-                                .map(|d| d.join("SKILL.md"))
-                                .unwrap_or_else(|| {
-                                    self.source_base().join(&skill_name).join("SKILL.md")
-                                });
-                            match std::fs::metadata(&md_phys) {
-                                Ok(meta) => {
-                                    let mut a = file_attr_from_metadata(&meta);
-                                    a.size = compiled.len() as u64;
-                                    a
-                                }
-                                Err(_) => self.virtual_file_attr(compiled.len() as u64),
-                            }
-                        };
-                        attr.ino = ino;
                         self.inodes.remember(ino);
+                        attr.ino = ino;
                         reply.entry(&Duration::from_secs(1), &attr, 0);
                     }
                     None => reply.error(libc::ENOENT),
@@ -472,39 +441,12 @@ impl SkillFs {
                     }
                     return;
                 }
-                if matches!(
-                    self.resolve_hermes_nested_read(category, skill_name),
-                    crate::fs::read_resolution::ReadResolution::Hidden
-                ) {
-                    reply.error(libc::ENOENT);
-                    return;
-                }
-                // Size must match the compiled payload the kernel will see
-                // on `read`; take mtime/type from the physical SKILL.md but
-                // project the compiled length over the raw size.
-                match self.compiled_hermes_nested_skill_md(category, skill_name) {
-                    Some(compiled) => {
-                        let md_phys = self
-                            .hermes_nested_skill_read_dir(category, skill_name)
-                            .map(|d| d.join("SKILL.md"))
-                            .unwrap_or_else(|| {
-                                self.source_base()
-                                    .join(category)
-                                    .join(skill_name)
-                                    .join("SKILL.md")
-                            });
+                match self.transformed_skill_attr(skill_name, Some(category)) {
+                    Some(mut attr) => {
                         let ino = self
                             .inodes
                             .allocate(&path_str, FileType::RegularFile, parent);
                         self.inodes.remember(ino);
-                        let mut attr = match std::fs::metadata(&md_phys) {
-                            Ok(meta) => {
-                                let mut a = file_attr_from_metadata(&meta);
-                                a.size = compiled.len() as u64;
-                                a
-                            }
-                            Err(_) => self.virtual_file_attr(compiled.len() as u64),
-                        };
                         attr.ino = ino;
                         reply.entry(&Duration::from_secs(1), &attr, 0);
                     }
@@ -678,34 +620,9 @@ impl SkillFs {
                     }
                     return;
                 }
-                if matches!(self.resolve_skill_read(&skill_name), ReadResolution::Hidden) {
-                    reply.error(libc::ENOENT);
-                    return;
-                }
-                match self.compiled_skill_md(&skill_name) {
-                    Some(compiled) => {
-                        // Use fd-safe path to avoid FUSE re-entry in in-place mode.
-                        // Snapshot mode reads metadata from the snapshot's
-                        // SKILL.md so attr.size is consistent with the
-                        // compiled payload the kernel will see on `read`.
-                        let attr = if skill_name == "skill-discover" {
-                            self.virtual_file_attr(compiled.len() as u64)
-                        } else {
-                            let md_phys = self
-                                .skill_read_dir(&skill_name)
-                                .map(|d| d.join("SKILL.md"))
-                                .unwrap_or_else(|| {
-                                    self.source_base().join(&skill_name).join("SKILL.md")
-                                });
-                            match std::fs::metadata(&md_phys) {
-                                Ok(meta) => {
-                                    let mut a = file_attr_from_metadata(&meta);
-                                    a.size = compiled.len() as u64;
-                                    a
-                                }
-                                Err(_) => self.virtual_file_attr(compiled.len() as u64),
-                            }
-                        };
+                match self.transformed_skill_attr(&skill_name, None) {
+                    Some(mut attr) => {
+                        attr.ino = ino;
                         reply.attr(&Duration::from_secs(1), &attr);
                     }
                     None => reply.error(libc::ENOENT),
@@ -932,32 +849,8 @@ impl SkillFs {
                     }
                     return;
                 }
-                if matches!(
-                    self.resolve_hermes_nested_read(category, skill_name),
-                    crate::fs::read_resolution::ReadResolution::Hidden
-                ) {
-                    reply.error(libc::ENOENT);
-                    return;
-                }
-                match self.compiled_hermes_nested_skill_md(category, skill_name) {
-                    Some(compiled) => {
-                        let md_phys = self
-                            .hermes_nested_skill_read_dir(category, skill_name)
-                            .map(|d| d.join("SKILL.md"))
-                            .unwrap_or_else(|| {
-                                self.source_base()
-                                    .join(category)
-                                    .join(skill_name)
-                                    .join("SKILL.md")
-                            });
-                        let mut attr = match std::fs::metadata(&md_phys) {
-                            Ok(meta) => {
-                                let mut a = file_attr_from_metadata(&meta);
-                                a.size = compiled.len() as u64;
-                                a
-                            }
-                            Err(_) => self.virtual_file_attr(compiled.len() as u64),
-                        };
+                match self.transformed_skill_attr(skill_name, Some(category)) {
+                    Some(mut attr) => {
                         attr.ino = ino;
                         reply.attr(&Duration::from_secs(1), &attr);
                     }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mod.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mod.rs
@@ -1,7 +1,7 @@
 //! FUSE callback bodies, grouped by semantic operation.
 //!
 //! Per the refactor contract, `impl Filesystem for SkillFs` itself stays
-//! in `fs/mod.rs` as a single block — Rust does not allow splitting a
+//! in `fs.rs` as a single block — Rust does not allow splitting a
 //! trait impl across files. Each trait method there is a thin wrapper
 //! that delegates to a `pub(in crate::fs) fn <name>_impl` inherent method
 //! defined in one of the files in this directory.

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
@@ -3,6 +3,7 @@
 use std::os::unix::fs::FileExt;
 use std::path::Path;
 
+use fuser::consts::FOPEN_DIRECT_IO;
 use fuser::{FUSE_ROOT_ID, ReplyData, ReplyEmpty, ReplyOpen, Request};
 use tracing::{debug, warn};
 
@@ -27,6 +28,22 @@ impl SkillFs {
         reply: ReplyData,
     ) {
         debug!(ino, offset, size, "read");
+
+        if offset < 0 {
+            reply.error(libc::EINVAL);
+            return;
+        }
+        // Captured reads must survive source and namespace changes after open.
+        if let Some(content) = self
+            .handles
+            .with_handle(fh, |entry| entry.transformed.clone())
+            .flatten()
+        {
+            let start = (offset as usize).min(content.len());
+            let end = start.saturating_add(size as usize).min(content.len());
+            reply.data(&content.as_bytes()[start..end]);
+            return;
+        }
 
         let path = match self.inodes.get_path(ino) {
             Some(p) => p,
@@ -511,6 +528,9 @@ impl SkillFs {
                             if policy_decided {
                                 self.metric_policy_fallback();
                             }
+                            if matches!(&path_type, PathType::SkillMd { .. }) {
+                                physical = dir.join("SKILL.md");
+                            }
                             if let PathType::Passthrough { relative_path, .. } = &path_type {
                                 // I4: grace bypass — if the path matches the
                                 // post-publish whitelist, open from physical
@@ -652,6 +672,69 @@ impl SkillFs {
                 reply.error(libc::EROFS);
                 return;
             }
+        }
+
+        let transformed_skill = match &path_type {
+            PathType::SkillMd { skill_name } => Some(skill_name.clone()),
+            PathType::NestedSkillMd {
+                category,
+                skill_name,
+            } => Some(Self::hermes_skill_id(category, skill_name)),
+            _ => None,
+        };
+        if let Some(skill_name) = transformed_skill.filter(|name| {
+            !is_mutating_open
+                && !self.transform_pipeline.is_empty()
+                && !self.is_staging_skill_root(name)
+                && !self.is_pending_install(name)
+        }) {
+            let content =
+                match self.capture_transformed(&skill_name, &physical, pinned_target.as_ref()) {
+                    Ok(content) => content,
+                    Err(error) => {
+                        let err = errno(&error);
+                        self.emit_op_event(
+                            req,
+                            &path_type,
+                            SkillEventKind::Open,
+                            SkillEventAction::Failed,
+                            Some(err),
+                            None,
+                        );
+                        reply.error(err);
+                        return;
+                    }
+                };
+            let fh = match self
+                .handles
+                .allocate_captured(ino, flags, pinned_target, content)
+            {
+                Ok(fh) => fh,
+                Err(err) => {
+                    self.emit_op_event(
+                        req,
+                        &path_type,
+                        SkillEventKind::Open,
+                        SkillEventAction::Failed,
+                        Some(err),
+                        None,
+                    );
+                    reply.error(err);
+                    return;
+                }
+            };
+            self.emit_op_event_with_detail(
+                req,
+                &path_type,
+                SkillEventKind::Open,
+                SkillEventAction::Allowed,
+                None,
+                None,
+                self.os_adapter_open_detail(),
+            );
+            // An inode's page cache cannot represent different per-open versions.
+            reply.opened(fh, FOPEN_DIRECT_IO);
+            return;
         }
 
         // SKILL.md: virtual read, physical write

--- a/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
@@ -41,12 +41,75 @@ pub(super) enum ReadResolution {
 impl SkillFs {
     pub(super) fn capture_transformed(
         &self,
-        _skill_name: &str,
+        skill_name: &str,
         physical: &Path,
-        _target: Option<&ActiveTarget>,
+        target: Option<&ActiveTarget>,
     ) -> std::io::Result<Arc<str>> {
-        let raw = std::fs::read_to_string(physical)?;
-        Ok(self.transform_pipeline.run(&raw).into())
+        self.load_transformed(skill_name, physical, target)
+            .map(|(content, _)| content)
+    }
+
+    fn load_transformed(
+        &self,
+        skill_name: &str,
+        physical: &Path,
+        target: Option<&ActiveTarget>,
+    ) -> std::io::Result<(Arc<str>, std::fs::Metadata)> {
+        if self.transform_pipeline.is_empty() {
+            use std::io::Read;
+            let mut file = std::fs::File::open(physical)?;
+            let metadata = file.metadata()?;
+            let mut raw = String::new();
+            file.read_to_string(&mut raw)?;
+            return Ok((raw.into(), metadata));
+        }
+        self.transform_cache.load(
+            skill_name,
+            physical,
+            target,
+            self.transform_pipeline.identity(),
+            |raw| self.transform_pipeline.run(raw),
+        )
+    }
+
+    // Select activation once for both the transformed size and physical attrs.
+    pub(super) fn transformed_skill_attr(
+        &self,
+        skill_name: &str,
+        category: Option<&str>,
+    ) -> Option<fuser::FileAttr> {
+        if category.is_none() && skill_name == "skill-discover" {
+            return Some(self.virtual_file_attr(self.get_skill_discover_content().len() as u64));
+        }
+        let (id, target, resolution) = match category {
+            Some(category) => {
+                let (target, resolution) =
+                    self.resolve_hermes_nested_read_pinned(category, skill_name);
+                (
+                    Self::hermes_skill_id(category, skill_name),
+                    target,
+                    resolution,
+                )
+            }
+            None => {
+                let (target, resolution) = self.resolve_skill_read_pinned(skill_name);
+                (skill_name.to_owned(), target, resolution)
+            }
+        };
+        let physical = match resolution {
+            ReadResolution::Hidden => return None,
+            ReadResolution::Snapshot { dir, .. } => dir.join("SKILL.md"),
+            ReadResolution::Source if category.is_some() || self.in_place => {
+                self.source_base().join(&id).join("SKILL.md")
+            }
+            ReadResolution::Source => self.skill_source_path(&id)?,
+        };
+        let (content, metadata) = self
+            .load_transformed(&id, &physical, target.as_ref())
+            .ok()?;
+        let mut attr = crate::attr::file_attr_from_metadata(&metadata);
+        attr.size = content.len() as u64;
+        Some(attr)
     }
 
     /// Read and compile a skill's SKILL.md content.
@@ -285,25 +348,6 @@ impl SkillFs {
         (target, resolution)
     }
 
-    /// Compiled SKILL.md for a Hermes nested skill.
-    pub(super) fn compiled_hermes_nested_skill_md(
-        &self,
-        category: &str,
-        skill_name: &str,
-    ) -> Option<String> {
-        let physical_path = match self.resolve_hermes_nested_read(category, skill_name) {
-            ReadResolution::Hidden => return None,
-            ReadResolution::Source => self
-                .source_base()
-                .join(category)
-                .join(skill_name)
-                .join("SKILL.md"),
-            ReadResolution::Snapshot { dir, .. } => dir.join("SKILL.md"),
-        };
-        let raw = std::fs::read_to_string(&physical_path).ok()?;
-        Some(self.transform_pipeline.run(&raw))
-    }
-
     /// Compiled nested `SKILL.md` honoring a pinned activation target.
     ///
     /// Mirrors [`Self::compiled_skill_md_pinned`] for the Hermes layout: when a
@@ -365,6 +409,50 @@ mod tests {
     use std::io::Read;
     use std::sync::Arc;
     use std::time::Duration;
+
+    #[test]
+    fn attrs_and_opens_share_results_but_mutable_reads_and_raw_do_not() {
+        for nested in [false, true] {
+            let tmp = tempfile::tempdir().unwrap();
+            let id = if nested { "cloud/web" } else { "web" };
+            let physical = tmp.path().join(id).join("SKILL.md");
+            std::fs::create_dir_all(physical.parent().unwrap()).unwrap();
+            std::fs::write(
+                &physical,
+                "<!-- @if os == plan9 -->\nhidden\n<!-- @endif -->\nvisible\n",
+            )
+            .unwrap();
+            let mut store = SkillStore::new();
+            store.load_from_directory(tmp.path(), &ParseConfig::default());
+            let mut fs = SkillFs::new(
+                tmp.path().into(),
+                tmp.path().into(),
+                Arc::new(RwLock::new(store)),
+                false,
+            );
+            let category = nested.then_some("cloud");
+            let attr = fs.transformed_skill_attr("web", category).unwrap();
+            assert_eq!(fs.transform_cache.events(), [0, 1, 0, 0]);
+            let content = fs.capture_transformed(id, &physical, None).unwrap();
+            assert_eq!(content.len() as u64, attr.size);
+            let again = fs.capture_transformed(id, &physical, None).unwrap();
+            assert!(Arc::ptr_eq(&content, &again));
+            assert_eq!(fs.transform_cache.events(), [2, 1, 0, 0]);
+            // These are the existing read helpers used by mutable handles.
+            let mutable = if nested {
+                fs.compiled_hermes_nested_skill_md_pinned("cloud", "web", None)
+            } else {
+                fs.compiled_skill_md_pinned("web", None)
+            }
+            .unwrap();
+            assert_eq!(mutable, &*content);
+            assert_eq!(fs.transform_cache.events(), [2, 1, 0, 0]);
+            fs.transform_pipeline.set_directive(None);
+            let raw_attr = fs.transformed_skill_attr("web", category).unwrap();
+            assert_eq!(raw_attr.size, std::fs::metadata(&physical).unwrap().len());
+            assert_eq!(fs.transform_cache.events(), [2, 1, 0, 0]);
+        }
+    }
 
     /// Minimal FUSE-availability probe (mirrors the integration harness) so
     /// mount-based unit tests skip gracefully where `/dev/fuse` is unusable.

--- a/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
@@ -11,6 +11,7 @@
 //! design.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use super::SkillFs;
 use crate::security::ActiveTarget;
@@ -38,6 +39,16 @@ pub(super) enum ReadResolution {
 }
 
 impl SkillFs {
+    pub(super) fn capture_transformed(
+        &self,
+        _skill_name: &str,
+        physical: &Path,
+        _target: Option<&ActiveTarget>,
+    ) -> std::io::Result<Arc<str>> {
+        let raw = std::fs::read_to_string(physical)?;
+        Ok(self.transform_pipeline.run(&raw).into())
+    }
+
     /// Read and compile a skill's SKILL.md content.
     ///
     /// In in-place mode reads via `/proc/self/fd/{n}` to bypass FUSE.

--- a/src/skillfs/crates/skillfs-fuse/src/fs/transform_cache.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/transform_cache.rs
@@ -1,0 +1,413 @@
+//! Mount-local, bounded reuse of exact transformed SKILL.md results.
+
+use std::collections::VecDeque;
+use std::fs::{File, Metadata};
+use std::io::{self, Read};
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use sha2::{Digest, Sha256};
+use tracing::debug;
+
+use crate::security::ActiveTarget;
+
+#[derive(Clone, PartialEq, Eq)]
+struct SourceIdentity {
+    dev: u64,
+    ino: u64,
+    size: u64,
+    mtime: (i64, i64),
+    ctime: (i64, i64),
+}
+
+impl From<&Metadata> for SourceIdentity {
+    fn from(meta: &Metadata) -> Self {
+        Self {
+            dev: meta.dev(),
+            ino: meta.ino(),
+            size: meta.len(),
+            mtime: (meta.mtime(), meta.mtime_nsec()),
+            ctime: (meta.ctime(), meta.ctime_nsec()),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+struct Key {
+    skill: String,
+    path: PathBuf,
+    target: Option<ActiveTarget>,
+    source: SourceIdentity,
+    source_digest: [u8; 32],
+    pipeline: [u8; 32],
+}
+
+struct Entry {
+    key: Key,
+    content: Arc<str>,
+}
+
+#[derive(Default)]
+struct State {
+    entries: VecDeque<Entry>,
+    bytes: usize,
+    #[cfg(test)]
+    events: [usize; 4],
+}
+
+impl State {
+    fn event(&mut self, event: usize) {
+        let name = ["hit", "miss", "invalidation", "eviction"][event];
+        debug!(
+            cache = "transformed_skill_md",
+            event = name,
+            entries = self.entries.len(),
+            bytes = self.bytes
+        );
+        #[cfg(test)]
+        {
+            self.events[event] += 1;
+        }
+    }
+}
+
+pub(super) struct TransformCache {
+    state: Mutex<State>,
+    max_entries: usize,
+    max_bytes: usize,
+}
+
+impl Default for TransformCache {
+    fn default() -> Self {
+        Self::new(128, 8 * 1024 * 1024)
+    }
+}
+
+impl TransformCache {
+    #[cfg(test)]
+    pub(super) fn events(&self) -> [usize; 4] {
+        self.state.lock().events
+    }
+
+    fn new(max_entries: usize, max_bytes: usize) -> Self {
+        Self {
+            state: Mutex::new(State::default()),
+            max_entries,
+            max_bytes,
+        }
+    }
+
+    pub(super) fn load(
+        &self,
+        skill: &str,
+        path: &Path,
+        target: Option<&ActiveTarget>,
+        pipeline: [u8; 32],
+        transform: impl FnOnce(&str) -> String,
+    ) -> io::Result<(Arc<str>, Metadata)> {
+        // Open before checking the key: atomic replacement must select a new inode.
+        let mut file = File::open(path)?;
+        let metadata = file.metadata()?;
+        // Timestamps can collide even at nanosecond API precision. Read and
+        // hash the selected bytes before reuse, rather than trusting stat alone.
+        let mut raw = String::new();
+        file.read_to_string(&mut raw)?;
+        let key = Key {
+            skill: skill.into(),
+            path: path.into(),
+            target: target.cloned(),
+            source: SourceIdentity::from(&metadata),
+            source_digest: Sha256::digest(raw.as_bytes()).into(),
+            pipeline,
+        };
+        {
+            let mut state = self.state.lock();
+            // ponytail: linear lookup is bounded to 128 entries; index if this grows.
+            if let Some(index) = state.entries.iter().position(|entry| entry.key == key) {
+                if let Some(entry) = state.entries.remove(index) {
+                    let content = entry.content.clone();
+                    state.entries.push_back(entry);
+                    state.event(0);
+                    return Ok((content, metadata));
+                }
+            }
+            let before = state.entries.len();
+            state.entries.retain(|entry| {
+                !(entry.key.skill == key.skill
+                    && entry.key.path == key.path
+                    && entry.key.target == key.target)
+            });
+            if state.entries.len() != before {
+                state.bytes = state.entries.iter().map(|entry| entry.content.len()).sum();
+                state.event(2);
+            }
+            state.event(1);
+        }
+        // No cache lock is held across file I/O or transformation.
+        let content: Arc<str> = transform(&raw).into();
+        let unchanged = SourceIdentity::from(&file.metadata()?) == key.source
+            && std::fs::metadata(path).is_ok_and(|meta| SourceIdentity::from(&meta) == key.source);
+        let mut state = self.state.lock();
+        if !unchanged {
+            state.event(2);
+        } else if self.max_entries > 0 && content.len() <= self.max_bytes {
+            // A concurrent miss may already have populated this exact key.
+            if let Some(entry) = state.entries.iter().find(|entry| entry.key == key) {
+                return Ok((entry.content.clone(), metadata));
+            }
+            while state.entries.len() >= self.max_entries
+                || state.bytes > self.max_bytes - content.len()
+            {
+                if let Some(entry) = state.entries.pop_front() {
+                    state.bytes -= entry.content.len();
+                    state.event(3);
+                }
+            }
+            state.bytes += content.len();
+            state.entries.push_back(Entry {
+                key,
+                content: content.clone(),
+            });
+        }
+        Ok((content, metadata))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn exact_reuse_and_every_key_dimension() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("SKILL.md");
+        std::fs::write(&path, "original").unwrap();
+        let cache = TransformCache::default();
+        let calls = Cell::new(0);
+        let run = |raw: &str| {
+            calls.set(calls.get() + 1);
+            raw.to_uppercase()
+        };
+        let original = cache.load("web", &path, None, [1; 32], run).unwrap().0;
+        let again = cache.load("web", &path, None, [1; 32], run).unwrap().0;
+        assert!(Arc::ptr_eq(&original, &again));
+        assert_eq!(calls.get(), 1);
+        cache.load("other", &path, None, [1; 32], run).unwrap();
+        cache.load("web", &path, None, [2; 32], run).unwrap();
+        let current = ActiveTarget::Current {
+            source_dir: tmp.path().into(),
+        };
+        cache
+            .load("web", &path, Some(&current), [1; 32], run)
+            .unwrap();
+        for version in ["v1", "v2"] {
+            let target = ActiveTarget::Snapshot {
+                snapshot_dir: tmp.path().into(),
+                version: version.into(),
+            };
+            cache
+                .load("web", &path, Some(&target), [1; 32], run)
+                .unwrap();
+        }
+        let alias = tmp.path().join("alias");
+        std::fs::hard_link(&path, &alias).unwrap();
+        cache.load("web", &alias, None, [1; 32], run).unwrap();
+        assert_eq!(calls.get(), 7);
+        assert_eq!(&*original, "ORIGINAL");
+        let state = cache.state.lock();
+        assert_eq!(state.events[0], 1);
+        assert_eq!(state.events[1], 7);
+        assert_eq!(state.events[2], 1);
+    }
+
+    #[test]
+    fn content_changes_invalidate_even_when_all_stat_fields_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("SKILL.md");
+        std::fs::write(&path, "old").unwrap();
+        let cache = TransformCache::default();
+        let calls = Cell::new(0);
+        let run = |raw: &str| {
+            calls.set(calls.get() + 1);
+            raw.to_uppercase()
+        };
+        let old = cache.load("web", &path, None, [1; 32], run).unwrap().0;
+        std::fs::write(&path, "new").unwrap();
+        // Model the timestamp collision observed on CI deterministically,
+        // without depending on the host filesystem's timestamp resolution.
+        cache.state.lock().entries[0].key.source =
+            SourceIdentity::from(&std::fs::metadata(&path).unwrap());
+        let new = cache.load("web", &path, None, [1; 32], run).unwrap().0;
+        assert_eq!(&*old, "OLD");
+        assert_eq!(&*new, "NEW");
+        assert_eq!(calls.get(), 2);
+        let again = cache.load("web", &path, None, [1; 32], run).unwrap().0;
+        assert!(Arc::ptr_eq(&new, &again));
+        assert_eq!(calls.get(), 2);
+    }
+
+    #[test]
+    fn source_updates_and_population_races_do_not_publish_stale_keys() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("SKILL.md");
+        std::fs::write(&path, "old").unwrap();
+        let cache = TransformCache::default();
+        let read = || {
+            cache
+                .load("web", &path, None, [1; 32], str::to_owned)
+                .unwrap()
+                .0
+        };
+        let old = read();
+        let mtime = std::fs::metadata(&path).unwrap().modified().unwrap();
+        std::fs::write(&path, "new").unwrap();
+        File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(mtime))
+            .unwrap();
+        assert_eq!(
+            &*read(),
+            "new",
+            "same-size edits with restored mtime must invalidate reuse"
+        );
+        let next = tmp.path().join("next");
+        std::fs::write(&next, "replacement").unwrap();
+        std::fs::rename(&next, &path).unwrap();
+        assert_eq!(&*read(), "replacement");
+        assert_eq!(&*old, "old");
+        for atomic in [false, true] {
+            let raced = TransformCache::default();
+            let captured = raced
+                .load("web", &path, None, [1; 32], |raw| {
+                    if atomic {
+                        std::fs::write(&next, "atomic").unwrap();
+                        std::fs::rename(&next, &path).unwrap();
+                    } else {
+                        std::fs::write(&path, "in-place").unwrap();
+                    }
+                    raw.to_owned()
+                })
+                .unwrap()
+                .0;
+            assert!(raced.state.lock().entries.is_empty());
+            assert_eq!(raced.state.lock().events[2], 1);
+            let fresh = raced
+                .load("web", &path, None, [1; 32], str::to_owned)
+                .unwrap()
+                .0;
+            assert_ne!(captured, fresh);
+        }
+        std::fs::remove_file(&path).unwrap();
+        assert!(
+            cache
+                .load("web", &path, None, [1; 32], str::to_owned)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn lru_limits_oversize_and_handle_lifetime() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("SKILL.md");
+        std::fs::write(&path, "1234").unwrap();
+        for (entries, bytes) in [(2, 100), (10, 8)] {
+            let cache = TransformCache::new(entries, bytes);
+            let get = |id| {
+                cache
+                    .load(id, &path, None, [0; 32], str::to_owned)
+                    .unwrap()
+                    .0
+            };
+            let first = get("a");
+            let weak = Arc::downgrade(&first);
+            get("b");
+            get("a");
+            get("c");
+            let state = cache.state.lock();
+            assert_eq!(
+                state
+                    .entries
+                    .iter()
+                    .map(|e| e.key.skill.as_str())
+                    .collect::<Vec<_>>(),
+                ["a", "c"]
+            );
+            assert_eq!(state.bytes, 8);
+            assert_eq!(state.events[3], 1);
+            drop(state);
+            get("b");
+            get("d");
+            assert_eq!(&*first, "1234", "eviction does not revoke captured handles");
+            drop(first);
+            assert!(weak.upgrade().is_none());
+        }
+        for (entries, bytes) in [(0, 8), (2, 0), (2, 3)] {
+            let cache = TransformCache::new(entries, bytes);
+            let result = cache
+                .load("a", &path, None, [0; 32], str::to_owned)
+                .unwrap()
+                .0;
+            assert_eq!(&*result, "1234");
+            assert!(cache.state.lock().entries.is_empty());
+        }
+        let cache = TransformCache::default();
+        let content = cache
+            .load("a", &path, None, [0; 32], str::to_owned)
+            .unwrap()
+            .0;
+        let weak = Arc::downgrade(&content);
+        drop(content);
+        assert!(weak.upgrade().is_some());
+        drop(cache);
+        assert!(weak.upgrade().is_none(), "unmount drops retained content");
+    }
+
+    #[test]
+    fn concurrent_population_keeps_limits_and_deduplicates() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("SKILL.md");
+        std::fs::write(&path, "1234").unwrap();
+        let cache = TransformCache::new(3, 12);
+        let barrier = std::sync::Barrier::new(8);
+        std::thread::scope(|scope| {
+            let mut workers = Vec::new();
+            for _ in 0..8 {
+                workers.push(scope.spawn(|| {
+                    cache
+                        .load("shared", &path, None, [0; 32], |raw| {
+                            barrier.wait();
+                            raw.to_owned()
+                        })
+                        .unwrap()
+                        .0
+                }));
+            }
+            let results: Vec<_> = workers.into_iter().map(|w| w.join().unwrap()).collect();
+            assert!(results.iter().all(|r| Arc::ptr_eq(r, &results[0])));
+        });
+        std::thread::scope(|scope| {
+            for worker in 0..8 {
+                let cache = &cache;
+                let path = &path;
+                scope.spawn(move || {
+                    for i in 0..20 {
+                        cache
+                            .load(&format!("{worker}/{i}"), path, None, [0; 32], str::to_owned)
+                            .unwrap();
+                        let state = cache.state.lock();
+                        assert!(state.entries.len() <= 3 && state.bytes <= 12);
+                        assert_eq!(
+                            state.bytes,
+                            state.entries.iter().map(|e| e.content.len()).sum::<usize>()
+                        );
+                    }
+                });
+            }
+        });
+    }
+}

--- a/src/skillfs/crates/skillfs-fuse/src/handles.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/handles.rs
@@ -6,6 +6,7 @@
 //! time.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use fuser::FileType;
@@ -20,6 +21,7 @@ pub(crate) struct HandleEntry {
     pub(crate) file: Option<std::fs::File>,
     pub(crate) append_mode: bool,
     pub(crate) pinned_target: Option<ActiveTarget>,
+    pub(crate) transformed: Option<Arc<str>>,
 }
 
 /// Directory handle entry with snapshot of entries at opendir time
@@ -33,9 +35,18 @@ pub(crate) struct DirHandleEntry {
     pub(crate) dir_file: Option<std::fs::File>,
 }
 
+#[derive(Default)]
+struct FileHandles {
+    entries: HashMap<u64, HandleEntry>,
+    captured_bytes: usize,
+    captured_count: usize,
+}
+
 pub(crate) struct HandleManager {
     next_fh: AtomicU64,
-    handles: RwLock<HashMap<u64, HandleEntry>>,
+    handles: RwLock<FileHandles>,
+    max_captured_bytes: usize,
+    max_captured_count: usize,
     dir_handles: RwLock<HashMap<u64, DirHandleEntry>>,
 }
 
@@ -43,7 +54,9 @@ impl HandleManager {
     pub(crate) fn new() -> Self {
         Self {
             next_fh: AtomicU64::new(1),
-            handles: RwLock::new(HashMap::new()),
+            handles: RwLock::new(FileHandles::default()),
+            max_captured_bytes: 64 * 1024 * 1024,
+            max_captured_count: 1024,
             dir_handles: RwLock::new(HashMap::new()),
         }
     }
@@ -57,7 +70,7 @@ impl HandleManager {
     ) -> u64 {
         let fh = self.next_fh.fetch_add(1, Ordering::Relaxed);
         let append_mode = (flags & libc::O_APPEND) != 0;
-        self.handles.write().insert(
+        self.handles.write().entries.insert(
             fh,
             HandleEntry {
                 ino,
@@ -65,9 +78,42 @@ impl HandleManager {
                 file,
                 append_mode,
                 pinned_target,
+                transformed: None,
             },
         );
         fh
+    }
+
+    // Charge each handle even when its Arc is shared with another handle.
+    // This conservative budget needs no allocation-identity side table.
+    pub(crate) fn allocate_captured(
+        &self,
+        ino: u64,
+        flags: i32,
+        pinned_target: Option<ActiveTarget>,
+        content: Arc<str>,
+    ) -> Result<u64, i32> {
+        let mut handles = self.handles.write();
+        if handles.captured_count >= self.max_captured_count
+            || content.len() > self.max_captured_bytes - handles.captured_bytes
+        {
+            return Err(libc::ENOMEM);
+        }
+        let fh = self.next_fh.fetch_add(1, Ordering::Relaxed);
+        handles.captured_bytes += content.len();
+        handles.captured_count += 1;
+        handles.entries.insert(
+            fh,
+            HandleEntry {
+                ino,
+                flags,
+                file: None,
+                append_mode: (flags & libc::O_APPEND) != 0,
+                pinned_target,
+                transformed: Some(content),
+            },
+        );
+        Ok(fh)
     }
 
     /// Allocate a directory handle with a frozen snapshot
@@ -131,7 +177,7 @@ impl HandleManager {
         f: impl FnOnce(&std::fs::File) -> R,
     ) -> Option<R> {
         let handles = self.handles.read();
-        for entry in handles.values() {
+        for entry in handles.entries.values() {
             if entry.ino == ino {
                 if let Some(ref file) = entry.file {
                     return Some(f(file));
@@ -143,7 +189,7 @@ impl HandleManager {
 
     pub(crate) fn with_handle<R>(&self, fh: u64, f: impl FnOnce(&HandleEntry) -> R) -> Option<R> {
         let handles = self.handles.read();
-        handles.get(&fh).map(f)
+        handles.entries.get(&fh).map(f)
     }
 
     pub(crate) fn with_handle_mut<R>(
@@ -152,11 +198,17 @@ impl HandleManager {
         f: impl FnOnce(&mut HandleEntry) -> R,
     ) -> Option<R> {
         let mut handles = self.handles.write();
-        handles.get_mut(&fh).map(f)
+        handles.entries.get_mut(&fh).map(f)
     }
 
     pub(crate) fn remove(&self, fh: u64) -> Option<HandleEntry> {
-        self.handles.write().remove(&fh)
+        let mut handles = self.handles.write();
+        let entry = handles.entries.remove(&fh)?;
+        if let Some(content) = &entry.transformed {
+            handles.captured_bytes -= content.len();
+            handles.captured_count -= 1;
+        }
+        Some(entry)
     }
 }
 
@@ -186,4 +238,92 @@ pub(crate) fn open_options_from_flags(flags: i32) -> std::fs::OpenOptions {
         opts.truncate(true);
     }
     opts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn captured_budget_rejects_excess_and_release_restores_capacity() {
+        let manager = HandleManager {
+            max_captured_bytes: 8,
+            max_captured_count: 2,
+            ..HandleManager::new()
+        };
+        let shared: Arc<str> = "1234".into();
+        let a = manager
+            .allocate_captured(1, libc::O_RDONLY, None, shared.clone())
+            .unwrap();
+        let b = manager
+            .allocate_captured(2, libc::O_RDONLY, None, shared.clone())
+            .unwrap();
+        assert_eq!(
+            manager.allocate_captured(3, libc::O_RDONLY, None, shared.clone()),
+            Err(libc::ENOMEM)
+        );
+        // Raw and writable handles do not consume the captured budget.
+        let raw = manager.allocate(4, libc::O_RDWR, None, None);
+        drop(manager.remove(raw));
+        drop(manager.remove(a));
+        assert!(manager.remove(a).is_none());
+        let c = manager
+            .allocate_captured(3, libc::O_RDONLY, None, shared)
+            .unwrap();
+        drop(manager.remove(b));
+        drop(manager.remove(c));
+        assert_eq!(manager.handles.read().captured_bytes, 0);
+        assert_eq!(manager.handles.read().captured_count, 0);
+        assert_eq!(
+            manager.allocate_captured(1, libc::O_RDONLY, None, "oversized".into()),
+            Err(libc::ENOMEM)
+        );
+        let empty = manager
+            .allocate_captured(1, libc::O_RDONLY, None, "".into())
+            .unwrap();
+        manager
+            .allocate_captured(1, libc::O_RDONLY, None, "".into())
+            .unwrap();
+        assert_eq!(
+            manager.allocate_captured(1, libc::O_RDONLY, None, "".into()),
+            Err(libc::ENOMEM)
+        );
+        drop(manager.remove(empty));
+        manager
+            .allocate_captured(1, libc::O_RDONLY, None, "".into())
+            .unwrap();
+    }
+
+    #[test]
+    fn concurrent_captured_admission_is_bounded() {
+        let manager = HandleManager {
+            max_captured_bytes: 8,
+            max_captured_count: 8,
+            ..HandleManager::new()
+        };
+        let barrier = std::sync::Barrier::new(16);
+        std::thread::scope(|scope| {
+            let mut workers = Vec::new();
+            for ino in 0..16 {
+                workers.push(scope.spawn({
+                    let manager = &manager;
+                    let barrier = &barrier;
+                    move || {
+                        barrier.wait();
+                        manager.allocate_captured(ino, libc::O_RDONLY, None, "1234".into())
+                    }
+                }));
+            }
+            let admitted: Vec<_> = workers
+                .into_iter()
+                .filter_map(|worker| worker.join().unwrap().ok())
+                .collect();
+            assert_eq!(admitted.len(), 2);
+            assert_eq!(manager.handles.read().captured_bytes, 8);
+            for fh in admitted {
+                drop(manager.remove(fh));
+            }
+        });
+        assert_eq!(manager.handles.read().captured_bytes, 0);
+    }
 }

--- a/src/skillfs/crates/skillfs-fuse/tests/os_transform_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/os_transform_tests.rs
@@ -847,3 +847,195 @@ fn hermes_snapshot_to_current_after_open_stays_snapshot() {
         "fresh open should read live: {fresh}"
     );
 }
+
+#[test]
+fn captured_current_survives_edits_and_replacement() {
+    use std::os::unix::fs::FileExt;
+    skip_if_no_fuse!();
+    for layout in [
+        skillfs_fuse::SkillLayout::Flat,
+        skillfs_fuse::SkillLayout::Hermes,
+    ] {
+        let source = tempfile::tempdir().unwrap();
+        let mountpoint = tempfile::tempdir().unwrap();
+        let id = if layout == skillfs_fuse::SkillLayout::Flat {
+            "web"
+        } else {
+            "cloud/web"
+        };
+        let original = UBUNTU_SKILL_MD.repeat(200);
+        seed_skill(source.path(), id, &original);
+        let physical = source.path().join(id).join("SKILL.md");
+        let mut store = SkillStore::new();
+        store.load_from_directory(source.path(), &ParseConfig::default());
+        let (_rules, stage) = stage_for(OsTarget::Alinux);
+        let expected = ALINUX_SKILL_MD.repeat(200);
+        let _mount = mount_background_configured(
+            mountpoint.path(),
+            source.path(),
+            Arc::new(RwLock::new(store)),
+            MountOptions::default(),
+            false,
+            MountConfig {
+                skill_layout: Some(layout),
+                os_adapter: Some(stage),
+                ..MountConfig::default()
+            },
+        )
+        .unwrap();
+        let path = mountpoint.path().join("skills").join(id).join("SKILL.md");
+        let old = std::fs::File::open(&path).unwrap();
+        let mut first = [0; 17];
+        assert_eq!(old.read_at(&mut first, 0).unwrap(), first.len());
+        assert_eq!(&first, &expected.as_bytes()[..17]);
+        // Same-size in-place modification, then shrink, then atomic growth.
+        for (replacement, atomic) in [
+            ("X".repeat(original.len()), false),
+            ("short\n".into(), false),
+            ("long\n".repeat(10000), true),
+        ] {
+            if atomic {
+                let next = physical.with_file_name("next");
+                std::fs::write(&next, &replacement).unwrap();
+                std::fs::rename(next, &physical).unwrap();
+            } else {
+                std::fs::write(&physical, &replacement).unwrap();
+            }
+            assert_eq!(std::fs::read_to_string(&path).unwrap(), replacement);
+            // A fresh open must not overwrite the old handle's cached pages.
+            let mut got = Vec::new();
+            let mut block = [0; 997];
+            for _ in 0..100 {
+                let n = old.read_at(&mut block, got.len() as u64).unwrap();
+                if n == 0 {
+                    break;
+                }
+                got.extend_from_slice(&block[..n]);
+            }
+            assert_eq!(got, expected.as_bytes());
+            assert_eq!(
+                old.read_at(&mut block, expected.len() as u64 + 10).unwrap(),
+                0
+            );
+            assert_eq!(old.read_at(&mut [], 0).unwrap(), 0);
+        }
+    }
+}
+
+#[test]
+fn captured_snapshot_survives_removal_without_live_fallback() {
+    skip_if_no_fuse!();
+    let mount = AdapterMount::new(
+        OsTarget::Alinux,
+        |src| {
+            seed_skill(src, "web", "LIVE\n");
+            seed_skill(src, "web/.skill-meta/versions/v1", UBUNTU_SKILL_MD);
+        },
+        |root| {
+            let resolver = Arc::new(ActiveSkillResolver::new(root.to_path_buf()));
+            resolver.set(
+                "web",
+                ActiveTarget::Snapshot {
+                    snapshot_dir: root.join("web/.skill-meta/versions/v1"),
+                    version: "v1".into(),
+                },
+            );
+            Some(resolver)
+        },
+    );
+    let mut old = std::fs::File::open(mount.skill_md("web")).unwrap();
+    std::fs::remove_file(
+        mount
+            .source
+            .path()
+            .join("web/.skill-meta/versions/v1/SKILL.md"),
+    )
+    .unwrap();
+    assert!(std::fs::File::open(mount.skill_md("web")).is_err());
+    mount.resolver.as_ref().unwrap().set(
+        "web",
+        ActiveTarget::Current {
+            source_dir: mount.source.path().join("web"),
+        },
+    );
+    assert_eq!(
+        std::fs::read_to_string(mount.skill_md("web")).unwrap(),
+        "LIVE\n"
+    );
+    let mut got = String::new();
+    old.read_to_string(&mut got).unwrap();
+    assert_eq!(got, ALINUX_SKILL_MD);
+}
+
+#[test]
+fn repeated_versions_hit_captured_budget_then_recover_after_close() {
+    use std::os::unix::fs::FileExt;
+    skip_if_no_fuse!();
+    // Stay just below the LRU per-entry ceiling, but keep more historical
+    // versions alive than the LRU can retain. Only eight fit the handle budget.
+    let payload_size = 8 * 1024 * 1024 - 64;
+    let fixture = MountFixture::normal(|src| {
+        seed_skill(src, "web", "# Initial\n");
+        seed_skill(src, "other", "# Initial\n");
+    });
+    let physical = fixture.source_skill_path("web").join("SKILL.md");
+    let path = fixture.skill_path("web").join("SKILL.md");
+    std::fs::write(
+        fixture.source_skill_path("other").join("SKILL.md"),
+        "Z".repeat(payload_size),
+    )
+    .unwrap();
+    let mut held = Vec::new();
+    for version in 0..24u8 {
+        let payload = vec![b'A' + version; payload_size];
+        if version % 2 == 0 {
+            std::fs::write(&physical, &payload).unwrap();
+        } else {
+            let next = physical.with_file_name("next");
+            std::fs::write(&next, &payload).unwrap();
+            std::fs::rename(next, &physical).unwrap();
+        }
+        match std::fs::File::open(&path) {
+            Ok(file) => {
+                assert!(version < 8);
+                held.push(file);
+            }
+            Err(error) => {
+                assert!(version >= 8, "version {version}: {error}");
+                assert_eq!(error.raw_os_error(), Some(libc::ENOMEM));
+            }
+        }
+    }
+    assert_eq!(held.len(), 8);
+    assert_eq!(
+        std::fs::File::open(fixture.skill_path("other").join("SKILL.md"))
+            .unwrap_err()
+            .raw_os_error(),
+        Some(libc::ENOMEM)
+    );
+    for (version, file) in held.iter().enumerate() {
+        let mut byte = [0];
+        assert_eq!(
+            file.read_at(&mut byte, (payload_size - 1) as u64).unwrap(),
+            1
+        );
+        assert_eq!(byte[0], b'A' + version as u8);
+    }
+    drop(held.pop());
+    // FUSE release can be asynchronous to close; allow a bounded dispatch delay.
+    let mut reopened = None;
+    for _ in 0..100 {
+        match std::fs::File::open(&path) {
+            Ok(file) => {
+                reopened = Some(file);
+                break;
+            }
+            Err(error) => assert_eq!(error.raw_os_error(), Some(libc::ENOMEM)),
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let file = reopened.expect("closing a captured handle restores admission capacity");
+    let mut byte = [0];
+    assert_eq!(file.read_at(&mut byte, 0).unwrap(), 1);
+    assert_eq!(byte[0], b'X');
+}

--- a/src/skillfs/docs/architecture/fuse-crate-layout.md
+++ b/src/skillfs/docs/architecture/fuse-crate-layout.md
@@ -24,13 +24,14 @@ crates/skillfs-fuse/src/
 ├── security.rs             (pre-existing) Skill Security extension seam (re-exports submodules)
 ├── security/               (pre-existing) policy, event, audit, drift, lifecycle, inbox, ledger, etc.
 │
-└── fs/                     SkillFs struct + helpers + the single `impl Filesystem for SkillFs`
-    ├── mod.rs              SkillFs definition, constructor + with_* builders, virtual_file_attr / dir_attr / ro_warn, and the thin trait impl block
+├── fs.rs                   SkillFs definition, constructor + with_* builders, virtual_file_attr / dir_attr / ro_warn, and the thin trait impl block
+└── fs/                     Helpers and callback implementations
     ├── discover.rs         get_skill_discover_content / simple_discover_md
     ├── events.rs           emit_event / emit_op_event / emit_xattr_event / demo_observe / inbox_observe_install_complete / send_sync
     ├── paths.rs            source_base / skill_inode_path / skills_dir_ino / skill_physical_dir / inbox_skill_dir / is_inbox_skill_name_allowed / skill_source_path / primary_skill_names / skill_physical_path / build_fuse_path / resolve_physical_path / open_parent_dir_for
     ├── policy.rs           evaluate_trusted_writer / policy_check / enforce_skill_meta / lifecycle_reservation / enforce_lifecycle_reservation / check_physical_access_result
     ├── read_resolution.rs  ReadResolution enum + resolve_skill_read / snapshot_read_dir / compiled_skill_md / skill_read_dir
+    ├── transform_cache.rs  Bounded reuse of exact transformed results
     └── callbacks/          FUSE callback bodies, one file per semantic group
         ├── mod.rs          Submodule declarations
         ├── meta.rs         lookup, getattr, access, statfs
@@ -48,7 +49,7 @@ crates/skillfs-fuse/src/
 
 Rust does not allow splitting a trait impl across multiple files. To get
 physical-file modularity for the 26 FUSE callbacks while keeping the trait
-impl in one place, `fs/mod.rs` holds the trait impl and each callback is
+impl in one place, `fs.rs` holds the trait impl and each callback is
 a one-line wrapper:
 
 ```rust
@@ -65,14 +66,14 @@ The actual callback body lives in `fs/callbacks/<group>.rs` as
 
 * Helpers in `fs/discover.rs`, `fs/events.rs`, `fs/paths.rs`,
   `fs/policy.rs`, `fs/read_resolution.rs` are `pub(super)` — visible to
-  their parent (`fs/mod.rs`) and, by inclusion, to every other module
+  their parent (`fs.rs`) and, by inclusion, to every other module
   under `fs/`.
 * Callback impls in `fs/callbacks/<group>.rs` use `pub(in crate::fs)`,
   one level wider than `pub(super)`. `pub(super)` from
   `crate::fs::callbacks::meta` would only reach `crate::fs::callbacks`,
-  which is *not* where the trait impl block in `fs/mod.rs` lives.
+  which is *not* where the trait impl block in `fs.rs` lives.
   `pub(in crate::fs)` makes the method visible to the entire `fs/`
-  subtree, including the wrapper in `fs/mod.rs`.
+  subtree, including the wrapper in `fs.rs`.
 
 Both are tighter than `pub(crate)` — none of these helpers leak to
 `lib.rs` or external consumers.
@@ -92,7 +93,7 @@ The split is acyclic. Roughly:
 lib.rs → mount.rs → fs::SkillFs
 lib.rs → fs::SkillFs
 
-fs/mod.rs → fs/{discover, events, paths, policy, read_resolution, callbacks}
+fs.rs → fs/{discover, events, paths, policy, read_resolution, transform_cache, callbacks}
 fs/callbacks/* → fs/{paths, events, policy, read_resolution, discover}
 fs/policy.rs   → fs/events.rs        (uses emit_event)
 fs/read_resolution.rs → fs/paths.rs  (uses source_base / skill_physical_dir / etc.)

--- a/src/skillfs/docs/design/read-time-transform-pipeline.md
+++ b/src/skillfs/docs/design/read-time-transform-pipeline.md
@@ -24,18 +24,21 @@ source, even if a stage errors; a `Hidden` skill is never read or transformed.
 
 ### Pinned open handles
 
-An open read handle captures the skill's `ActiveTarget` at open time and stores
-it on the handle. Subsequent reads resolve against that pinned target rather
-than re-consulting the live resolver, so a resolver change after open cannot
-re-point an in-flight read (a `Snapshot` handle keeps reading the snapshot; a
-`Current` handle stays readable if the skill is later hidden). Flat and Hermes
-nested `SKILL.md` share this contract via the same pinned-resolution helper.
+A non-mutating read-only open of a transformed flat or Hermes `SKILL.md`
+captures the complete transformed UTF-8 bytes after selecting activation once.
+Reads slice that immutable result until close, including after Current edits,
+atomic replacement, activation changes, or removal of the selected snapshot.
+A new open reads the newly selected source; a missing snapshot fails without
+live fallback. Empty pipelines, writable or truncating opens, staging, pending
+installs, passthrough files, and skill-discover retain their existing behavior.
 
-`getattr` operates on the inode and is not handle-pinned: after an activation
-change, a fresh `stat` reflects the new target's transformed size. Open handles
-continue to serve their pinned target's bytes; only the kernel's cached size may
-change. Within a stable activation state, `getattr` size, offset/partial reads,
-and full reads all agree on the transformed bytes.
+Captured handles use FUSE direct I/O so the inode's shared page cache cannot
+mix different open-time versions. This bypasses kernel readahead and does not
+enable shared mmap for these handles. `getattr` remains an inode operation:
+it reports the currently selected target's transformed length, not necessarily
+an old handle's length. Reads and EOF on a captured handle use its own bytes.
+Linux may omit the handle even for `fstat`; inode-only queries must not choose
+an arbitrary open handle as the size authority.
 
 ## 2. Optional stages, fixed order
 
@@ -210,8 +213,5 @@ suppressed to avoid audit flooding.
 
 ## 8. Out of scope (tracked by #1488)
 
-This change does not store transformed bytes in `HandleEntry`, add a per-open
-cache, add a cross-open LRU, or change the existing `getattr`/`read`
-recomputation behavior. Those cache and handle-lifetime changes are tracked by
-#1488. Additional text-file types, script transforms, LLM/network calls in the
+Cross-open LRU reuse remains separate from the captured-handle contract. Additional text-file types, script transforms, LLM/network calls in the
 read path, and rule hot-reload without a remount also remain out of scope.

--- a/src/skillfs/docs/design/read-time-transform-pipeline.md
+++ b/src/skillfs/docs/design/read-time-transform-pipeline.md
@@ -211,7 +211,54 @@ Write, staging, pending, passthrough, adapter-disabled, and failed/hidden paths
 are not labeled as adapter transforms. Successful per-syscall Read events remain
 suppressed to avoid audit flooding.
 
-## 8. Out of scope (tracked by #1488)
+## 8. Bounded cross-open reuse
 
-Cross-open LRU reuse remains separate from the captured-handle contract. Additional text-file types, script transforms, LLM/network calls in the
-read path, and rule hot-reload without a remount also remain out of scope.
+Each mount owns an in-memory LRU of at most 128 entries and 8 MiB of transformed
+UTF-8 payload. `lookup`, `getattr`, and eligible read-only opens reuse the same
+`Arc<str>` when the complete key matches: Skill identity (including Hermes
+category), physical path, pinned activation target (including snapshot path
+and version), source device/inode/size/nanosecond mtime and ctime, a SHA-256
+digest of the selected source bytes, and pipeline fingerprint. Activation is selected once for both metadata and transformed
+size. Reads on captured handles never consult the LRU or the physical source.
+
+The pipeline fingerprint covers the ordered enabled stages, the directive
+stage's captured OS, sorted available commands and environment key/value pairs,
+and the adapter's resolved target and rule-artifact digest. Length-prefixed
+fields prevent ambiguous concatenation. It is computed when configuring stages,
+not on reads; environment or rule-file edits still require a remount to take
+effect. No environment values or Skill content appear in cache diagnostics.
+
+Cache lookup opens and reads the selected physical file, then hashes those
+bytes before checking the key. Timestamp precision does not guarantee a unique
+version: same-size writes can share mtime and ctime, including when mtime is
+restored. Every lookup/getattr/new open therefore pays for source reading and
+hashing, while hits avoid pipeline execution and transformed-result allocation.
+Population uses those same bytes and checks both the fd metadata and the
+selected path after transformation. If an edit or replacement is detected, the
+captured result is returned without insertion. This fixes the bytes for that
+handle; it does not promise an atomic snapshot of a source being concurrently
+written in place. Snapshot failures never trigger live-source fallback.
+
+The cache lock covers LRU ordering and entry/byte accounting, not I/O or
+transformation. Concurrent cold misses may perform duplicate work; insertion
+deduplicates an exact key. Debug events report only hit, miss, invalidation,
+eviction, entry count, and payload bytes. Tests count transformations through
+the loader closure without production pipeline counters.
+
+Oversize results are kept only by their open handles. Eviction drops the LRU's
+reference without revoking open handles; the 8 MiB limit bounds cached payload,
+not in-flight transformations. Captured handles have a separate mount-wide
+budget of 64 MiB and 1,024 handles, charged at the full transformed length per
+handle even when the payload is shared. Admission and release update both
+counters under the handle-table lock. Exceeding either limit (including a
+single result larger than 64 MiB) returns `ENOMEM` for the new open; existing
+handles keep their bytes and closing them restores capacity. Counting empty
+handles also bounds their bookkeeping. Thus retained transformed payload is
+bounded by 64 MiB for handles plus the 8 MiB LRU; temporary load/transform
+allocations are outside these retained-memory budgets. Closing handles and
+dropping the mount release their references. Nothing is persisted to disk.
+Empty/raw pipelines and mutable, staging, pending-install, passthrough, and generated
+skill-discover reads do not use the transformed-content cache.
+
+Additional text-file types, script transforms, LLM/network calls in the read
+path, and rule hot-reload without a remount remain out of scope.


### PR DESCRIPTION
## Why

Transformed `SKILL.md` reads rerun the full pipeline for every FUSE block and
attribute query. A live edit between blocks can also mix source versions within
one read-only handle.

## What changed

Read-only transformed opens now capture immutable bytes and serve subsequent
reads by slicing, using direct I/O to keep different handles' versions separate.
A mount-local LRU shares results across lookup/getattr and later opens, bounded
by 128 entries and 8 MiB of transformed payload. Reuse requires matching Skill,
physical source identity and content digest, activation target and complete
pipeline fingerprint;
source changes detected during population prevent insertion. The two commits
separate per-open semantics from cross-open reuse.

## Related issue

closes #1488

## User / Agent impact

An already-open Current handle keeps its captured view after live edits or
replacement, while a new open observes the new content. Snapshot handles retain
their selected bytes and never fall back to live source. Mutable, raw, staging,
pending-install, passthrough and generated skill-discover paths retain their
existing behavior.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Migration or rollback guidance is needed

Captured handles bypass kernel page caching/readahead and do not enable shared
mmap. Inode attributes describe the current target; an old handle's reads and
EOF use its captured length. Cache eviction does not revoke open handles. A separate mount-wide budget
limits captured handles to 64 MiB and 1,024 handles, conservatively charging
each handle in full even for shared payloads. New opens return ENOMEM when
either limit is reached; closing handles restores capacity. Temporary
read/transform allocations remain outside these retained-memory limits.
Every new open and attribute lookup reads and hashes the selected source bytes
to detect changes even when stat timestamps collide. Cache hits still avoid
transformation and transformed-result allocation. Reading a concurrently
written live file does not provide a transactional snapshot.
No cache content is persisted or logged, and no new dependency is introduced.

## Validation

Linux aarch64, Rust 1.86.0, real FUSE:

- `cargo +1.86.0 fmt --all -- --check`
- `cargo +1.86.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.86.0 test --workspace`: 1,612 passed, 7 existing ignored
- `cargo +1.86.0 doc --workspace --no-deps`: passed with existing rustdoc warnings
- `RUSTUP_TOOLCHAIN=1.86.0 scripts/test.sh`: passed

Focused checks cover flat/Hermes old and new handles, partial reads and EOF,
snapshot removal, attribute/open reuse, complete pipeline identity, same-size
edits with restored mtime, identical stat identities, population races, deterministic LRU eviction,
concurrent capacity accounting and reference lifetime. A real FUSE stress
test retains eight near-8-MiB versions while making 24 edits/replacements,
checks mount-wide backpressure across Skills, and recovers admission on close. Independent agent review
of the full change found no actionable issues.

## Documentation and rollback

Updated `src/skillfs/docs/design/read-time-transform-pipeline.md` with captured
handle semantics, direct I/O compatibility, cache identity, limits and lifetime.
Renamed the filesystem parent to `src/fs.rs` and updated the crate layout guide.
No configuration or persistent-data migration is required. To roll back, revert
the cross-open cache commit followed by the per-open capture commit and remount.
