### PR TITLE
fix(cosh-ng): route null suppression by channel

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk.rs
@@ -1,4 +1,4 @@
-use super::broker::can_run_approved_bash_tool;
+use super::broker::{can_run_approved_bash_tool, configured_readonly_command};
 use super::command_risk_build::{
     apply_null_redirection_policy, assessment, basename, command_requires_tty, dedupe_reasons,
     downloaded_program_file, has_interpreter_inline_code, has_tty_arg, high_risk_program,
@@ -79,8 +79,11 @@ pub fn assess_shell_command(command: &str, policy: AssessmentPolicy) -> CommandA
         return high_shell_syntax(policy.source, command, parsed.shape, "redirection-write");
     }
 
-    let null_redirections = parsed.null_redirections;
-    if null_redirections > 0 && parsed.shape == CommandShape::Complex {
+    // Extracted before the shape match moves `parsed` into the
+    // per-shape assessment paths.
+    let has_null_redirections = !parsed.null_redirections.is_empty();
+    let null_redirections_stderr_only = parsed.null_redirections_stderr_only();
+    if has_null_redirections && parsed.shape == CommandShape::Complex {
         // Subshells, brace groups, and background syntax cannot be
         // reliably segmented; keep the pre-fix fail-closed classification
         // for redirection-carrying complex commands.
@@ -130,8 +133,8 @@ pub fn assess_shell_command(command: &str, policy: AssessmentPolicy) -> CommandA
             | CommandShape::RedirectionWrite => unreachable!("handled above"),
         }
     };
-    if null_redirections > 0 {
-        apply_null_redirection_policy(&mut result);
+    if has_null_redirections {
+        apply_null_redirection_policy(&mut result, null_redirections_stderr_only);
     }
     result
 }
@@ -229,7 +232,9 @@ pub(super) fn assess_simple_command(
     }
 
     let mut stage = stage_assessment(&program, command_tokens);
