### PR TITLE
fix(ckpt): fail fast on detached workspace

### DIFF
--- a/src/ws-ckpt/Makefile
+++ b/src/ws-ckpt/Makefile
@@ -86,11 +86,20 @@ uninstall:
 ifeq ($(INSTALL_PROFILE),user)
 	@echo "User mode: ws-ckpt was not installed (requires systemd/root daemon); skipping uninstall."
 else
-	@# 1. Pre-removal: recover workspaces and stop daemon (skip when staging)
-	@if [ -z "$(DESTDIR)" ]; then \
+	@# 1. Pre-removal: recover workspaces and stop daemon (skip when staging).
+	@#    A sentinel file carries the recover outcome across recipe lines to
+	@#    the state-wipe below (each recipe line is a fresh shell): when
+	@#    recover fails the state dirs may hold the only copies of workspace
+	@#    data, so they must be preserved for manual inspection (#3069).
+	@#    /run is tmpfs, so the sentinel never leaks past a reboot.
+	@rm -f /run/ws-ckpt-recover-failed; \
+	if [ -z "$(DESTDIR)" ]; then \
 		if [ -x "$(BINDIR)/ws-ckpt" ]; then \
-			"$(BINDIR)/ws-ckpt" recover --all --force 2>&1 || \
-				echo "WARNING: recover workspaces failed"; \
+			if ! "$(BINDIR)/ws-ckpt" recover --all --force; then \
+				echo "WARNING: ws-ckpt recover --all failed; preserving /var/lib/ws-ckpt"; \
+				echo "         (and /data/ws-ckpt if present) for manual inspection."; \
+				: > /run/ws-ckpt-recover-failed; \
+			fi; \
 		fi; \
 		systemctl stop ws-ckpt.service 2>/dev/null || true; \
 		systemctl disable ws-ckpt.service 2>/dev/null || true; \
@@ -104,18 +113,28 @@ else
 	rm -rf "$(DESTDIR)$(PLUGINS_DIR)"
 	rm -f "$(DESTDIR)$(SYSTEMD_SYSTEM_DIR)/ws-ckpt.service"
 	rm -f "$(DESTDIR)$(CONFIG_DIR)/config.toml.sample"
-	@# 3. Post-removal: cleanup BtrfsLoop backend (skip when staging)
+	@# 3. Post-removal: cleanup BtrfsLoop backend (skip when staging). When
+	@#    recover failed above, keep the loop image and state dirs on disk
+	@#    (detached loops, plain files) for manual data recovery (#3069).
 	@if [ -z "$(DESTDIR)" ]; then \
 		umount /mnt/btrfs-workspace 2>/dev/null || true; \
 		for img in /var/lib/ws-ckpt/btrfs-data.img /data/ws-ckpt/btrfs-data.img; do \
 			losetup -j "$$img" 2>/dev/null | \
 				cut -d: -f1 | xargs -r losetup -d 2>/dev/null || true; \
-			rm -f "$$img" 2>/dev/null || true; \
 		done; \
 		rmdir /mnt/btrfs-workspace 2>/dev/null || true; \
-		rmdir /data/ws-ckpt 2>/dev/null || true; \
-		rm -f /var/lib/ws-ckpt/state.json /var/lib/ws-ckpt/daemon.lock 2>/dev/null || true; \
-		rmdir /var/lib/ws-ckpt 2>/dev/null || true; \
+		if [ -e /run/ws-ckpt-recover-failed ]; then \
+			echo "NOTE: preserving /var/lib/ws-ckpt (recover failed)."; \
+			echo "      Remove it manually once the data is no longer needed."; \
+		else \
+			for img in /var/lib/ws-ckpt/btrfs-data.img /data/ws-ckpt/btrfs-data.img; do \
+				rm -f "$$img" 2>/dev/null || true; \
+			done; \
+			rmdir /data/ws-ckpt 2>/dev/null || true; \
+			rm -f /var/lib/ws-ckpt/state.json /var/lib/ws-ckpt/daemon.lock 2>/dev/null || true; \
+			rmdir /var/lib/ws-ckpt 2>/dev/null || true; \
+		fi; \
+		rm -f /run/ws-ckpt-recover-failed 2>/dev/null || true; \
 		systemctl daemon-reload 2>/dev/null || true; \
 	fi
 endif

--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -1957,6 +1957,7 @@ async fn handle_recover(workspace: Option<String>, all: bool, force: bool) -> Re
             }
         }
 
+        let mut failed: usize = 0;
         for ws in &workspaces {
             let req = Request::Recover {
                 workspace: ws.path.clone(),
@@ -1971,13 +1972,28 @@ async fn handle_recover(workspace: Option<String>, all: bool, force: bool) -> Re
                         "\x1b[31mError [{:?}] recovering {}: {}\x1b[0m",
                         code, ws.path, message
                     );
+                    failed += 1;
                 }
                 _ => {
                     eprintln!("\x1b[33mUnexpected response for {}\x1b[0m", ws.path);
+                    failed += 1;
                 }
             }
         }
-        println!("All workspaces recovered.");
+        if failed == 0 {
+            println!("All workspaces recovered.");
+        } else {
+            // RPM %preun and other automation chain destructive cleanup off
+            // this exit code; a partially failed batch must not look successful.
+            let summary = format!(
+                "Recover failed for {}/{} workspace(s); failed workspaces \
+                 and their snapshots are preserved for retry.",
+                failed,
+                workspaces.len(),
+            );
+            eprintln!("\x1b[31m{}\x1b[0m", summary);
+            process::exit(1);
+        }
     } else {
         // Single workspace mode
         let ws_arg = resolve_workspace_arg(workspace.as_deref().unwrap());

--- a/src/ws-ckpt/src/crates/daemon/src/dispatcher.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/dispatcher.rs
@@ -285,6 +285,13 @@ async fn handle_status(
                 });
             }
         };
