### PR TITLE
fix(ckpt): gate OpenClaw capability consent

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -991,6 +991,10 @@ jobs:
           cd src/ws-ckpt/src
           cargo test --workspace
 
+      - name: Run openclaw install script tests
+        working-directory: src/ws-ckpt
+        run: make test-openclaw-install
+
       # ── Rust coverage gate ──────────────────────────────────────────────
       - name: Rust coverage gate (≥45%)
         run: |

--- a/src/ws-ckpt/Makefile
+++ b/src/ws-ckpt/Makefile
@@ -24,7 +24,7 @@ PLUGINS_DIR ?= $(RUNTIME_DIR)/ws-ckpt/plugins
 SYSTEMD_SYSTEM_DIR ?= $(LIBDIR)/systemd/system
 CONFIG_DIR ?= $(SYSCONFDIR)/ws-ckpt
 
-.PHONY: build install uninstall clean test help
+.PHONY: build install uninstall clean test test-openclaw-install help
 
 build:
 	cd src && cargo build --release --workspace
@@ -140,9 +140,13 @@ clean:
 
 test:
 	cd src && cargo test --workspace
+	$(MAKE) test-openclaw-install
+
+test-openclaw-install:
+	bash tests/openclaw-install.sh
 
 help:
-	@echo "Targets: build install uninstall clean test"
+	@echo "Targets: build install uninstall clean test test-openclaw-install"
 	@echo "Variables:"
 	@echo "  INSTALL_PROFILE=user|system"
 	@echo "  DESTDIR= staging root for packages"

--- a/src/ws-ckpt/scripts/openclaw/install-openclaw.sh
+++ b/src/ws-ckpt/scripts/openclaw/install-openclaw.sh
@@ -13,6 +13,13 @@ OPENCLAW_BIN="${OPENCLAW_BIN:-openclaw}"
 DRY_RUN="${ANOLISA_DRY_RUN:-0}"
 SKILL_DST="${OPENCLAW_STATE_DIR%/}/skills/ws-ckpt"
 
+help_lists_flag() {
+    local help_text="$1"
+    local flag="$2"
+
+    grep -Eq "(^|[^[:alnum:]_.-])${flag}([^[:alnum:]_.-]|$)" <<<"$help_text"
+}
+
 # 1. Check openclaw availability. Dry-run should not require the CLI.
 if [ "$DRY_RUN" != "1" ] && ! command -v "$OPENCLAW_BIN" &>/dev/null; then
     echo "ERROR: openclaw is not installed, please install openclaw first"
@@ -22,11 +29,22 @@ fi
 # 2. Try plugin install (preferred).
 if PLUGIN_SRC=$(find_plugin_src openclaw); then
     if [ "$DRY_RUN" = "1" ]; then
-        echo "DRY-RUN: env -u OPENCLAW_HOME OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR $OPENCLAW_BIN plugins install $PLUGIN_SRC --force"
+        echo "DRY-RUN: probe '$OPENCLAW_BIN plugins install --help' for --accept-capabilities"
+        echo "DRY-RUN: env -u OPENCLAW_HOME OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR $OPENCLAW_BIN plugins install $PLUGIN_SRC --force [--accept-capabilities when supported]"
         echo "DRY-RUN: env -u OPENCLAW_HOME OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR $OPENCLAW_BIN plugins enable ws-ckpt"
         exit 0
     fi
-    env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins install "$PLUGIN_SRC" --force
+
+    install_args=(plugins install "$PLUGIN_SRC" --force)
+    install_help=""
+    if install_help="$(env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" \
+        "$OPENCLAW_BIN" plugins install --help 2>/dev/null)" \
+        && help_lists_flag "$install_help" "--accept-capabilities"; then
+        install_args+=(--accept-capabilities)
+    fi
+
+    env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" \
+        "$OPENCLAW_BIN" "${install_args[@]}"
     env -u OPENCLAW_HOME OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" "$OPENCLAW_BIN" plugins enable ws-ckpt 2>/dev/null || true
     echo "openclaw ws-ckpt plugin installed and enabled successfully (from $PLUGIN_SRC)"
     exit 0

