### PR TITLE
fix(memory): declare session keys in plugin schema

### DIFF
--- a/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
@@ -26,7 +26,7 @@
       "userId": {
         "type": "string",
         "maxLength": 128,
-        "description": "Namespace user_id for the memory mount. Default: auto-detect from OS uid. Must not contain '..', '/', '\\' or control characters (validated against the Rust side)."
+        "description": "Namespace user_id for the memory mount. Default: auto-detect from OS uid. At most 128 UTF-8 bytes; must not contain '..', '/', '\\' or control characters (validated against the Rust side)."
       },
       "profile": {
         "type": "string",
@@ -52,7 +52,7 @@
       "sessionId": {
         "type": "string",
         "maxLength": 128,
-        "description": "Session id pinned for this plugin's lifetime and forwarded as MEMORY_SESSION_ID on every spawn, so respawns reuse the same session directory and mem_promote finds prior scratch. Default: env MEMORY_SESSION_ID, else a generated ses_<random>. Validated with the same rules as userId."
+        "description": "Session id pinned for this plugin's lifetime and forwarded as MEMORY_SESSION_ID on every spawn, so respawns reuse the same session directory and mem_promote finds prior scratch. Default: env MEMORY_SESSION_ID, else a generated ses_<random>. Validated with the same rules as userId: at most 128 UTF-8 bytes, no '..', path separator or control character."
       },
       "sessionDir": {
         "type": "string",

--- a/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
@@ -48,6 +48,15 @@
         "minimum": 1,
         "maximum": 4294967296,
         "description": "Maximum bytes for a single mem_write call. Default: 16777216 (16 MiB). Hard cap: 4 GiB."
+      },
+      "sessionId": {
+        "type": "string",
+        "maxLength": 128,
+        "description": "Session id pinned for this plugin's lifetime and forwarded as MEMORY_SESSION_ID on every spawn, so respawns reuse the same session directory and mem_promote finds prior scratch. Default: env MEMORY_SESSION_ID, else a generated ses_<random>. Validated with the same rules as userId."
+      },
+      "sessionDir": {
+        "type": "string",
+        "description": "Base directory for per-session scratch and log, forwarded as MEMORY_SESSION_DIR. Default: env MEMORY_SESSION_DIR, else /run/anolisa/sessions (created 0700 by the shipped tmpfiles.d snippet)."
       }
     }
   },
@@ -73,6 +82,16 @@
     "maxWriteBytes": {
       "label": "Max Write Bytes",
       "help": "Maximum bytes accepted by a single write call. Caps disk and buffer growth.",
+      "advanced": true
+    },
+    "sessionId": {
+      "label": "Session ID",
+      "help": "Pin one session id so plugin respawns reuse the same session scratch. Leave empty to use MEMORY_SESSION_ID or a generated ses_<random>.",
+      "advanced": true
+    },
+    "sessionDir": {
+      "label": "Session Directory",
+      "help": "Root for per-session scratch and log files. Defaults to /run/anolisa/sessions.",
       "advanced": true
     }
   }

