### PR TITLE
fix(ckpt): manage live config.toml via RPM

### DIFF
--- a/src/ws-ckpt/Makefile
+++ b/src/ws-ckpt/Makefile
@@ -71,6 +71,11 @@ else
 	install -d -m 0755 "$(DESTDIR)$(CONFIG_DIR)"
 	install -p -m 0644 src/config.toml.sample \
 		"$(DESTDIR)$(CONFIG_DIR)/config.toml.sample"
+	@# Mirror RPM %config(noreplace): never clobber an existing live config
+	@if [ ! -f "$(DESTDIR)$(CONFIG_DIR)/config.toml" ]; then \
+		install -p -m 0644 src/config.toml.sample \
+			"$(DESTDIR)$(CONFIG_DIR)/config.toml"; \
+	fi
 	@# 2. Post-install: reload+enable+restart daemon (skip when staging)
 	@if [ -z "$(DESTDIR)" ]; then \
 		systemctl daemon-reload; \
@@ -104,6 +109,16 @@ else
 	rm -rf "$(DESTDIR)$(PLUGINS_DIR)"
 	rm -f "$(DESTDIR)$(SYSTEMD_SYSTEM_DIR)/ws-ckpt.service"
 	rm -f "$(DESTDIR)$(CONFIG_DIR)/config.toml.sample"
+	@# Mirror RPM erase semantics for %config(noreplace): keep a backup only
+	@# when the live config was modified from the packaged default.
+	@if [ -f "$(DESTDIR)$(CONFIG_DIR)/config.toml" ]; then \
+		if cmp -s "$(DESTDIR)$(CONFIG_DIR)/config.toml" src/config.toml.sample; then \
+			rm -f "$(DESTDIR)$(CONFIG_DIR)/config.toml"; \
+		else \
+			mv "$(DESTDIR)$(CONFIG_DIR)/config.toml" \
+				"$(DESTDIR)$(CONFIG_DIR)/config.toml.rpmsave"; \
+		fi; \
+	fi
 	@# 3. Post-removal: cleanup BtrfsLoop backend (skip when staging)
 	@if [ -z "$(DESTDIR)" ]; then \
 		umount /mnt/btrfs-workspace 2>/dev/null || true; \

--- a/src/ws-ckpt/README.md
+++ b/src/ws-ckpt/README.md
@@ -23,7 +23,7 @@ Btrfs-based workspace snapshot system for AI Agents, providing sub-second checkp
 ws-ckpt/
 ├── src/                       # Rust Cargo workspace
 │   ├── Cargo.toml
-│   ├── config.toml.sample     # Config template (installed to /etc/ws-ckpt/)
+│   ├── config.toml.sample     # Default config (shipped as /etc/ws-ckpt/config.toml, %config(noreplace), plus .sample reference)
 │   ├── crates/
 │   │   ├── common/            # Shared types, IPC protocol codec
 │   │   ├── daemon/            # Daemon core logic

--- a/src/ws-ckpt/README_zh.md
+++ b/src/ws-ckpt/README_zh.md
@@ -23,7 +23,7 @@
 ws-ckpt/
 ├── src/                       # Rust Cargo workspace
 │   ├── Cargo.toml
-│   ├── config.toml.sample     # 配置示例（安装到 /etc/ws-ckpt/；复制为 config.toml 启用）
+│   ├── config.toml.sample     # 默认配置（安装为 /etc/ws-ckpt/config.toml，%config(noreplace)，另附 .sample 参考）
 │   ├── crates/
 │   │   ├── common/            # 共享类型、IPC 协议编解码
 │   │   ├── daemon/            # 守护进程核心逻辑

--- a/src/ws-ckpt/src/config.toml.sample
+++ b/src/ws-ckpt/src/config.toml.sample
@@ -1,9 +1,8 @@
-# ws-ckpt configuration sample
+# ws-ckpt configuration
 #
-# This file is a reference. To customize ws-ckpt, copy it to
-# /etc/ws-ckpt/config.toml and uncomment/edit fields you care about:
-#
-#     cp /etc/ws-ckpt/config.toml.sample /etc/ws-ckpt/config.toml
+# The package installs this file as the live /etc/ws-ckpt/config.toml.
+# Uncomment/edit fields in place — the copy at config.toml.sample stays
+# as the canonical commented reference.
 #
 # Any field left unset falls back to its built-in default; a missing
 # /etc/ws-ckpt/config.toml is equivalent to all defaults.

--- a/src/ws-ckpt/ws-ckpt.spec.in
+++ b/src/ws-ckpt/ws-ckpt.spec.in
@@ -60,6 +60,9 @@ install -d -m 0755 %{buildroot}%{_datadir}/anolisa/adapters/ws-ckpt/hermes
 install -p -m 0755 src/target/release/ws-ckpt %{buildroot}%{_localbindir}/ws-ckpt
 install -p -m 0644 src/systemd/ws-ckpt.service %{buildroot}%{_unitdir}/ws-ckpt.service
 install -p -m 0644 src/config.toml.sample %{buildroot}/etc/ws-ckpt/config.toml.sample