-    if let Some(readonly) = direct_readonly_evidence(command) {
+    if let Some(readonly) = direct_readonly_evidence(command)
+        .or_else(|| stderr_suppressed_readonly_evidence(&parsed, &tokens))
+    {
         stage.impact = RiskImpact::Low;
         stage.confidence = AssessmentConfidence::High;
         stage.reasons.insert(0, readonly.reason_code());
@@ -270,6 +275,25 @@ fn direct_readonly_evidence(command: &str) -> Option<ReadonlyEvidence> {
         .then_some(ReadonlyEvidence::DirectReadonlyBroker)
 }
 
+/// Issue #1752 Layer 2: re-opens the direct-readonly evidence channel
+/// for a command whose only stripped null redirections suppress stderr
+/// (fd 2). The text-based broker gate above rejects the raw command
+/// because it carries `2>`, so eligibility is re-checked on the parser's
+/// stripped argv — what the real shell executes after quote removal,
+/// plus a stderr suppression that cannot add side effects. The full
+/// stage tokens (including env-assignment prefixes) are checked,
+/// matching the text gate, which also rejects them.
+fn stderr_suppressed_readonly_evidence(
+    parsed: &ParsedCommand,
+    tokens: &[String],
+) -> Option<ReadonlyEvidence> {
+    if parsed.null_redirections_stderr_only() && configured_readonly_command(tokens) {
+        Some(ReadonlyEvidence::DirectReadonlyBroker)
+    } else {
+        None
+    }
+}
+
 fn assess_first_stage(
     command: &str,
     parsed: &ParsedCommand,
@@ -282,7 +306,7 @@ fn assess_first_stage(
             CommandShape::Simple
         },
         stages: parsed.stages.first().cloned().into_iter().collect(),
-        null_redirections: 0,
+        null_redirections: Vec::new(),
         segments: Vec::new(),
         segment_connectors: Vec::new(),
     };

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_build.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_build.rs
@@ -505,16 +505,28 @@ pub(super) fn basename(program: &str) -> &str {
 
 /// Post-processing for assessments whose command carried stripped
 /// null-suppression redirections (issue #1667): append the informational
-/// reason and keep the execution boundary unchanged. Risk itself is fully
-/// decided by the shape/segment assessment paths.
+/// reason, then split by suppressed channel (issue #1752 Layer 2).
+/// Risk itself is fully decided by the shape/segment assessment paths.
 ///
-/// Note (issue #1752): this policy deliberately keeps null-redirection
-/// commands at AskUser — the issue's auto-approve request was not granted
-/// by that fix; adjusting the Layer 2 suppression policy is a separate
-/// discussion, see #1752.
-pub(super) fn apply_null_redirection_policy(result: &mut CommandAssessment) {
+/// Stderr-only suppression (`2>/dev/null`, `2>>/dev/null`, `2>&-`)
+/// keeps the assessment untouched: the suppressed stream is diagnostic
+/// noise, while the stdout evidence chain — transcript output and audit
+/// trail — stays complete, so an auto-allow verdict and its evidence
+/// remain valid.
+///
+/// Any stdout-side suppression (the default `>`, `1>`, auxiliary fds,
+/// fd-closes that silence stdout, and mixed forms) keeps the AskUser
+/// boundary: after auto-execution the transcript would record no
+/// reviewable output for the command, so the verdict is downgraded and
+/// the auto-allow evidence cleared. This stays defensive even though
+/// the evidence paths already withhold evidence for stdout-suppressed
+/// commands: any future grant is still clamped here.
+pub(super) fn apply_null_redirection_policy(result: &mut CommandAssessment, stderr_only: bool) {
     result.reasons.push("output-suppressed");
     result.reasons = dedupe_reasons(std::mem::take(&mut result.reasons));
+    if stderr_only {
+        return;
+    }
     if result.execution == ExecutionDecision::AutoAllow {
         result.execution = ExecutionDecision::AskUser;
     }

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_compound.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_compound.rs
@@ -76,7 +76,7 @@ pub(super) fn assess_stripped_compound(
                 CommandShape::Simple
             },
             stages: segment.clone(),
-            null_redirections: 0,
+            null_redirections: Vec::new(),
             segments: Vec::new(),
             segment_connectors: Vec::new(),
         };

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_parser.rs
@@ -17,7 +17,37 @@ use super::command_risk::CommandShape;
 /// RedirectionWrite high-risk path. Extending this table requires
 /// revisiting the issue #1667 boundaries and the decision-matrix tests
 /// in `command_risk_tests.rs`.
+///
+/// Stripped sink redirections are additionally classified by suppressed
+/// channel (issue #1752 Layer 2): stderr-only suppression (fd 2) keeps
+/// the auto-allow verdict, stdout-side suppression stays at AskUser —
+/// see [`NullRedirectionChannel`].
 const SAFE_OUTPUT_SINKS: &[&str] = &["/dev/null"];
+
+/// Output channel suppressed by a stripped null-suppression redirection
+/// (issue #1752 Layer 2). `Stderr` (fd 2 only) leaves the stdout evidence
+/// chain — transcript output and audit trail — intact, so such commands
+/// may keep an auto-allow verdict. `Stdout` covers every other channel:
+/// the default stdout fd, fd 1, auxiliary fds, and fd-closes that silence
+/// stdout; the transcript-recorded output is gone or uncertain there, so
+/// those commands stay at AskUser.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NullRedirectionChannel {
+    Stderr,
+    Stdout,
+}
+
+/// Classifies a stripped null-suppression redirection by its fd word:
+/// fd 2 suppresses stderr only; the default (stdout), fd 1, and any
+/// other numeric fd suppress or leave uncertain the recorded stdout
+/// evidence, so they take the conservative Stdout channel.
+fn null_redirection_channel(fd_candidate: bool, token: &str) -> NullRedirectionChannel {
+    if fd_candidate && token == "2" {
+        NullRedirectionChannel::Stderr
+    } else {
+        NullRedirectionChannel::Stdout
+    }
+}
 
 /// Segment separator kind recorded at each `&&`/`||`/`;`/newline break.
 /// A single `&` also records a mark (background list separator) but the
@@ -34,7 +64,10 @@ pub(crate) enum SegmentConnector {
 pub(super) struct ParsedCommand {
     pub(super) shape: CommandShape,
     pub(super) stages: Vec<Vec<String>>,
-    pub(super) null_redirections: usize,
+    /// Every null-suppression redirection stripped while parsing, in
+    /// source order, classified by suppressed channel (issue #1752
+    /// Layer 2). Empty when none were stripped.
+    pub(super) null_redirections: Vec<NullRedirectionChannel>,
     /// Command segments split at `&&`, `||`, `;`, and newlines; each
     /// segment holds its own pipeline stages. Only populated when the
     /// command contains segment separators (used by the stripped-compound
@@ -48,12 +81,26 @@ pub(super) struct ParsedCommand {
     pub(super) segment_connectors: Vec<SegmentConnector>,
 }
 
+impl ParsedCommand {
+    /// Returns true when at least one null-suppression redirection was
+    /// stripped and every one of them suppressed stderr only (fd 2):
+    /// the stdout evidence chain stays complete, so the assessment may
+    /// keep its auto-allow verdict and evidence (issue #1752 Layer 2).
+    pub(super) fn null_redirections_stderr_only(&self) -> bool {
+        !self.null_redirections.is_empty()
+            && self
+                .null_redirections
+                .iter()
+                .all(|channel| matches!(channel, NullRedirectionChannel::Stderr))
+    }
+}
+
 pub(super) fn parse_command(command: &str) -> ParsedCommand {
     if command.is_empty() {
         return ParsedCommand {
             shape: CommandShape::Empty,
             stages: Vec::new(),
-            null_redirections: 0,
+            null_redirections: Vec::new(),
             segments: Vec::new(),
             segment_connectors: Vec::new(),
         };
@@ -62,7 +109,7 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
         return ParsedCommand {
             shape: CommandShape::Unparseable,
             stages: Vec::new(),
-            null_redirections: 0,
+            null_redirections: Vec::new(),
             segments: Vec::new(),
             segment_connectors: Vec::new(),
         };
@@ -73,7 +120,7 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
     let mut stages: Vec<Vec<String>> = Vec::new();
     let mut shape = CommandShape::Simple;
     let mut quote: Option<char> = None;
-    let mut null_redirections = 0usize;
+    let mut null_redirections: Vec<NullRedirectionChannel> = Vec::new();
     let mut amp_redirect_guard = false;
     // Segment breaks recorded as (stage index, token offset, connector)
     // at each `&&`/`||`/`;`/newline, resolved into `segments` after
@@ -231,17 +278,18 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
                         // stay annotation-free like duplications.
                         let closes_output_stream =
                             has_dash && (!fd_candidate || token == "1" || token == "2");
+                        // Output-closing forms join the issue #1667
+                        // null-sink channel (`output-suppressed` reason +
+                        // auto-allow fallback). The fd word is classified
+                        // before it is cleared from the token buffer.
+                        if closes_output_stream {
+                            null_redirections.push(null_redirection_channel(fd_candidate, &token));
+                        }
                         if fd_candidate {
                             // The IO_NUMBER prefix (the `2` in `2>&1`)
                             // belongs to the redirection syntax, not argv.
                             token.clear();
                             token_quoted = false;
-                        }
-                        // Output-closing forms join the issue #1667
-                        // null-sink channel (`output-suppressed` reason +
-                        // auto-allow fallback).
-                        if closes_output_stream {
-                            null_redirections += 1;
                         }
                         continue;
                     }
@@ -322,6 +370,8 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
                                     )
                                 });
                             if word_ends && SAFE_OUTPUT_SINKS.contains(&quoted_target.as_str()) {
+                                null_redirections
+                                    .push(null_redirection_channel(fd_candidate, &token));
                                 if fd_candidate {
                                     token.clear();
                                     token_quoted = false;
@@ -329,7 +379,6 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
                                 for _ in 0..consumed + quoted_consumed {
                                     chars.next();
                                 }
-                                null_redirections += 1;
                                 continue;
                             }
                         }
@@ -353,6 +402,7 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
                     consumed += 1;
                 }
                 if !guarded && literal && SAFE_OUTPUT_SINKS.contains(&target.as_str()) {
+                    null_redirections.push(null_redirection_channel(fd_candidate, &token));
                     if fd_candidate {
                         token.clear();
                         token_quoted = false;
@@ -360,7 +410,6 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
                     for _ in 0..consumed {
                         chars.next();
                     }
-                    null_redirections += 1;
                 } else {
                     if fd_candidate {
                         push_token(&mut tokens, &mut token, &mut token_quoted);
@@ -402,7 +451,7 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
         return ParsedCommand {
             shape: CommandShape::Unparseable,
             stages: Vec::new(),
-            null_redirections: 0,
+            null_redirections: Vec::new(),
             segments: Vec::new(),
             segment_connectors: Vec::new(),
         };

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_quoted_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_quoted_tests.rs
@@ -6,8 +6,8 @@
 //! `--lib` target only, while `main.rs` does not declare it.
 
 use crate::tools::command_risk::{
-    assess_shell_command, AssessmentPolicy, AssessmentSource, CommandAssessment, ExecutionDecision,
-    RiskImpact,
+    assess_shell_command, AssessmentPolicy, AssessmentSource, AutoAllowEvidence, CommandAssessment,
+    ExecutionDecision, RiskImpact,
 };
 
 fn auto(command: &str) -> CommandAssessment {
@@ -63,11 +63,17 @@ fn quoted_safe_output_sink_redirection_is_null_suppression() {
     // target never enter argv; the sink is counted as a null
     // redirection) is pinned through its observable effects instead —
     // `output-suppressed` present proves the null-redirection count,
-    // and any argv leak would leave a plain auto-allowable command and
-    // flip the V-M10 boundary assertion below.
+    // and any argv leak would fail the readonly re-check on the
+    // stripped argv and drop the Layer 2 auto-allow asserted below.
+    // Issue #1752 Layer 2: a wholly-quoted stderr-only sink joins the
+    // unquoted stderr channel — the auto-allow boundary re-opens with
+    // broker evidence rebuilt on the stripped argv.
     let auto_policy = auto("ps aux 2>\"/dev/null\"");
-    assert_eq!(auto_policy.execution, ExecutionDecision::AskUser);
-    assert!(auto_policy.auto_allow.is_none());
+    assert_eq!(auto_policy.execution, ExecutionDecision::AutoAllow);
+    assert_eq!(
+        auto_policy.auto_allow,
+        Some(AutoAllowEvidence::DirectReadonlyBroker)
+    );
 }
 
 #[test]
@@ -95,4 +101,89 @@ fn quoted_non_sink_redirection_targets_stay_fail_closed() {
             assessment.reasons
         );
     }
+}
+
+#[test]
+fn null_suppression_routes_the_auto_allow_boundary_by_channel() {
+    // Issue #1752 Layer 2 decision table: suppression routes by the
+    // channel it suppresses instead of a blanket boundary. Forms whose
+    // null redirections only touch stderr (fd 2) keep the stdout
+    // evidence chain observable — the transcript still carries what
+    // the command printed — so the auto-allow boundary re-opens for
+    // them, with broker evidence rebuilt on the parser's stripped argv
+    // (never a silent auto-allow without evidence).
+    for command in [
+        "ps aux 2>/dev/null",
+        "ps aux 2>>/dev/null",
+        "ps aux 2> /dev/null",
+        "ps aux 2>\"/dev/null\"",
+        "ps aux 2>'/dev/null'",
+        "find /tmp -maxdepth 3 -name '*cosh*' 2>/dev/null",
+        "du -sh /var 2> /dev/null",
+    ] {
+        let auto_policy = auto(command);
+        assert_eq!(
+            auto_policy.execution,
+            ExecutionDecision::AutoAllow,
+            "{command}"
+        );
+        assert_eq!(
+            auto_policy.auto_allow,
+            Some(AutoAllowEvidence::DirectReadonlyBroker),
+            "{command}"
+        );
+        assert!(
+            auto_policy.reasons.contains(&"output-suppressed"),
+            "{command}: {:?}",
+            auto_policy.reasons
+        );
+    }
+
+    // Forms that suppress stdout — the bare default, fd 1, or a mixed
+    // stderr+stdout suppression — leave the transcript with nothing to
+    // review, so the execution boundary stays AskUser.
+    for command in [
+        "ls >/dev/null",
+        "ls>/dev/null",
+        "ls 1>/dev/null",
+        "ls 2>/dev/null >/dev/null",
+    ] {
+        let auto_policy = auto(command);
+        assert_eq!(
+            auto_policy.execution,
+            ExecutionDecision::AskUser,
+            "{command}"
+        );
+        assert!(auto_policy.auto_allow.is_none(), "{command}");
+        assert!(
+            auto_policy.reasons.contains(&"output-suppressed"),
+            "{command}: {:?}",
+            auto_policy.reasons
+        );
+    }
+
+    // `&>/dev/null` merges stderr into stdout before discarding both —
+    // the whole observable stream is gone — and keeps its fail-closed
+    // RedirectionWrite behavior (decision table: stay as-is).
+    let both_streams = ask("ls &>/dev/null");
+    assert_eq!(both_streams.impact, RiskImpact::High);
+    assert!(both_streams.reasons.contains(&"redirection-write"));
+
+    // fd duplication (`2>&1`) is not null suppression and keeps its
+    // existing assessment (decision table: stay as-is): not High, not
+    // annotated `output-suppressed`, and still gated to AskUser under
+    // an auto policy because the text broker gate rejects `>`.
+    let dup = ask("ls 2>&1");
+    assert_ne!(dup.impact, RiskImpact::High);
+    assert!(!dup.reasons.contains(&"output-suppressed"));
+    let dup_auto = auto("ls 2>&1");
+    assert_eq!(dup_auto.execution, ExecutionDecision::AskUser);
+    assert!(dup_auto.auto_allow.is_none());
+
+    // Remaining command risk is never masked by the stderr channel:
+    // a high-risk program under stderr suppression stays High.
+    let delete = ask("rm -rf x 2>/dev/null");
+    assert_eq!(delete.impact, RiskImpact::High);
+    assert!(delete.reasons.contains(&"filesystem-delete"));
+    assert!(delete.reasons.contains(&"output-suppressed"));
 }

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
@@ -568,10 +568,18 @@ fn null_redirection_keeps_remaining_command_risk_and_boundaries() {
     assert!(delete.reasons.contains(&"filesystem-delete"));
     assert!(delete.reasons.contains(&"output-suppressed"));
 
-    // V-M10: the execution boundary is never widened.
+    // Issue #1752 Layer 2: stderr-only suppression keeps the stdout
+    // evidence chain observable, so the auto-allow boundary re-opens
+    // for it — with broker evidence rebuilt on the stripped argv, never
+    // a silent auto-allow without evidence.
     let auto_policy = auto("ps aux 2>/dev/null");
-    assert_eq!(auto_policy.execution, ExecutionDecision::AskUser);
-    assert!(auto_policy.auto_allow.is_none());
+    assert_eq!(auto_policy.execution, ExecutionDecision::AutoAllow);
+    assert_eq!(
+        auto_policy.auto_allow,
+        Some(AutoAllowEvidence::DirectReadonlyBroker)
+    );
+    assert!(auto_policy.reasons.contains(&"output-suppressed"));
+    assert!(auto_policy.reasons.contains(&"bounded-readonly"));
 }
 
 #[test]
@@ -1020,11 +1028,14 @@ fn fd_duplication_is_not_redirection_write() {
         );
     }
 
-    // V-F5: close
-    // forms that hit an output stream (bare default, fd 1, fd 2)
-    // suppress user-visible output, so they join the issue #1667
+    // V-F5: close forms that hit an output stream (bare default, fd 1,
+    // fd 2) suppress user-visible output, so they join the issue #1667
     // null-sink channel: still not a write, but annotated
-    // `output-suppressed` and never auto-allowed.
+    // `output-suppressed`. Issue #1752 Layer 2 then routes by channel:
+    // closing fd 2 only suppresses stderr and keeps the stdout evidence
+    // chain observable, so it re-opens the auto-allow boundary, while
+    // closing fd 1 or the bare default suppresses stdout and stays
+    // AskUser.
     for command in ["ls 2>&-", "ls 1>&-", "ls >&-"] {
         let assessment = ask(command);
         assert_ne!(assessment.impact, RiskImpact::High, "{command}");
@@ -1038,6 +1049,14 @@ fn fd_duplication_is_not_redirection_write() {
             "{command}: {:?}",
             assessment.reasons
         );
+    }
+    let stderr_close = auto("ls 2>&-");
+    assert_eq!(stderr_close.execution, ExecutionDecision::AutoAllow);
+    assert_eq!(
+        stderr_close.auto_allow,
+        Some(AutoAllowEvidence::DirectReadonlyBroker)
+    );
+    for command in ["ls 1>&-", "ls >&-"] {
         let auto_policy = auto(command);
         assert_eq!(
             auto_policy.execution,

--- a/src/cosh-ng/crates/cosh-shell/src/tools/readonly_compound.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/readonly_compound.rs
@@ -79,7 +79,7 @@ pub(crate) fn build_readonly_compound_plan(command: &str) -> Option<ReadonlyComp
     ) {
         return None;
     }
-    if parsed.null_redirections > 0 {
+    if !parsed.null_redirections.is_empty() {
         return None;
     }
     if parsed.segments.len() < 2 {


### PR DESCRIPTION
## Why

A readonly command carrying `2>/dev/null` (e.g. `find /tmp -maxdepth 3 -name '*cosh*' 2>/dev/null`) was blanket-downgraded to AskUser by the null-redirection execution boundary introduced in ab88c853: any null suppression, regardless of which stream it discarded, closed the auto-allow channel, so issue #1752 kept filing approval requests for benign diagnostics commands even after the Layer 1 classification fix (#2710). The maintainer decision in the issue comments is to route by the suppressed channel instead of a blanket boundary.

## What changed

- `command_risk_parser.rs`: `null_redirections` changes from a `usize` count to `Vec<NullRedirectionChannel>` (Stderr / Stdout); each stripped null redirection is classified at parse time from its fd word (`2>`, `2>>`, `2>&-` → Stderr; `>`, `1>`, bare default, `>&-` → Stdout). Channel classification happens in the parser, never guessed in the policy layer.
- `command_risk_build.rs`: `apply_null_redirection_policy` takes a `stderr_only` flag — when every suppression hits stderr it only annotates `output-suppressed` and keeps the assessment; otherwise the existing AskUser downgrade, evidence clearing, and defensive clamp stay.
- `command_risk.rs`: new `stderr_suppressed_readonly_evidence` rebuilds `DirectReadonlyBroker` evidence on the parser's stripped argv via `configured_readonly_command`, because the text-based broker gate rejects the raw command (`2>` carries `>`). Auto-allow always carries evidence — never a silent approval.
- Type-only adaptation in `command_risk_compound.rs` / `readonly_compound.rs`; the compound readonly plan still rejects every null redirection (stderr-only included), so that boundary is not widened.

Decision table (issue #1752):

| Form | Before | After |
|---|---|---|
| `2>/dev/null`, `2>>/dev/null`, quoted forms | AskUser | AutoAllow (evidence rebuilt on stripped argv) |
| `>/dev/null`, `1>/dev/null`, `ls>/dev/null`, mixed | AskUser | AskUser (unchanged) |
| `&>/dev/null`, `2>&1` | fail-closed High / fd-dup path | unchanged |
| `rm -rf x 2>/dev/null` | High | High (unchanged) |

## Related issue

fixes #1752

## User / Agent impact

Readonly commands whose only null suppression targets stderr are auto-approved again instead of raising an approval card; stdout-suppressing forms, `&>` and `2>&1` behave exactly as before.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The auto-allow execution boundary is security-sensitive: this widens it for stderr-only suppression. Guardrails kept: (1) auto-allow requires readonly-whitelist evidence rebuilt on the stripped argv, so no silent approvals; (2) changes are `pub(crate)`-internal, no public API change; (3) stdout-side, mixed, `&>` and fd-dup forms are unchanged; (4) the compound readonly executor still rejects all null redirections; (5) high-risk program verdicts are assessed before the evidence channel, so `rm -rf x 2>/dev/null` stays High.

## Validation

- `cargo fmt --all -- --check` — pass
- `cargo clippy -p cosh-shell --all-targets --locked -- -D warnings` — pass
- `cargo test -p cosh-shell --lib` — 1460 passed; 5 failures in `hooks::engine` are pre-existing on macOS (verified via `git stash`: same failures without this change)
- `cargo test -p cosh-shell --bins` — 2615 passed; 7 failures all in the hooks domain, pre-existing (same stash verification)
- command_risk suites: 45 + 3 tests (quoted lib-only module) all green, including the new decision-table matrix test `null_suppression_routes_the_auto_allow_boundary_by_channel`
- `./scripts/check-test-inventory.sh` — pass (`cosh-shell overlap: 696 (ceiling 696)`; new tests live in the lib-only `command_risk_quoted_tests` module)

## Documentation and rollback

CHANGELOG entry is generated at release time per the cosh-ng release process. Rollback: revert this single commit — no configuration, format, or persisted-state changes are involved.