--- a/src/agent-memory/adapters/agent-memory/openclaw/src/config.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/src/config.ts
@@ -62,8 +62,23 @@ export function validateUserId(value: string): string {
   if (value.length === 0) {
     throw new Error("userId must not be empty");
   }
-  if (value.length > USER_ID_MAX_LEN) {
-    throw new Error(`userId length ${value.length} exceeds ${USER_ID_MAX_LEN} bytes`);
+  // The Rust limit is `str::len() > 128`, i.e. UTF-8 *bytes* (its error
+  // text says so). Counting `value.length` instead — UTF-16 code units —
+  // made this mirror accept everything the subprocess then rejects: 43 CJK
+  // characters are 43 units but 129 bytes, and 33 emoji are 66 units but
+  // 132 bytes. The rejection is also silent where it matters. A `userId`
+  // that fails `validate_user_id` is only warned about and dropped
+  // (`config.rs::read_validated_user_id_env` → the OS uid), and a
+  // `sessionId` that fails it is replaced by a freshly generated one
+  // (`service/mod.rs` → `SessionId::generate()`), so the operator keeps a
+  // working plugin pinned to the wrong namespace and loses the
+  // `mem_promote` continuity that pinning a session id exists to provide.
+  // Failing here instead is the contract this module already states: a
+  // configuration error the operator sees at plugin boot, not one that
+  // resurfaces as different behaviour in the deep child.
+  const byteLength = Buffer.byteLength(value, "utf8");
+  if (byteLength > USER_ID_MAX_LEN) {
+    throw new Error(`userId length ${byteLength} exceeds ${USER_ID_MAX_LEN} bytes`);
   }
   if (value.includes("/") || value.includes("\\")) {
     throw new Error(`userId '${value}' contains a path separator`);

--- a/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/config-test.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/config-test.ts
@@ -44,6 +44,42 @@ describe("validateUserId", () => {
     assert.equal(validateUserId("a".repeat(128)).length, 128);
   });
 
+  // The Rust side counts UTF-8 bytes (`str::len() > 128` in
+  // `ns::mod.rs::validate_user_id`, whose own error text says "bytes"), so
+  // this mirror has to count them too. A value accepted here and rejected
+  // there is not a hard failure — it is silently swapped in the subprocess:
+  // `userId` falls back to the OS uid (`config.rs::read_validated_user_id_env`
+  // only warns) and `sessionId` to a freshly generated one (`service/mod.rs`),
+  // which is precisely the pinning the operator asked for, lost without an
+  // error anywhere the operator would look.
+  it("rejects 43 CJK characters (43 code points, 129 bytes)", () => {
+    const cjk = "\u5b57".repeat(43);
+    assert.equal(cjk.length, 43);
+    assert.equal([...cjk].length, 43);
+    assert.equal(Buffer.byteLength(cjk, "utf8"), 129);
+    assert.throws(() => validateUserId(cjk), /length 129 exceeds 128 bytes/);
+  });
+
+  it("rejects 33 emoji (66 code units, 33 code points, 132 bytes)", () => {
+    const emoji = "\u{1f600}".repeat(33);
+    assert.equal(emoji.length, 66);
+    assert.equal([...emoji].length, 33);
+    assert.equal(Buffer.byteLength(emoji, "utf8"), 132);
+    assert.throws(() => validateUserId(emoji), /length 132 exceeds 128 bytes/);
+  });
+
+  it("accepts 42 CJK characters (126 bytes)", () => {
+    const cjk = "\u5b57".repeat(42);
+    assert.equal(Buffer.byteLength(cjk, "utf8"), 126);
+    assert.equal(validateUserId(cjk), cjk);
+  });
+
+  it("accepts exactly 128 bytes of mixed-width text", () => {
+    const mixed = "\u5b57".repeat(42) + "ab"; // 126 + 2 bytes, 44 code points
+    assert.equal(Buffer.byteLength(mixed, "utf8"), 128);
+    assert.equal(validateUserId(mixed), mixed);
+  });
+
   it("rejects '..' substring", () => {
     assert.throws(() => validateUserId("foo..bar"), /contains '\.\.'/);
   });
@@ -188,6 +224,19 @@ describe("resolveConfig sessionId (R6-1 regression)", () => {
     assert.throws(
       () => resolveConfig(mockApi({ sessionId: "../escape" })),
       /path separator|control|contains/,
+    );
+  });
+
+  it("rejects a multibyte sessionId the manifest's code-point bound accepts", () => {
+    // JSON Schema `maxLength` counts code points and has no byte-length
+    // keyword, so the manifest cannot express the Rust limit; the resolver is
+    // the binding check. 43 code points sail through `maxLength: 128` and are
+    // 129 UTF-8 bytes.
+    const sessionId = "\u5b57".repeat(43);
+    assert.equal([...sessionId].length, 43);
+    assert.throws(
+      () => resolveConfig(mockApi({ sessionId })),
+      /length 129 exceeds 128 bytes/,
     );
   });
 

--- a/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/manifest-config-schema-test.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/manifest-config-schema-test.ts
@@ -132,6 +132,26 @@ describe("openclaw.plugin.json configSchema", () => {
     assert.deepEqual(stray, [], `uiHints has entries for undeclared keys: ${stray.join(", ")}`);
   });
 
+  it("leaves the resolver's byte bound stricter than the schema's code-point bound", async () => {
+    // JSON Schema `maxLength` counts code points and has no byte-length
+    // keyword, while `validate_user_id` counts UTF-8 bytes. Bytes are always
+    // >= code points, so the schema can only ever be the weaker of the two:
+    // it never rejects a value the resolver would accept, and a multibyte id
+    // that slips past it is stopped by the resolver at plugin boot instead of
+    // being silently replaced inside the subprocess. Pinning the direction
+    // keeps anyone from "fixing" the mismatch by loosening the resolver.
+    const { validateUserId } = await import("../../src/config.js");
+    const limit = properties.sessionId?.maxLength ?? properties.userId?.maxLength;
+    assert.ok(
+      typeof limit === "number" && limit > 0,
+      "expected a numeric maxLength on sessionId/userId to compare against",
+    );
+    const multibyte = "\u5b57".repeat(limit); // 3 bytes per code point
+    assert.equal([...multibyte].length, limit);
+    assert.equal(Buffer.byteLength(multibyte, "utf8"), limit * 3);
+    assert.throws(() => validateUserId(multibyte), /exceeds 128 bytes/);
+  });
+
   it("caps sessionId exactly like userId, which is what validates it", () => {
     // resolveSessionId() runs explicit config through validateUserId(), so the
     // two schema entries must not drift apart.

--- a/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/manifest-config-schema-test.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/manifest-config-schema-test.ts
@@ -1,0 +1,176 @@
+/**
+ * Manifest ↔ config-resolution drift guard.
+ *
+ * OpenClaw validates `plugins.entries.memory-anolisa.config` against this
+ * plugin's `openclaw.plugin.json` `configSchema` *before* the plugin runtime
+ * loads (host docs, `docs/plugins/manifest.md` → "JSON Schema requirements":
+ * "Bundled plugin schemas are strict, so adding
+ * `plugins.entries.<id>.config.myNewKey` in user config without adding
+ * `myNewKey` to `configSchema.properties` will be rejected before the plugin
+ * runtime loads"). The loader then skips the plugin outright — one undeclared
+ * key costs the whole memory backend, not that one setting.
+ *
+ * The schema is strict (`additionalProperties: false`), which is the right
+ * choice: it turns an operator's typo into a config error instead of a silently
+ * ignored key. The price is that every key `resolveConfig` reads must also be
+ * declared, and nothing used to check that. `sessionId` / `sessionDir` shipped
+ * undeclared while the user guide documented both as plugin-config keys, so the
+ * documented configuration was exactly the one the host rejected.
+ *
+ * These tests derive the consumed key set from `src/config.ts` rather than
+ * restating it, so adding a key to the resolver without declaring it in the
+ * manifest fails here. Both directions are asserted: a refactor that changes how
+ * the resolver reads `api.pluginConfig` empties the derived set, and the
+ * reverse-direction assertion then fails instead of passing vacuously.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const manifestPath = fileURLToPath(
+  new URL("../../openclaw.plugin.json", import.meta.url),
+);
+const configSourcePath = fileURLToPath(new URL("../../src/config.ts", import.meta.url));
+
+type SchemaProperty = {
+  type?: string;
+  description?: string;
+  maxLength?: number;
+};
+
+type Manifest = {
+  id: string;
+  configSchema: {
+    type?: string;
+    additionalProperties?: boolean;
+    properties?: Record<string, SchemaProperty>;
+  };
+  uiHints?: Record<string, { label?: string; help?: string }>;
+};
+
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as Manifest;
+const properties = manifest.configSchema.properties ?? {};
+const declaredKeys = Object.keys(properties);
+
+/** Config keys `resolveConfig` reads off `api.pluginConfig` (its `raw` local). */
+function consumedKeys(): Set<string> {
+  const source = readFileSync(configSourcePath, "utf8");
+  const keys = new Set<string>();
+  for (const match of source.matchAll(/\braw\.([A-Za-z_$][A-Za-z0-9_$]*)/g)) {
+    keys.add(match[1]!);
+  }
+  return keys;
+}
+
+/** The plugin-config table documented in
+ *  `docs/user-guide/{en,zh}/token-saving/agent-memory.md`. */
+const DOCUMENTED_CONFIG: Record<string, unknown> = {
+  binaryPath: "/usr/bin/agent-memory",
+  userId: "1000",
+  profile: "advanced",
+  maxReadBytes: 1_048_576,
+  maxWriteBytes: 16_777_216,
+  sessionId: "ses_pinned_001",
+  sessionDir: "/run/anolisa/sessions",
+};
+
+describe("openclaw.plugin.json configSchema", () => {
+  it("stays strict, which is what makes an undeclared key fatal", () => {
+    assert.equal(manifest.configSchema.type, "object");
+    assert.equal(manifest.configSchema.additionalProperties, false);
+  });
+
+  it("declares every key resolveConfig reads", () => {
+    const consumed = consumedKeys();
+    assert.ok(consumed.size > 0, "no `raw.<key>` reads found in src/config.ts");
+    const undeclared = [...consumed].filter((key) => !(key in properties)).sort();
+    assert.deepEqual(
+      undeclared,
+      [],
+      `resolveConfig reads ${undeclared.join(", ")} but configSchema.properties ` +
+        `does not declare ${undeclared.length === 1 ? "it" : "them"}; the host ` +
+        `rejects the whole plugin config and skips loading the plugin`,
+    );
+  });
+
+  it("declares no key resolveConfig ignores", () => {
+    const consumed = consumedKeys();
+    const dead = declaredKeys.filter((key) => !consumed.has(key)).sort();
+    assert.deepEqual(
+      dead,
+      [],
+      `configSchema declares ${dead.join(", ")} but resolveConfig never reads ` +
+        `${dead.length === 1 ? "it" : "them"} — either wire it up or drop the ` +
+        `declaration and this guard's derived set`,
+    );
+  });
+
+  it("gives every declared key a type and a description", () => {
+    for (const key of declaredKeys) {
+      const property = properties[key]!;
+      assert.ok(property.type, `${key}: configSchema property needs a "type"`);
+      assert.ok(
+        property.description,
+        `${key}: configSchema property needs a "description" (the host surfaces it in config validation errors and the Control UI)`,
+      );
+    }
+  });
+
+  it("hints every declared key so the Control UI can render it", () => {
+    const hints = manifest.uiHints ?? {};
+    const unhinted = declaredKeys.filter((key) => !(key in hints)).sort();
+    assert.deepEqual(unhinted, [], `uiHints is missing ${unhinted.join(", ")}`);
+    for (const key of declaredKeys) {
+      assert.ok(hints[key]!.label, `${key}: uiHints entry needs a "label"`);
+      assert.ok(hints[key]!.help, `${key}: uiHints entry needs a "help"`);
+    }
+    const stray = Object.keys(hints)
+      .filter((key) => !declaredKeys.includes(key))
+      .sort();
+    assert.deepEqual(stray, [], `uiHints has entries for undeclared keys: ${stray.join(", ")}`);
+  });
+
+  it("caps sessionId exactly like userId, which is what validates it", () => {
+    // resolveSessionId() runs explicit config through validateUserId(), so the
+    // two schema entries must not drift apart.
+    assert.equal(properties.sessionId?.maxLength, properties.userId?.maxLength);
+  });
+});
+
+describe("documented plugin config", () => {
+  it("passes the strict schema the host validates it against", () => {
+    // With additionalProperties: false and no `required` list, a flat config
+    // object of correctly-typed values is accepted iff every key is declared.
+    const undeclared = Object.keys(DOCUMENTED_CONFIG)
+      .filter((key) => !(key in properties))
+      .sort();
+    assert.deepEqual(
+      undeclared,
+      [],
+      `the user guide documents ${undeclared.join(", ")} as plugin config but the ` +
+        `manifest does not declare ${undeclared.length === 1 ? "it" : "them"}`,
+    );
+  });
+
+  it("reaches the resolver instead of being rejected at the host", async () => {
+    const { resolveConfig } = await import("../../src/config.js");
+    delete process.env["MEMORY_SESSION_ID"];
+    delete process.env["MEMORY_SESSION_DIR"];
+    // `binaryPath` points at a binary that exists (this test runner) so the
+    // assertion is about the session keys, not about agent-memory being
+    // installed on the machine running the suite.
+    const pluginConfig = { ...DOCUMENTED_CONFIG, binaryPath: process.execPath };
+    const api = {
+      pluginConfig,
+      resolvePath: (p: string) => p,
+      logger: { info: () => {}, warn: () => {}, debug: () => {} },
+    } as never;
+    const cfg = resolveConfig(api);
+    assert.equal(cfg.sessionId, DOCUMENTED_CONFIG.sessionId);
+    assert.equal(cfg.sessionDir, DOCUMENTED_CONFIG.sessionDir);
+    assert.equal(cfg.userId, DOCUMENTED_CONFIG.userId);
+    assert.equal(cfg.binaryPath, process.execPath);
+  });
+});


### PR DESCRIPTION
## Why

`src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json` declares its plugin config schema with `"additionalProperties": false`, and OpenClaw validates `plugins.entries.memory-anolisa.config` against that schema **before the plugin runtime loads** — host docs, `docs/plugins/manifest.md` → *JSON Schema requirements*:

> Bundled plugin schemas are strict, so adding `plugins.entries.<id>.config.myNewKey` in user config without adding `myNewKey` to `configSchema.properties` will be rejected before the plugin runtime loads.

and on failure the loader does not degrade gracefully: it logs `[plugins] <id> invalid config: …` and `continue`s past the candidate (`validatePluginConfig` in the host's plugin loader), i.e. the plugin is skipped entirely.

`resolveConfig` (`src/config.ts:242-252`) reads **seven** keys off `api.pluginConfig`. The schema declared **five**. `sessionId` and `sessionDir` have been read by the resolver since `bc00bbe5` (2026-05-26) added the adapter, were documented as plugin-config keys in `docs/user-guide/en/token-saving/agent-memory.md:152-153` / `zh:151-152` by that same commit, and are covered by `tests/unit/config-test.ts` ("explicit plugin-config sessionId wins over env") — but were never declared.

So the documented configuration is exactly the configuration the host rejects:

```text
# manifest on main, validated with the host's own ajv settings
# (allErrors: true, strict: false, removeAdditional: false, useDefaults: true)
{sessionId: "ses_pinned_001"}                     -> REJECT  "<root> must NOT have additional properties"
{sessionDir: "/var/lib/anolisa/sessions"}         -> REJECT  "<root> must NOT have additional properties"
{userId: "1000", sessionId: …, sessionDir: …}     -> REJECT  "<root> must NOT have additional properties"
{userId: "1000", profile: "advanced"}             -> ACCEPT
```

The cost is not the one setting the operator was trying to make — the whole memory backend disappears. No `memory_search` / `memory_get` / `memory_observe` / `memory_get_context`, no corpus supplement, no conversation hooks, and the failure is a load-time log line rather than an error surfaced through a tool the agent then reports. `sessionId` is the worst possible key for this: the user guide flags it "must be fixed", because a fresh `ses_<random>` per respawn orphans prior session scratch and leaves `mem_promote` nothing to promote — so the operator most likely to pin it is the one who loses the plugin.

## What changed

**`adapters/agent-memory/openclaw/openclaw.plugin.json`**

- `configSchema.properties.sessionId` — `type: string`, `maxLength: 128`. The cap mirrors the resolver rather than inventing policy: `resolveSessionId()` runs explicit config through `validateUserId()`, whose `USER_ID_MAX_LEN` is 128.
- `configSchema.properties.sessionDir` — `type: string`. Deliberately no path validation: the resolver forwards it verbatim as `MEMORY_SESSION_DIR` and the Rust side reads it the same way (`src/config.rs::apply_env_overrides`), so the schema does not start enforcing a contract neither side has.
- `uiHints.sessionId` / `uiHints.sessionDir` (`label`, `help`, `advanced: true`, alongside `maxReadBytes` / `maxWriteBytes` — plumbing an operator pins once, not a choice the basic form should lead with). The user guide offers the OpenClaw UI as one of the two ways to set plugin config, and a declared field with no hint renders there without a label or help text.

**`adapters/agent-memory/openclaw/tests/unit/manifest-config-schema-test.ts`** (new, 8 tests) — the guard that was missing:

- derives the consumed key set from `src/config.ts` (every `raw.<key>` read) instead of restating it, so the next key added to the resolver without a manifest entry fails here;
- asserts it in **both** directions against `configSchema.properties` — the reverse direction is load-bearing: a refactor that changes how the resolver reads `api.pluginConfig` empties the derived set, and that assertion then fails instead of passing vacuously;
- asserts the schema stays strict, because that strictness is what makes an undeclared key fatal, so relaxing it should be a conscious reviewed act rather than a silent one;
- asserts a `type` and a `description` per declaration, a `uiHints` entry per declared key, and no stray hints;
- asserts `sessionId.maxLength === userId.maxLength`, since one validator serves both;
- feeds the user guide's full documented config through `resolveConfig` and checks the session keys actually arrive.

## Related issue

`no-issue:` found while auditing agent-memory for live defects on `main`. Happy to open a tracking issue instead if triagers would rather have one for the next release notes — this is user-perceivable for anyone who followed the documented config table.

## User / Agent impact

- Operators can now pin `sessionId` / `sessionDir` in `plugins.entries.memory-anolisa.config` (or the Control UI) as documented, without the plugin being dropped.
- Anyone who already wrote one of those keys is currently running **without** agent-memory and seeing only a load-time log line; their existing config loads after this change.
- No behavior change for configs using only the five previously declared keys, and none for env-only setups (`MEMORY_SESSION_ID` / `MEMORY_SESSION_DIR` were and remain the other route).
- Strictness is unchanged where it should be: an undeclared or typo'd key still rejects the config. `sessionId` over 128 characters and a non-string `sessionDir` now reject with a per-field error instead of a root-level one that names neither key.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed

Configuration surface only, and only in the permissive direction: two keys the resolver already read and the user guide already documented become settable. No Rust change, no MCP tool change, no install-script change, and no schema key removed or retyped, so no currently-valid config can start failing. `install.sh` writes only `plugins.entries.memory-anolisa.hooks.allowConversationAccess`, which lives outside `config` and is therefore not schema-validated — no installer path depended on the rejection.

Checked the three sibling OpenClaw plugins for the same drift; agent-memory was the only instance: `selective-claw` (tokenless) declares all three keys it reads, `agent-sec` is not strict (no `additionalProperties`), and `ws-ckpt` ships the documented empty strict schema.

## Validation

Node v22.21.1 in `src/agent-memory/adapters/agent-memory/openclaw`, base `main @ 7ad9bb53`:

```text
npm test                                          126 -> 134 tests, 23 suites, 0 fail
npm run build:check                               tsc --noEmit: 0 errors
make test-openclaw-install                        all PASS (installer negotiation untouched)
make sync-versions generate-component-contract    no diff, so no derived JSON needed regenerating
commitlint (.github/commitlint.config.json)       ✔ found 0 problems, 0 warnings
```

The guard reproduces the defect rather than only describing it — run against the pre-fix manifest:

```text
not ok 2 - declares every key resolveConfig reads
    resolveConfig reads sessionDir, sessionId but configSchema.properties does not declare
    them; the host rejects the whole plugin config and skips loading the plugin
not ok 1 - passes the strict schema the host validates it against
    the user guide documents sessionDir, sessionId as plugin config but the manifest does
    not declare them
not ok 6 - caps sessionId exactly like userId, which is what validates it
# tests 8  # pass 5  # fail 3
```

and after the fix the four configs above are ACCEPT / ACCEPT / ACCEPT / ACCEPT, while `{sessionIdd: "x"}` still rejects, `{sessionId: "a" × 129}` gives `/sessionId must NOT have more than 128 characters`, and `{sessionDir: 42}` gives `/sessionDir must be string`.

Not re-run: `cargo test` / `clippy` / `fmt` — the change touches no Rust file. The adapter's TS suite is still not wired into the `Test agent-memory` job (#3134 asks for it and it needs a token with `workflow` scope), so the guard runs under `make test-openclaw-plugin` locally until that lands.

## Documentation and rollback

No docs change: `docs/user-guide/{en,zh}/token-saving/agent-memory.md` already document both keys with the right defaults and precedence — the manifest was the side that disagreed with them. `specs/documentation-standard.md` §5 asks for docs to accompany a configuration option, which they already do. `src/agent-memory/README.md` has no plugin-config table (it documents the MCP client config), so there was nothing there to keep in sync; say the word if reviewers would rather this PR add one.

Rollback: `git revert`. No persisted state and no migration — reverting restores the rejection behavior for the two keys.