+# Ship the live config too; %config(noreplace) preserves admin edits on
+# upgrade and saves them as .rpmsave on erase (issue #3070).
+install -p -m 0644 src/config.toml.sample %{buildroot}/etc/ws-ckpt/config.toml
 cp -pr src/skills/ws-ckpt/. %{buildroot}%{_datadir}/anolisa/runtime/skills/ws-ckpt/
 cp -pr src/plugins/openclaw/dist %{buildroot}%{_datadir}/anolisa/runtime/ws-ckpt/plugins/openclaw/
 install -p -m 0644 src/plugins/openclaw/package.json %{buildroot}%{_datadir}/anolisa/runtime/ws-ckpt/plugins/openclaw/
@@ -85,6 +88,7 @@ install -p -m 0755 scripts/hermes/uninstall-hermes.sh %{buildroot}%{_datadir}/an
 %attr(0755,root,root) %{_localbindir}/ws-ckpt
 %{_unitdir}/ws-ckpt.service
 %dir /etc/ws-ckpt
+%config(noreplace) /etc/ws-ckpt/config.toml
 /etc/ws-ckpt/config.toml.sample
 %dir %{_datadir}/anolisa/runtime
 %dir %{_datadir}/anolisa/runtime/skills


### PR DESCRIPTION
## Why

Fixes #3070

`rpm -e ws-ckpt` 完全卸载时清理不对称：`%postun` 无条件清掉 `/var/lib/ws-ckpt`，但真正生效的 `/etc/ws-ckpt/config.toml`（运行期生成、不归任何包）原样残留。重装后 daemon 以「上一次的旧配置 + 全新空 state」启动，管理员无任何提示——旧配置里的 `auto_cleanup` / retention 设置静默作用于空 state。

## What changed

把生效的 config.toml 纳入包管理（issue 建议的方案 2）：

- **spec**：`%install` 以 sample 内容安装 config.toml；`%files` 声明 `%config(noreplace)`。RPM 原生接管整个生命周期：
  - 完全卸载：改过的配置存为 `.rpmsave`（未改过则直接删除）——消除 #3070 的错配组合
  - 升级：管理员改动保留，新版本默认值落 `.rpmnew`
  - `rpm -qf /etc/ws-ckpt/config.toml` 不再报 unowned
- **Makefile**：install 仅在 config.toml 不存在时落默认值（永不覆盖既有配置，等价 noreplace）；uninstall 按「改过→`.rpmsave`、未改→删除」对齐 RPM erase 语义
- **sample 头注释与 README/README_zh**：「copy 为 config.toml 启用」的说明改为「原地编辑生效配置」
- `.sample` 保留：`ws-ckpt config --set` 会把生效文件重写为无注释版本，sample 是带注释的权威参考
- 与仓库既有先例对齐：agentsight（`agentsight.spec.in:75`）、blaze（`blaze.spec:62`）、anolisa（`anolisa.spec.in:105`）均用 `%config(noreplace)` 打包生效配置

选择方案 2 而非方案 1（`%postun` 手动 mv）：一次修复整个生命周期（卸载/升级/归属查询），而不是在手搓清理上再叠一层手搓备份。历史包袱说明：0.2.0 把 config.toml 改为 sample-only 是为了避免升级覆盖管理员配置，当时若用裸 `%config` 确实会覆盖；`%config(noreplace)` 不会，且空节配置与「文件缺失」对 daemon 等价（sample 注释自述），新装行为不变。

## Related issue

Fixes #3070

## User / Agent impact

新装：`/etc/ws-ckpt/config.toml` 直接存在（全注释默认内容），可原地编辑，daemon 行为与之前「文件缺失走内置默认」完全一致。卸载：改过的配置以 `.rpmsave` 留存供管理员处置。升级：管理员改动不再有被覆盖的风险面。

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed — RPM 包内容新增 `/etc/ws-ckpt/config.toml`（`%config(noreplace)`）；从旧版（≤0.4.5）升级时，磁盘上遗留的 unowned config.toml 会被 RPM 接管：内容保留，打包默认值落 `.rpmnew`（已实测，见 Validation D）。
- [ ] Migration or rollback guidance is needed

无迁移需求：旧版升级/全新安装两条路径均已覆盖。回滚：revert 本 commit，config.toml 回到 unowned 状态，行为与 ≤0.4.5 一致。

## Validation

本机（ALinux 4，rpm 4.14.3）用与 ws-ckpt 相同 spec 模式的合成 RPM + 私有 dbpath 跑完整生命周期，12/12 通过：

- A 新装：config.toml 落地、`rpm -qf` 归属正确、内容为打包默认值
- B 完全卸载（未改）：config 删除、无 `.rpmsave`
- C 完全卸载（改过）：config 删除、`.rpmsave` 保留且携带管理员修改（#3070 修复语义）
- D 旧版（sample-only）+ 遗留 unowned config 升级到新版：管理员配置保留、打包默认值落 `.rpmnew`
- E 新版间升级（改过）：管理员修改保留、新默认值落 `.rpmnew`

`rpmspec -P` 解析真实 ws-ckpt spec 无误（`%config(noreplace)` 正确展开）；Makefile install/uninstall 新增片段语义模拟 4/4 通过；`make -n` 语法解析正常。

已知限制：合成包验证而非完整 `rpm-build.sh`（后者需 cargo release 全量构建 + root 权限装包验证）；建议合并前在真实 ECS 上过一遍 issue 中的复现步骤。

## Documentation and rollback

README/README_zh/sample 注释已同步。回滚：revert 本 commit 即可，无残留状态。