+        // Detached-registration guard: reporting snapshot counts for a stale
+        // subvolume would look healthy while the user's directory is not the
+        // one being described. Global status stays unguarded so `recover
+        // --all` can still enumerate detached workspaces to repair them.
+        if let Some(resp) = state.detached_registration_error(&arc).await {
+            return Ok(resp);
+        }
 
         let ws = arc.read().await;
         vec![WorkspaceInfo {
@@ -1064,6 +1071,135 @@ mod tests {
         match resp {
             Response::Error { code, .. } => assert_eq!(code, ErrorCode::WorkspaceNotFound),
             _ => panic!("expected WorkspaceNotFound error from Cleanup"),
+        }
+    }
+
+    // ── Detached-registration guard at the dispatch layer ──
+    //
+    // Real topology: BtrfsBaseBackend on a tempdir (data_root =
+    // `<tmp>/ws-ckpt-data`), a `ws-<id>` directory inside it as the
+    // live-subvolume stand-in, and a workspace symlink pointing at it.
+
+    /// Returns (state, ws_id, workspace symlink, tempdir to keep alive).
+    fn live_topology(ws_id: &str) -> (Arc<DaemonState>, String, PathBuf, tempfile::TempDir) {
+        let temp = tempfile::tempdir().unwrap();
+        let backend: Arc<dyn StorageBackend> =
+            Arc::new(crate::backends::btrfs_base::BtrfsBaseBackend::new(
+                temp.path().to_path_buf(),
+                crate::backends::btrfs_base::BtrfsBaseScenario::InPlace,
+            ));
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            backend,
+            temp.path().join("state"),
+        ));
+        let subvol = temp.path().join("ws-ckpt-data").join(ws_id);
+        std::fs::create_dir_all(&subvol).unwrap();
+        let ws_link = temp.path().join("ws-link");
+        std::os::unix::fs::symlink(&subvol, &ws_link).unwrap();
+        state.register_workspace(
+            ws_id.to_string(),
+            ws_link.clone(),
+            ws_ckpt_common::SnapshotIndex::new(ws_link.clone()),
+        );
+        (state, ws_id.to_string(), ws_link, temp)
+    }
+
+    fn assert_detach_hint(resp: Response, op: &str) {
+        match resp {
+            Response::Error { code, message } => {
+                assert_eq!(code, ErrorCode::InternalError, "{op}: {message}");
+                assert!(message.contains("recover"), "{op}: {message}");
+                assert!(message.contains("regular directory"), "{op}: {message}");
+            }
+            other => panic!("{op}: expected detach error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_checkpoint_refuses_detached_registration() {
+        let (state, _ws_id, ws_link, _temp) = live_topology("ws-dispatch");
+        // Detach: replace the symlink with a plain directory (issue #3059 repro).
+        std::fs::remove_file(&ws_link).unwrap();
+        std::fs::create_dir(&ws_link).unwrap();
+
+        let resp = dispatch(
+            &state,
+            Request::Checkpoint {
+                workspace: ws_link.to_string_lossy().to_string(),
+                id: "snap-1".to_string(),
+                message: None,
+                metadata: None,
+                pin: false,
+            },
+        )
+        .await;
+        // The checkpoint path must fail loudly instead of auto-initing over
+        // the replacement directory or snapshotting the stale subvolume.
+        assert_detach_hint(resp, "dispatch checkpoint");
+    }
+
+    #[tokio::test]
+    async fn dispatch_checkpoint_healthy_registration_proceeds_past_guard() {
+        let (state, _ws_id, _ws_link, _temp) = live_topology("ws-dispatch-live");
+        let empty_ws = tempfile::tempdir().unwrap();
+        let resp = dispatch(
+            &state,
+            Request::Checkpoint {
+                workspace: empty_ws.path().to_string_lossy().to_string(),
+                id: "snap-1".to_string(),
+                message: None,
+                metadata: None,
+                pin: false,
+            },
+        )
+        .await;
+        // Auto-init on an unregistered directory must still be attempted: it
+        // reaches the real backend (which fails outside btrfs, legitimately as
+        // InternalError), never the detach guard.
+        match resp {
+            Response::Error { code, message } => {
+                assert_ne!(code, ErrorCode::WorkspaceNotFound, "{message}");
+                assert!(
+                    !message.contains("ws-ckpt recover"),
+                    "must not look like a detach error: {message}"
+                );
+            }
+            other => panic!("expected an error from the backend, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_status_single_workspace_refuses_detached_registration() {
+        let (state, _ws_id, ws_link, _temp) = live_topology("ws-status");
+        std::fs::remove_file(&ws_link).unwrap();
+        std::fs::create_dir(&ws_link).unwrap();
+
+        let resp = dispatch(
+            &state,
+            Request::Status {
+                workspace: Some(ws_link.to_string_lossy().to_string()),
+            },
+        )
+        .await;
+        assert_detach_hint(resp, "dispatch status -w");
+    }
+
+    #[tokio::test]
+    async fn dispatch_status_global_stays_unguarded() {
+        let (state, _ws_id, ws_link, _temp) = live_topology("ws-global");
+        std::fs::remove_file(&ws_link).unwrap();
+        std::fs::create_dir(&ws_link).unwrap();
+
+        // Global status must keep listing detached workspaces: `recover --all`
+        // uses it to enumerate the workspaces it repairs.
+        let resp = dispatch(&state, Request::Status { workspace: None }).await;
+        match resp {
+            Response::StatusOk { report } => {
+                assert_eq!(report.workspaces.len(), 1);
+                assert_eq!(report.workspaces[0].ws_id, "ws-global");
+            }
+            other => panic!("expected StatusOk, got {other:?}"),
         }
     }
 

--- a/src/ws-ckpt/src/crates/daemon/src/guarded_checkpoint.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/guarded_checkpoint.rs
@@ -42,7 +42,7 @@ pub(crate) async fn workspace_identity(
     if !state.exact_registration_is_current(path, &candidate, &workspace) {
         return workspace_not_found(registration_path);
     }
-    if !registration_resolves_to_live(state, path, &candidate).await {
+    if !state.registration_is_live(&candidate, path).await {
         return workspace_not_found(registration_path);
     }
 
@@ -125,7 +125,7 @@ pub(crate) async fn checkpoint(
     if workspace.ws_id != ws_id {
         return workspace_not_found(ws_id);
     }
-    if !registration_resolves_to_live(state, &workspace.path, ws_id).await {
+    if !state.registration_is_live(ws_id, &workspace.path).await {
         return rejected(
             GuardedCheckpointRejectionCodeV2::InvalidRegistrationPath,
             "registered workspace path no longer resolves to the live subvolume",
@@ -371,21 +371,6 @@ fn validate_registration_path(value: &str) -> Result<(), String> {
         return Err("registration path must not contain '.' or '..' components".to_string());
     }
     Ok(())
-}
-
-async fn registration_resolves_to_live(
-    state: &DaemonState,
-    registration_path: &Path,
-    ws_id: &str,
-) -> bool {
-    let live_path = state.backend.data_root().join(ws_id);
-    match tokio::try_join!(
-        tokio::fs::canonicalize(registration_path),
-        tokio::fs::canonicalize(live_path)
-    ) {
-        Ok((registration_target, live_target)) => registration_target == live_target,
-        Err(_) => false,
-    }
 }
 
 fn index_with_evidence_slot(

--- a/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/snapshot_mgr.rs
@@ -167,6 +167,11 @@ pub async fn checkpoint(
         None => return Ok(workspace_not_found(workspace)),
     };
 
+    // 1a. Detached-registration guard: refuse before snapshotting the stale subvolume.
+    if let Some(resp) = state.detached_registration_error(&arc).await {
+        return Ok(resp);
+    }
+
     // 2. Acquire write lock
     let mut ws = arc.write().await;
 
@@ -271,6 +276,12 @@ pub async fn rollback(
         None => return Ok(workspace_not_found(workspace)),
     };
 
+    // 1a. Detached-registration guard: without it a rollback "succeeds" on the
+    // stale subvolume while the user's replacement directory never changes.
+    if let Some(resp) = state.detached_registration_error(&arc).await {
+        return Ok(resp);
+    }
+
     // 2. Read lock: grab workspace path for /proc scan
     let ws_path_str = {
         let ws = arc.read().await;
@@ -337,6 +348,11 @@ pub async fn rollback_preview(
         Some(a) => a,
         None => return Ok(workspace_not_found(workspace)),
     };
+
+    // Detached-registration guard: a preview of a rollback the user will never see.
+    if let Some(resp) = state.detached_registration_error(&arc).await {
+        return Ok(resp);
+    }
 
     let (ws_id, resolved_id) = {
         let ws = arc.read().await;
@@ -414,6 +430,12 @@ pub async fn list_snapshots(state: &Arc<DaemonState>, workspace: &str) -> anyhow
         None => return Ok(workspace_not_found(workspace)),
     };
 
+    // Detached-registration guard: the listed snapshots belong to a subvolume
+    // the registered path no longer exposes to the user.
+    if let Some(resp) = state.detached_registration_error(&arc).await {
+        return Ok(resp);
+    }
+
     let ws = arc.read().await;
     let ws_path = ws.index.workspace_path.to_string_lossy().to_string();
     let mut snapshots: Vec<(String, SnapshotMeta)> = ws
@@ -476,6 +498,12 @@ pub async fn diff_snapshots(
         Some(a) => a,
         None => return Ok(workspace_not_found(workspace)),
     };
+
+    // Detached-registration guard: the diff would describe a subvolume the
+    // registered path no longer exposes to the user.
+    if let Some(resp) = state.detached_registration_error(&arc).await {
+        return Ok(resp);
+    }
 
     let ws = arc.read().await;
 
@@ -540,6 +568,14 @@ pub async fn cleanup_snapshots(
         Some(a) => a,
         None => return Ok(workspace_not_found(workspace)),
     };
+
+    // Detached-registration guard: refuse before mutating the stale subvolume's
+    // snapshot set. The scheduler's auto-cleanup path bypasses this guard via
+    // `delete_snapshots_locked` — background deletion of already-recorded
+    // snapshots must keep working even while the registration is detached.
+    if let Some(resp) = state.detached_registration_error(&arc).await {
+        return Ok(resp);
+    }
 
     // P1: plan under read lock — pure in-memory work, no fs I/O.
     let (ws_id, to_remove_ids, snap_dir) = {
@@ -656,6 +692,226 @@ mod tests {
         }
     }
 
+    // ── Detached-registration guard fixtures ──
+    //
+    // Real topology: a tempdir doubles as the backend data root
+    // (BtrfsLoopBackend::data_root() is exactly its mount path), `<root>/ws-<id>`
+    // stands in for the live subvolume, and a workspace symlink points at it.
+    // Registering fake paths like `/home/user/ws` no longer works: the guard
+    // (correctly) treats them as detached.
+
+    /// How a registration got detached from its live subvolume.
+    enum DetachMode {
+        /// Registered path replaced by a plain directory (issue #3059 repro).
+        ReplacedByDir,
+        /// Registered path removed entirely.
+        Missing,
+        /// Registered symlink repointed at another directory.
+        Repointed,
+    }
+
+    struct GuardFixture {
+        _temp: tempfile::TempDir,
+        state: Arc<DaemonState>,
+        ws_id: String,
+        ws_link: PathBuf,
+    }
+
+    impl GuardFixture {
+        fn new(ws_id: &str) -> Self {
+            let temp = tempfile::tempdir().unwrap();
+            let backend: Arc<dyn StorageBackend> =
+                Arc::new(crate::backends::btrfs_loop::BtrfsLoopBackend::new(
+                    temp.path().to_path_buf(),
+                    temp.path().join("test.img"),
+                ));
+            let state = Arc::new(DaemonState::new(
+                test_config(),
+                backend,
+                temp.path().join("state"),
+            ));
+            let subvol = temp.path().join(ws_id);
+            std::fs::create_dir_all(&subvol).unwrap();
+            let ws_link = temp.path().join("ws-link");
+            std::os::unix::fs::symlink(&subvol, &ws_link).unwrap();
+            state.register_workspace(
+                ws_id.to_string(),
+                ws_link.clone(),
+                SnapshotIndex::new(ws_link.clone()),
+            );
+            Self {
+                _temp: temp,
+                state,
+                ws_id: ws_id.to_string(),
+                ws_link,
+            }
+        }
+
+        /// Break the registration the way an external `rm -rf $W; mkdir $W` does.
+        fn detach(&self, mode: DetachMode) {
+            std::fs::remove_file(&self.ws_link).unwrap();
+            match mode {
+                DetachMode::ReplacedByDir => {
+                    std::fs::create_dir(&self.ws_link).unwrap();
+                }
+                DetachMode::Missing => {}
+                DetachMode::Repointed => {
+                    let other = self._temp.path().join("other-target");
+                    std::fs::create_dir(&other).unwrap();
+                    std::os::unix::fs::symlink(&other, &self.ws_link).unwrap();
+                }
+            }
+        }
+
+        /// Insert a snapshot record so post-guard resolution stages are meaningful.
+        async fn add_snapshot(&self, snapshot_id: &str) {
+            let arc = self.state.get_by_wsid(&self.ws_id).unwrap();
+            arc.write()
+                .await
+                .index
+                .snapshots
+                .insert(snapshot_id.to_string(), make_snapshot_meta(false));
+        }
+    }
+
+    /// The detach error is uniform across ops: InternalError, points at recover.
+    /// The data-loss note must appear only for the replaced-by-directory case.
+    fn assert_detach_error(resp: Response, op: &str, expect_dir_note: bool) {
+        match resp {
+            Response::Error { code, message } => {
+                assert_eq!(code, ErrorCode::InternalError, "{op}: {message}");
+                assert!(message.contains("recover"), "{op}: {message}");
+                assert!(message.contains("re-init"), "{op}: {message}");
+                assert_eq!(
+                    message.contains("regular directory"),
+                    expect_dir_note,
+                    "{op}: {message}"
+                );
+            }
+            other => panic!("{op}: expected detach error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn v1_snapshot_ops_refuse_detached_registration() {
+        for mode in [
+            DetachMode::ReplacedByDir,
+            DetachMode::Missing,
+            DetachMode::Repointed,
+        ] {
+            let expect_dir_note = matches!(mode, DetachMode::ReplacedByDir);
+            let fx = GuardFixture::new("ws-guard");
+            fx.add_snapshot("snap-1").await;
+            fx.detach(mode);
+            let ws_ref = fx.ws_link.to_string_lossy().to_string();
+
+            let resp = checkpoint(&fx.state, &ws_ref, "snap-1", None, None, false)
+                .await
+                .unwrap();
+            assert_detach_error(resp, "checkpoint", expect_dir_note);
+
+            let resp = rollback(&fx.state, &ws_ref, Some("snap-1"), None)
+                .await
+                .unwrap();
+            assert_detach_error(resp, "rollback", expect_dir_note);
+
+            let resp = rollback_preview(&fx.state, &ws_ref, Some("snap-1"), None)
+                .await
+                .unwrap();
+            assert_detach_error(resp, "rollback_preview", expect_dir_note);
+
+            let resp = list_snapshots(&fx.state, &ws_ref).await.unwrap();
+            assert_detach_error(resp, "list_snapshots", expect_dir_note);
+
+            let resp = diff_snapshots(&fx.state, &ws_ref, "snap-1", None)
+                .await
+                .unwrap();
+            assert_detach_error(resp, "diff_snapshots", expect_dir_note);
+
+            let resp = cleanup_snapshots(&fx.state, &ws_ref, None).await.unwrap();
+            assert_detach_error(resp, "cleanup_snapshots", expect_dir_note);
+        }
+    }
+
+    #[tokio::test]
+    async fn v1_snapshot_ops_proceed_past_guard_on_healthy_registration() {
+        let fx = GuardFixture::new("ws-live");
+        fx.add_snapshot("snap-1").await;
+        let ws_ref = fx.ws_link.to_string_lossy().to_string();
+
+        // Every op must reach a stage after the guard (or fully succeed);
+        // none may return the detach error.
+        match checkpoint(&fx.state, &ws_ref, "snap-1", None, None, false)
+            .await
+            .unwrap()
+        {
+            Response::Error { code, .. } => assert_eq!(code, ErrorCode::SnapshotAlreadyExists),
+            other => panic!("checkpoint: {other:?}"),
+        }
+
+        match rollback(&fx.state, &ws_ref, Some("no-such"), None)
+            .await
+            .unwrap()
+        {
+            Response::Error { code, message } => {
+                assert_eq!(code, ErrorCode::SnapshotNotFound);
+                assert!(message.contains("no-such"), "{message}");
+            }
+            other => panic!("rollback: {other:?}"),
+        }
+
+        match rollback_preview(&fx.state, &ws_ref, Some("no-such"), None)
+            .await
+            .unwrap()
+        {
+            Response::Error { code, message } => {
+                assert_eq!(code, ErrorCode::SnapshotNotFound);
+                assert!(message.contains("no-such"), "{message}");
+            }
+            other => panic!("rollback_preview: {other:?}"),
+        }
+
+        assert!(matches!(
+            list_snapshots(&fx.state, &ws_ref).await.unwrap(),
+            Response::ListOk { .. }
+        ));
+
+        match diff_snapshots(&fx.state, &ws_ref, "no-such", None)
+            .await
+            .unwrap()
+        {
+            Response::Error { code, message } => {
+                assert_eq!(code, ErrorCode::SnapshotNotFound);
+                assert!(message.contains("no-such"), "{message}");
+            }
+            other => panic!("diff_snapshots: {other:?}"),
+        }
+
+        assert!(matches!(
+            cleanup_snapshots(&fx.state, &ws_ref, Some(20))
+                .await
+                .unwrap(),
+            Response::CleanupOk { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn guard_applies_when_workspace_addressed_by_ws_id() {
+        let fx = GuardFixture::new("ws-byid");
+        fx.add_snapshot("snap-1").await;
+        fx.detach(DetachMode::ReplacedByDir);
+
+        let resp = checkpoint(&fx.state, &fx.ws_id, "snap-1", None, None, false)
+            .await
+            .unwrap();
+        assert_detach_error(resp, "checkpoint by ws_id", true);
+
+        let resp = rollback(&fx.state, &fx.ws_id, Some("snap-1"), None)
+            .await
+            .unwrap();
+        assert_detach_error(resp, "rollback by ws_id", true);
+    }
+
     // ── Duplicate snapshot ID tests ──
 
     #[test]
@@ -730,19 +986,11 @@ mod tests {
 
     #[tokio::test]
     async fn checkpoint_duplicate_id_returns_already_exists() {
-        let state = Arc::new(crate::state::DaemonState::new(
-            test_config(),
-            test_backend(),
-            test_state_dir(),
-        ));
+        let fx = GuardFixture::new("ws-dup");
         // Register a workspace with an existing snapshot
-        let mut index = SnapshotIndex::new(PathBuf::from("/home/user/ws"));
-        index
-            .snapshots
-            .insert("existing-id".to_string(), make_snapshot_meta(false));
-        state.register_workspace("ws-dup".to_string(), PathBuf::from("/home/user/ws"), index);
+        fx.add_snapshot("existing-id").await;
 
-        let resp = checkpoint(&state, "ws-dup", "existing-id", None, None, false)
+        let resp = checkpoint(&fx.state, &fx.ws_id, "existing-id", None, None, false)
             .await
             .unwrap();
         match resp {
@@ -756,37 +1004,27 @@ mod tests {
 
     #[tokio::test]
     async fn checkpoint_cannot_reuse_id_reserved_by_guarded_evidence() {
-        use ws_ckpt_common::{
-            GuardedCheckpointEvidenceV2, GuardedCheckpointOutcomeV2, WorkspaceGenerationTokenV2,
-        };
-
-        let state = Arc::new(crate::state::DaemonState::new(
-            test_config(),
-            test_backend(),
-            test_state_dir(),
-        ));
-        let mut index = SnapshotIndex::new(PathBuf::from("/home/user/ws"));
-        index.governed_evidence.insert(
-            "reserved-id".to_string(),
-            GuardedCheckpointEvidenceV2 {
-                ws_id: "ws-abcdef".to_string(),
-                registered_path: "/home/user/ws".to_string(),
-                generation: WorkspaceGenerationTokenV2::from_bytes([1; 32]),
-                checkpoint_id: "reserved-id".to_string(),
-                operation_digest: [2; 32],
-                caller_uid: 1000,
-                outcome: GuardedCheckpointOutcomeV2::Created {
-                    snapshot_id: "reserved-id".to_string(),
+        let fx = GuardFixture::new("ws-abcdef");
+        let arc = fx.state.get_by_wsid(&fx.ws_id).unwrap();
+        {
+            let mut ws = arc.write().await;
+            ws.index.governed_evidence.insert(
+                "reserved-id".to_string(),
+                GuardedCheckpointEvidenceV2 {
+                    ws_id: fx.ws_id.clone(),
+                    registered_path: fx.ws_link.to_string_lossy().into_owned(),
+                    generation: WorkspaceGenerationTokenV2::from_bytes([1; 32]),
+                    checkpoint_id: "reserved-id".to_string(),
+                    operation_digest: [2; 32],
+                    caller_uid: 1000,
+                    outcome: GuardedCheckpointOutcomeV2::Created {
+                        snapshot_id: "reserved-id".to_string(),
+                    },
                 },
-            },
-        );
-        state.register_workspace(
-            "ws-abcdef".to_string(),
-            PathBuf::from("/home/user/ws"),
-            index,
-        );
+            );
+        }
 
-        let response = checkpoint(&state, "ws-abcdef", "reserved-id", None, None, false)
+        let response = checkpoint(&fx.state, &fx.ws_id, "reserved-id", None, None, false)
             .await
             .unwrap();
         match response {
@@ -1133,18 +1371,10 @@ mod tests {
     /// `SnapshotNotFound`, not as `InternalError` via the dispatcher fallback.
     #[tokio::test]
     async fn diff_snapshots_missing_id_returns_snapshot_not_found() {
-        let state = Arc::new(crate::state::DaemonState::new(
-            test_config(),
-            test_backend(),
-            test_state_dir(),
-        ));
-        let mut index = SnapshotIndex::new(PathBuf::from("/home/user/ws"));
-        index
-            .snapshots
-            .insert("real-id".to_string(), make_snapshot_meta(false));
-        state.register_workspace("ws-diff".to_string(), PathBuf::from("/home/user/ws"), index);
+        let fx = GuardFixture::new("ws-diff");
+        fx.add_snapshot("real-id").await;
 
-        let resp = diff_snapshots(&state, "ws-diff", "does-not-exist", Some("real-id"))
+        let resp = diff_snapshots(&fx.state, &fx.ws_id, "does-not-exist", Some("real-id"))
             .await
             .unwrap();
         match resp {
@@ -1156,7 +1386,7 @@ mod tests {
         }
 
         // Also covers the `to`-side branch.
-        let resp = diff_snapshots(&state, "ws-diff", "real-id", Some("missing-to"))
+        let resp = diff_snapshots(&fx.state, &fx.ws_id, "real-id", Some("missing-to"))
             .await
             .unwrap();
         match resp {
@@ -1172,7 +1402,9 @@ mod tests {
     async fn diff_and_rollback_preview_reach_live_diff_backend() {
         use ws_ckpt_common::DiffEntry;
 
-        struct DiffStubBackend;
+        struct DiffStubBackend {
+            data_root: PathBuf,
+        }
 
         #[async_trait::async_trait]
         impl StorageBackend for DiffStubBackend {
@@ -1180,7 +1412,7 @@ mod tests {
                 ws_ckpt_common::backend::BackendType::BtrfsBase
             }
             fn data_root(&self) -> &std::path::Path {
-                std::path::Path::new("/tmp/stub")
+                &self.data_root
             }
             fn snapshots_root(&self) -> &std::path::Path {
                 std::path::Path::new("/tmp/stub-snaps")
@@ -1245,20 +1477,27 @@ mod tests {
             }
         }
 
+        // Real registration topology: subvolume stand-in under the stub's
+        // data root, workspace symlink pointing at it.
+        let tmp = tempfile::tempdir().unwrap();
+        let data_root = tmp.path().join("stub-data");
+        let subvol = data_root.join("ws-diff-live");
+        std::fs::create_dir_all(&subvol).unwrap();
+        let ws_link = tmp.path().join("ws-link");
+        std::os::unix::fs::symlink(&subvol, &ws_link).unwrap();
+
         let state = Arc::new(crate::state::DaemonState::new(
             test_config(),
-            Arc::new(DiffStubBackend),
+            Arc::new(DiffStubBackend {
+                data_root: data_root.clone(),
+            }),
             test_state_dir(),
         ));
-        let mut index = SnapshotIndex::new(PathBuf::from("/home/user/ws"));
+        let mut index = SnapshotIndex::new(ws_link.clone());
         index
             .snapshots
             .insert("snap-from".to_string(), make_snapshot_meta(false));
-        state.register_workspace(
-            "ws-diff-live".to_string(),
-            PathBuf::from("/home/user/ws"),
-            index,
-        );
+        state.register_workspace("ws-diff-live".to_string(), ws_link.clone(), index);
 
         let resp = diff_snapshots(&state, "ws-diff-live", "snap-from", None)
             .await
@@ -1306,18 +1545,9 @@ mod tests {
 
     #[tokio::test]
     async fn rollback_preview_snapshot_not_found() {
-        let state = Arc::new(crate::state::DaemonState::new(
-            test_config(),
-            test_backend(),
-            test_state_dir(),
-        ));
-        state.register_workspace(
-            "ws-preview".to_string(),
-            PathBuf::from("/home/user/ws"),
-            SnapshotIndex::new(PathBuf::from("/home/user/ws")),
-        );
+        let fx = GuardFixture::new("ws-preview");
 
-        let resp = rollback_preview(&state, "ws-preview", Some("missing-snapshot"), None)
+        let resp = rollback_preview(&fx.state, &fx.ws_id, Some("missing-snapshot"), None)
             .await
             .unwrap();
         match resp {
@@ -1346,10 +1576,10 @@ mod tests {
     }
 
     impl PartialFailBackend {
-        fn new(fail_ids: impl IntoIterator<Item = String>) -> Self {
+        fn new(data_root: PathBuf, fail_ids: impl IntoIterator<Item = String>) -> Self {
             Self {
-                data_root: PathBuf::from("/tmp/pfb-data"),
-                snapshots_root: PathBuf::from("/tmp/pfb-snaps"),
+                snapshots_root: data_root.join("snapshots"),
+                data_root,
                 fail_ids: fail_ids.into_iter().collect(),
             }
         }
@@ -1435,14 +1665,24 @@ mod tests {
         //   - in-memory index keeps only snap-3 (others removed)
         //   - failed snap meta is re-inserted (no detach drift)
         let tmp = tempfile::tempdir().unwrap();
-        let backend = Arc::new(PartialFailBackend::new(["snap-3".to_string()]));
+        let data_root = tmp.path().join("pfb-data");
+        let backend = Arc::new(PartialFailBackend::new(
+            data_root.clone(),
+            ["snap-3".to_string()],
+        ));
         let state = Arc::new(crate::state::DaemonState::new(
             test_config(),
             backend as Arc<dyn StorageBackend>,
             tmp.path().to_path_buf(),
         ));
 
-        let ws_path = PathBuf::from("/ws/partial-fail");
+        // Real registration topology: subvolume stand-in under the stub's
+        // data root, workspace symlink pointing at it, registered by that path.
+        let subvol = data_root.join("ws-partial");
+        std::fs::create_dir_all(&subvol).unwrap();
+        let ws_path = tmp.path().join("ws-link");
+        std::os::unix::fs::symlink(&subvol, &ws_path).unwrap();
+
         let mut idx = SnapshotIndex::new(ws_path.clone());
         let now = Utc::now();
         for (i, off) in [0i64, 1, 2, 3, 4].iter().enumerate() {

--- a/src/ws-ckpt/src/crates/daemon/src/state.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/state.rs
@@ -13,8 +13,9 @@ use ws_ckpt_common::persist::{
     self, BackendIdentity, BackendPaths, DaemonStateFile, WorkspaceEntry, DAEMON_STATE_VERSION,
 };
 use ws_ckpt_common::{
-    load_workspace_policy, load_workspace_policy_with_failsafe, DaemonConfig, LoadPolicyOutcome,
-    ResolveError, SnapshotIndex, WorkspaceInfo, WorkspacePolicy, INDEXES_DIR, INDEX_FILE,
+    load_workspace_policy, load_workspace_policy_with_failsafe, DaemonConfig, ErrorCode,
+    LoadPolicyOutcome, ResolveError, Response, SnapshotIndex, WorkspaceInfo, WorkspacePolicy,
+    INDEXES_DIR, INDEX_FILE,
 };
 
 use crate::fs_watcher::WorkspaceWatcher;
@@ -392,6 +393,80 @@ impl DaemonState {
             return Some(arc);
         }
         None
+    }
+
+    /// True iff `registration_path` still resolves to the workspace's live
+    /// subvolume (`data_root/ws_id`).
+    ///
+    /// Canonicalize-equality rather than `read_link`-equality: registration
+    /// paths may reach the subvolume through symlink chains, relative
+    /// symlinks, or directly through the backend mount (init's bind-mount
+    /// adoption case), and only canonicalization follows every hop. Any
+    /// resolution failure (path missing, broken symlink) counts as detached.
+    pub(crate) async fn registration_is_live(&self, ws_id: &str, registration_path: &Path) -> bool {
+        let live_path = self.backend.data_root().join(ws_id);
+        match tokio::try_join!(
+            tokio::fs::canonicalize(registration_path),
+            tokio::fs::canonicalize(live_path)
+        ) {
+            Ok((registration_target, live_target)) => registration_target == live_target,
+            Err(_) => false,
+        }
+    }
+
+    /// V1 detached-registration guard: `Some(Error)` when the registered path
+    /// no longer resolves to the workspace's live subvolume, `None` when the
+    /// registration is healthy and the caller may proceed.
+    ///
+    /// When a workspace symlink is deleted and the path recreated as a plain
+    /// directory, V1 path-addressed ops would otherwise resolve the stale
+    /// registry binding and silently operate on the old subvolume while the
+    /// user reads/writes the replacement directory — snapshots containing
+    /// none of the user's data, "successful" rollbacks the user never sees.
+    /// Guarded (V2) requests enforce the same liveness contract via
+    /// [`Self::registration_is_live`]. `recover_workspace` must not use this
+    /// guard: it is the repair path this error points the operator at.
+    pub(crate) async fn detached_registration_error(
+        &self,
+        workspace: &Arc<RwLock<WorkspaceState>>,
+    ) -> Option<Response> {
+        let (ws_id, registration_path) = {
+            let ws = workspace.read().await;
+            (ws.ws_id.clone(), ws.path.clone())
+        };
+        if self.registration_is_live(&ws_id, &registration_path).await {
+            return None;
+        }
+        warn!(
+            "workspace {} registration detached at {:?}; refusing operation — \
+             run 'ws-ckpt recover -w {:?}' to restore",
+            ws_id, registration_path, registration_path
+        );
+        // Distinguish the detach states so the operator knows whether
+        // recover is safe or would clobber a replacement directory.
+        let (cause, hint) = match tokio::fs::symlink_metadata(&registration_path).await {
+            Err(_) => ("the registered path no longer exists", ""),
+            Ok(meta) if !meta.file_type().is_symlink() => (
+                "the registered path is no longer a workspace symlink",
+                "\n  note: path is currently a regular directory — \
+                 move or rename it before running recover to avoid data loss",
+            ),
+            Ok(_) => (
+                "the registered symlink no longer points at the live workspace subvolume",
+                "",
+            ),
+        };
+        Some(Response::Error {
+            code: ErrorCode::InternalError,
+            message: format!(
+                "workspace registered (ws_id={}) but {}; \
+                 run 'ws-ckpt recover -w {}' to restore, then re-init{}",
+                ws_id,
+                cause,
+                registration_path.display(),
+                hint
+            ),
+        })
     }
 
     pub fn register_workspace(&self, ws_id: String, path: PathBuf, index: SnapshotIndex) {

--- a/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
@@ -468,6 +468,12 @@ pub async fn delete_snapshot(
         }
     };
 
+    // 1a. Detached-registration guard: refuse before unlinking snapshots of a
+    // subvolume the registered path no longer exposes to the user.
+    if let Some(resp) = state.detached_registration_error(&ws_lock).await {
+        return Ok(resp);
+    }
+
     // 2. Write lock
     let mut ws = ws_lock.write().await;
 
@@ -1025,6 +1031,96 @@ mod tests {
         match resp {
             Response::Error { code, .. } => assert_eq!(code, ErrorCode::WorkspaceNotFound),
             _ => panic!("expected WorkspaceNotFound error"),
+        }
+    }
+
+    // ── Detached-registration guard: delete_snapshot ──
+
+    /// Real registration topology: tempdir as backend data root,
+    /// `<root>/ws-<id>` as the live-subvolume stand-in, workspace symlink at it.
+    /// Returns (state, workspace symlink, tempdir to keep alive).
+    fn live_topology(ws_id: &str) -> (Arc<DaemonState>, PathBuf, tempfile::TempDir) {
+        let temp = tempfile::tempdir().unwrap();
+        let backend: Arc<dyn StorageBackend> =
+            Arc::new(crate::backends::btrfs_loop::BtrfsLoopBackend::new(
+                temp.path().to_path_buf(),
+                temp.path().join("test.img"),
+            ));
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            backend,
+            temp.path().join("state"),
+        ));
+        let subvol = temp.path().join(ws_id);
+        std::fs::create_dir_all(&subvol).unwrap();
+        let ws_link = temp.path().join("ws-link");
+        std::os::unix::fs::symlink(&subvol, &ws_link).unwrap();
+        let mut index = SnapshotIndex::new(ws_link.clone());
+        index.snapshots.insert(
+            "snap-1".to_string(),
+            ws_ckpt_common::SnapshotMeta {
+                message: None,
+                metadata: None,
+                pinned: false,
+                created_at: chrono::Utc::now(),
+                missing: false,
+                parent_id: None,
+                child_ids: vec![],
+            },
+        );
+        state.register_workspace(ws_id.to_string(), ws_link.clone(), index);
+        (state, ws_link, temp)
+    }
+
+    #[tokio::test]
+    async fn delete_snapshot_healthy_registration_reaches_snapshot_resolution() {
+        let (state, _ws_link, _temp) = live_topology("ws-del-live");
+        // A healthy registration must get PAST the guard: the unknown snapshot
+        // id fails at the later resolve-by-prefix stage, not the detach guard.
+        let resp = delete_snapshot(&state, "ws-del-live", "no-such", false)
+            .await
+            .unwrap();
+        match resp {
+            Response::Error { code, message } => {
+                assert_eq!(code, ErrorCode::SnapshotNotFound);
+                assert!(message.contains("no-such"), "got: {message}");
+            }
+            other => panic!("expected SnapshotNotFound, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_snapshot_refuses_detached_registration() {
+        let (state, ws_link, _temp) = live_topology("ws-del-gone");
+        // Detach: replace the symlink with a plain directory (issue #3059 repro).
+        std::fs::remove_file(&ws_link).unwrap();
+        std::fs::create_dir(&ws_link).unwrap();
+
+        // Addressing by registered path …
+        let resp = delete_snapshot(&state, &ws_link.to_string_lossy(), "snap-1", false)
+            .await
+            .unwrap();
+        match resp {
+            Response::Error { code, message } => {
+                assert_eq!(code, ErrorCode::InternalError);
+                assert!(message.contains("recover"), "hint missing: {message}");
+                assert!(
+                    message.contains("regular directory"),
+                    "note missing: {message}"
+                );
+            }
+            other => panic!("expected detach error, got {other:?}"),
+        }
+        // … and by ws_id: the guard checks the registered path either way.
+        let resp = delete_snapshot(&state, "ws-del-gone", "snap-1", false)
+            .await
+            .unwrap();
+        match resp {
+            Response::Error { code, message } => {
+                assert_eq!(code, ErrorCode::InternalError);
+                assert!(message.contains("recover"), "hint missing: {message}");
+            }
+            other => panic!("expected detach error, got {other:?}"),
         }
     }
 

--- a/src/ws-ckpt/tests/integration/e2e.sh
+++ b/src/ws-ckpt/tests/integration/e2e.sh
@@ -96,10 +96,17 @@ assert_output_contains() {
 
 # ── build ─────────────────────────────────────────────────────────────────────
 
-echo "=== Building ws-ckpt ==="
-cd "$CARGO_ROOT"
-cargo build --release --workspace
-BIN="$CARGO_ROOT/target/release/ws-ckpt"
+# WS_CKPT_E2E_BIN lets local reruns skip the cargo build by pointing at an
+# already-built binary (it must contain the changes under test).
+if [ -n "${WS_CKPT_E2E_BIN:-}" ]; then
+    BIN="${WS_CKPT_E2E_BIN%/}"
+    echo "=== Using prebuilt binary: $BIN ==="
+else
+    echo "=== Building ws-ckpt ==="
+    cd "$CARGO_ROOT"
+    cargo build --release --workspace
+    BIN="$CARGO_ROOT/target/release/ws-ckpt"
+fi
 [ -x "$BIN" ] || { echo "FATAL: binary not found at $BIN"; exit 1; }
 
 # ── setup btrfs loop ──────────────────────────────────────────────────────────
@@ -194,6 +201,59 @@ assert_ok "cleanup" "$BIN" cleanup -w "$WORKSPACE"
 # error paths
 assert_fail "init nonexistent" "$BIN" init -w /nonexistent/path/should/fail
 assert_fail "checkpoint without init" "$BIN" checkpoint -w /tmp -i bad
+
+# ── detached registration (issue #3059 regression) ────────────────────────────
+# The workspace symlink is externally deleted and the path recreated as a
+# plain directory. Every path-addressed operation must fail loudly (pointing
+# at recover) instead of snapshotting the stale subvolume, and the user's
+# replacement directory must stay untouched.
+
+DETACHED="$TMPBASE/detached-ws"
+mkdir -p "$DETACHED"
+echo "seed" > "$DETACHED/seed.txt"
+assert_ok "detached: init workspace" "$BIN" init -w "$DETACHED"
+assert_ok "detached: pre-detach checkpoint" "$BIN" checkpoint -w "$DETACHED" -i pre-detach
+
+# External removal of the symlink + plain-directory replacement.
+rm -rf "$DETACHED"
+mkdir -p "$DETACHED"
+echo "user-data" > "$DETACHED/f.txt"
+
+assert_fail "detached: checkpoint refuses" "$BIN" checkpoint -w "$DETACHED" -i post-detach
+assert_output_contains "detached: checkpoint error points at recover" "ws-ckpt recover" \
+    "$BIN" checkpoint -w "$DETACHED" -i post-detach
+assert_fail "detached: rollback refuses" "$BIN" rollback -w "$DETACHED" -s pre-detach
+assert_fail "detached: list refuses" "$BIN" list -w "$DETACHED"
+
+DETACHED_CONTENT=$(cat "$DETACHED/f.txt")
+if [ "$DETACHED_CONTENT" = "user-data" ]; then
+    echo "  PASS  detached: refused ops leave user directory untouched"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL  detached: user directory changed: '$DETACHED_CONTENT'"
+    FAIL=$((FAIL + 1))
+fi
+
+# ── recover --all exit code (issue #3059 follow-up, links #3069) ──────────────
+# One healthy workspace ($WORKSPACE) plus one detached registration
+# ($DETACHED): the batch must exit non-zero and report the failure instead
+# of printing "All workspaces recovered." while the detached workspace was
+# never actually repaired.
+
+# NOTE: order matters — the output assertion must run first: each invocation
+# recovers the healthy workspace, so a second run would see 1/1 instead of 1/2.
+assert_output_contains "recover --all reports failed count" "Recover failed for 1/2" \
+    "$BIN" recover --all --force
+assert_fail "recover --all nonzero when a workspace fails" "$BIN" recover --all --force
+# The healthy workspace was still recovered by the batch: plain directory again.
+if [ -d "$WORKSPACE" ] && [ ! -L "$WORKSPACE" ]; then
+    echo "  PASS  recover --all still recovers healthy workspaces"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL  recover --all left healthy workspace as symlink"
+    FAIL=$((FAIL + 1))
+fi
+
 
 # ── summary ───────────────────────────────────────────────────────────────────
 

--- a/src/ws-ckpt/ws-ckpt.spec.in
+++ b/src/ws-ckpt/ws-ckpt.spec.in
@@ -112,10 +112,21 @@ echo "Run 'ws-ckpt --help' for usage."
 
 %preun
 if [ $1 -eq 0 ]; then
-    # Recover workspaces before stopping the daemon
+    # Recover workspaces before stopping the daemon. A sentinel file carries
+    # the outcome to %postun: when recover fails (e.g. a detached registration
+    # whose snapshots may be the only copy of the data), %postun must NOT wipe
+    # /var/lib/ws-ckpt — that would destroy exactly the data recover refused
+    # to touch. The sentinel lives in /run (tmpfs) so it never survives a
+    # reinstall or leaks into the package's file list.
+    rm -f /run/ws-ckpt-recover-failed
     if [ -x %{_localbindir}/ws-ckpt ]; then
-        %{_localbindir}/ws-ckpt recover --all --force 2>&1 || \
-            echo "WARNING: recover workspaces failed"
+        if ! %{_localbindir}/ws-ckpt recover --all --force; then
+            echo "WARNING: ws-ckpt recover --all failed; preserving /var/lib/ws-ckpt"
+            echo "         (and /data/ws-ckpt if present) for manual inspection."
+            echo "         Reinstall ws-ckpt or inspect the snapshots manually"
+            echo "         before deleting the state directories."
+            : > /run/ws-ckpt-recover-failed
+        fi
     fi
     systemctl stop ws-ckpt.service 2>/dev/null || true
     systemctl disable ws-ckpt.service 2>/dev/null || true
@@ -132,8 +143,18 @@ if [ $1 -eq 0 ]; then
             cut -d: -f1 | xargs -r losetup -d 2>/dev/null || true
     done
     rmdir /mnt/btrfs-workspace 2>/dev/null || true
-    # Remove daemon runtime state to avoid stale state on reinstall
-    rm -rf /var/lib/ws-ckpt /data/ws-ckpt 2>/dev/null || true
+    # Skip the state wipe when %preun's recover failed: the loop image and
+    # state directories may hold the only remaining copies of workspace data
+    # (issue #3069). Loop devices were already detached above, so the files
+    # are merely left on disk for manual recovery.
+    if [ -e /run/ws-ckpt-recover-failed ]; then
+        echo "NOTE: preserving /var/lib/ws-ckpt (recover failed in %preun)."
+        echo "      Remove it manually once the data is no longer needed."
+    else
+        # Remove daemon runtime state to avoid stale state on reinstall
+        rm -rf /var/lib/ws-ckpt /data/ws-ckpt 2>/dev/null || true
+    fi
+    rm -f /run/ws-ckpt-recover-failed
     systemctl daemon-reload
 fi
 


### PR DESCRIPTION
## Description

A workspace whose symlink was externally deleted and replaced by a plain directory (`rm -rf $W; mkdir $W` — user cleanup, CI fixtures, backup restores, or a tmpfs workspace after one reboot) used to pass **every** V1 path-addressed operation with rc=0: `resolve_workspace` trusts the stale registry binding, so checkpoints snapshot the empty old subvolume (capturing none of the user's data) and rollbacks swap subvolumes the user's directory never points at. `init` already refuses this state (#694 guard); nothing else did. The same silent-failure pattern then extended through the CLI batch recover and the RPM uninstall scriptlets into permanent data loss.

Three commits, each fixing one layer of the chain:

1. **`fix(ckpt): fail fast on detached workspace`** — Promotes the V2 guarded protocol's liveness check into `DaemonState::registration_is_live` (canonicalize-equality, so bind-mount/symlink-chain topologies stay supported) and enforces it at all eight V1 entry points (checkpoint, rollback, rollback-preview, list, diff, cleanup, delete, single-ws status) via `detached_registration_error`, returning init's same actionable error (run `recover`, then re-init) with a data-loss note for the regular-directory case. `recover` stays unguarded (it is the repair path); global status stays unguarded so `recover --all` can still enumerate; scheduler auto-cleanup bypasses via `delete_snapshots_locked` and keeps working. V2 calls the shared method (dedup).
2. **`fix(ckpt): recover --all nonzero on failure`** — Batch recover used to print "All workspaces recovered." and exit 0 even when items failed, so the remediation init recommends "succeeded" without fixing anything. Now aggregates failures, prints a failed-count summary, exits 1. e2e.sh gains the #3059 repro as a regression section plus `WS_CKPT_E2E_BIN` for reruns against a prebuilt binary.
3. **`fix(ckpt): keep state when recover fails on erase`** — Closes #3069's data-destruction path: `%preun` used to swallow recover's exit code (`2>&1 || echo`) and `%postun` then unconditionally wiped `/var/lib/ws-ckpt`, destroying the btrfs loop image holding the only remaining snapshot copies — with `rpm -e` exiting 0 throughout. A sentinel file in `/run` (tmpfs: never survives a reboot, never enters the file list) now carries the recover outcome from `%preun` to `%postun`, which skips the state wipe and tells the operator what was preserved. Loop devices are still detached (nothing left mounted). `make uninstall` gets the same treatment; the sentinel also spans its separate recipe lines (each a fresh shell).

## Related Issue

Fixes #3059
Fixes #3069

## Risk and compatibility

- No protocol/schema changes; V2 guarded checkpoint behavior is byte-identical (only the liveness check is deduplicated into `DaemonState`).
- Single-ws `status -w` and `list -w` now error on detached registrations instead of reporting stale snapshot counts — intentional per the issue's expected behavior; `status` (global) keeps listing them so `recover --all` still works.
- Sidecar/bind-mount topologies verified unaffected by canonicalize-equality (checked against init's mount_path adoption logic).
- Uninstall behavior change: when recover fails, `rpm -e`/`make uninstall` now leave `/var/lib/ws-ckpt` (loop image + state) on disk with a NOTE instead of deleting it. This is deliberate data preservation; operators remove it manually once the data is no longer needed.
- Daemon unit tests migrated from fake-path fixtures to real symlink-on-tempdir topology (the guard correctly rejects nonexistent fake paths).
- RPM scriptlet logic validated by shell-level simulation (sentinel set on failure → state preserved; no sentinel on success → normal cleanup); full `rpm -e` end-to-end still recommended on a test host before release.

## Validation

- `cargo fmt --all -- --check` ✅, `cargo clippy --workspace --all-targets --locked -- -D warnings` ✅, `cargo test --workspace --locked` ✅ (487 passed / 0 failed / 6 pre-existing env-gated ignored) — in a Linux build container (host has no Rust toolchain).
- New unit tests: all three detach modes (plain dir, missing path, repointed symlink) × every guarded op, healthy-path pass-through, ws_id-addressed guard application, dispatch-level checkpoint/status/global-status.
- e2e.sh in a privileged container (btrfs-loop): **25/25 passed**, including the 7-step issue repro — both checkpoints and rollback now exit 1 with the recover hint, no ghost empty snapshots, user directory untouched; healthy workspace full cycle unaffected; `recover --all` over one healthy + one detached workspace exits 1 with the failed-count summary.
- Rebased onto current `main` (2f66720c) before opening; commits are independent and each compiles.

## Documentation and rollback

- No user-facing docs changes: the new errors reuse init's existing #694 wording users already see; the RPM NOTE is self-explanatory in the uninstall output.
- Rollback: revert all three commits; no on-disk format or state migration involved.