--- a/src/ws-ckpt/tests/openclaw-install.sh
+++ b/src/ws-ckpt/tests/openclaw-install.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Behavioral tests for scripts/openclaw/install-openclaw.sh capability gating.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALL_SCRIPT="$PROJECT_ROOT/scripts/openclaw/install-openclaw.sh"
+REPO_ROOT="$(cd "$PROJECT_ROOT/../.." && pwd)"
+PLUGIN_SRC="$PROJECT_ROOT/src/plugins/openclaw"
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+FAKE_OPENCLAW="$TMPDIR_TEST/openclaw"
+ARGV_LOG="$TMPDIR_TEST/argv.log"
+
+# A staged runtime dir that really exists: a leaked ANOLISA_TARGET_DIR makes
+# plugin discovery resolve here, so the install-path assertion fails loudly.
+FAKE_TARGET_DIR="$TMPDIR_TEST/staged-target"
+mkdir -p "$FAKE_TARGET_DIR/share/anolisa/runtime/ws-ckpt/plugins/openclaw"
+
+# Hostile ambient values every run_case must strip. DRY_RUN=1 would divert the
+# installer to its dry-run branch and leave the argv log empty.
+export ANOLISA_DRY_RUN=1
+export ANOLISA_TARGET_DIR="$FAKE_TARGET_DIR"
+
+cat >"$FAKE_OPENCLAW" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$ARGV_LOG"
+
+if [ "$*" = "plugins install --help" ]; then
+    case "${INSTALL_HELP_MODE:-modern}" in
+        modern) printf '%s\n' 'Usage: openclaw plugins install [--force] [--accept-capabilities]' ;;
+        legacy) printf '%s\n' 'Usage: openclaw plugins install [--force]' ;;
+        near-miss) printf '%s\n' 'Usage: openclaw plugins install [--accept-capabilities-only]' ;;
+        failure) exit 2 ;;
+    esac
+fi
+exit 0
+EOF
+chmod +x "$FAKE_OPENCLAW"
+
+run_case() {
+    local mode="$1"
+    : >"$ARGV_LOG"
+    env -u ANOLISA_DRY_RUN -u ANOLISA_TARGET_DIR \
+        ARGV_LOG="$ARGV_LOG" \
+        INSTALL_HELP_MODE="$mode" \
+        OPENCLAW_BIN="$FAKE_OPENCLAW" \
+        OPENCLAW_STATE_DIR="$TMPDIR_TEST/state" \
+        ANOLISA_PROJECT_ROOT="$REPO_ROOT" \
+        "$INSTALL_SCRIPT" >/dev/null
+}
+
+# The installer must invoke openclaw exactly three times, in order: capability
+# probe, plugin install, plugin enable. Exact-line comparison catches a
+# missing, trailing, or duplicated --accept-capabilities token and any extra
+# or repeated install call.
+assert_install() {
+    local with_flag="$1"  # "flag" or "noflag"
+    mapfile -t calls <"$ARGV_LOG"
+
+    if [ "${#calls[@]}" -ne 3 ]; then
+        echo "FAIL: expected 3 openclaw invocations (probe/install/enable), got ${#calls[@]}:" >&2
+        printf '  %s\n' "${calls[@]}" >&2
+        exit 1
+    fi
+    if [ "${calls[0]}" != "plugins install --help" ]; then
+        echo "FAIL: unexpected probe call: ${calls[0]}" >&2
+        exit 1
+    fi
+    if [ "${calls[2]}" != "plugins enable ws-ckpt" ]; then
+        echo "FAIL: unexpected enable call: ${calls[2]}" >&2
+        exit 1
+    fi
+
+    local expected="plugins install $PLUGIN_SRC --force"
+    if [ "$with_flag" = "flag" ]; then
+        expected="$expected --accept-capabilities"
+    fi
+    if [ "${calls[1]}" != "$expected" ]; then
+        echo "FAIL: install invocation mismatch" >&2
+        echo "  expected: $expected" >&2
+        echo "  actual:   ${calls[1]}" >&2
+        exit 1
+    fi
+}
+
+run_case modern
+assert_install flag
+
+for mode in legacy near-miss failure; do
+    run_case "$mode"
+    assert_install noflag
+done
+
+echo "OpenClaw install script tests passed"


### PR DESCRIPTION
## Why

Fixes #3116

OpenClaw 2026.9.2 引入 capability-consent 门禁：从本地路径安装声明了 capability 的插件时，不传 `--accept-capabilities` 直接 rc=1（`Plugin "ws-ckpt" requires capability consent`）。`install-openclaw.sh` 只传了 `--force`，导致 `ws-ckpt plugin install --runtime openclaw` 在 2026.9.2 主机上失败，`/root/.openclaw/extensions/ws-ckpt` 不落地。

## What changed

- 安装前探测 `openclaw plugins install --help`，仅在当前 CLI 广告 `--accept-capabilities` 时追加该 flag（token 边界匹配，`--accept-capabilities-only` 等近似名不会误命中）。
- 探测失败或无输出不致命：回落到原有 argv（即探测机制引入前的行为）。
- 旧版 OpenClaw（< 2026.9.1）保持原 argv 不变——未注册的 flag 会被 commander 直接 `error: unknown option` 并 exit 1，无条件追加会把「能装」变「必失败」（版本矩阵证据见 #3100 的上游核对：该 flag 自 2026.9.1 起才注册进 `plugins install` 并出现在 docs，2026.4.14–2026.8.2 各版本均无）。
- DRY-RUN echo 同步更新探测语义。
- 新增 `tests/openclaw-install.sh` fake-CLI 契约测试（modern / legacy / near-miss / probe-failure 四条路径），接入 `make test-openclaw-install`，并由 `make test` 串跑。

本 PR 取代 #3117：修复目标相同，但 #3117 无条件追加 flag，会让项目仍声明支持的旧版 OpenClaw 安装硬失败。

## Related issue

Fixes #3116
Closes #3117 (superseded)

## User / Agent impact

OpenClaw 2026.9.1+ 主机上 `ws-ckpt plugin install --runtime openclaw` 恢复成功（rc=0，插件目录落地）；旧版主机行为不变。

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed — ws-ckpt OpenClaw 插件安装 argv 有条件追加 `--accept-capabilities`（按 CLI 能力探测门控）；对不广告该 flag 的 CLI，argv 与改动前逐字一致。
- [ ] Migration or rollback guidance is needed

注：`--accept-capabilities` 意味着非交互式接受 capability 授权；若运维策略要求显式人工同意，可直接 revert 本 commit（见下）。

## Validation

- `make -C src/ws-ckpt test-openclaw-install` → pass（4/4：modern 加 flag、legacy 不加、near-miss 不误判、探测失败非致命回落）。
- 探测前提的上游证据（#3100 对 `openclaw@2026.9.2` 发布包的静态核对）：`--accept-capabilities` 在 `plugins install` 上自 2026.9.1 注册；旧版 commander 对未注册选项报 `error: unknown option` 并 exit 1。
- 已知限制：CI 的 `test-ws-ckpt` job 直接跑 `cargo test --workspace`，不经 `make test`，本 shell 契约测试暂不会在 CI 自动执行（与 #3100 遇到的接线问题相同，改 workflow 需 `workflow` scope 单独补）。

## Documentation and rollback

无需文档变更。回滚：revert 本 commit 即恢复改动前的无条件 argv 行为。