### PR TITLE
docs(docs): document ANOLISA 1.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4] - 2026-09-10
+
+### Component Versions
+
+| Component | Version |
+|-----------|--------|
+| copilot-shell | 2.8.0 |
+| agent-sec-core | 0.12.0 |
+| agentsight | 0.12.1 |
+| tokenless | 0.8.1 |
+| agent-memory | 0.2.7 |
+| os-skills | 0.6.3 |
+| anolisa | 0.3.11 |
+| skillfs | 0.4.2 |
+| ws-ckpt | 0.4.5 |
+| cosh-ng | 0.24.1 |
+
+> **Note:** copilot-shell, os-skills, skillfs, and ws-ckpt are unchanged
+> since v1.3; they are listed to show the complete stack composition.
+
+### Highlights
+
+- **cosh-ng**: Updated to v0.24.1, routes natural-language and path-like input to the Agent in Enhanced Assisted Zsh while preserving ordinary Shell behavior and the user's terminal customizations, users get a more natural Zsh experience without rebuilding their existing setup (#3004, #3156)
+- **agent-sec-core**: Updated to v0.12.0, applies configured policy checks consistently to legacy cosh and cosh-ng Skill calls while reducing false positives, users get consistent Skill enforcement and fewer incorrect security findings across both shells (#2871, #2928)
+- **agentsight**: Updated to v0.12.1, adds collection without eBPF, native DashScope support, Kubernetes packaging, and more resilient long-running capture, operators can retain accurate observability in restricted and production environments (#2954, #2976, #3135, #3147)
+- **tokenless**: Updated to v0.8.1, adds QwenPaw support and reversible compression for large JSON payloads, build logs, and CSV/TSV data, agents can reduce more kinds of context and retrieve omitted content precisely when needed (#3047, #3052, #3067, #3075, #3089)
+- **anolisa**: Updated to v0.3.11, adds QwenPaw adapter management and ktuner discovery when the configured repository provides it while improving install, recovery, and audit behavior, administrators get more trustworthy lifecycle status and component-index previews without requiring root (#2084, #3075, #3127, #3141, #3142, #3158)
+- **agent-memory**: Updated to v0.2.7, improves OpenClaw installation, corpus retrieval, configuration validation, and source-build setup, agents can share persistent memory with more reliable setup and recall (#2560, #3149, #3155, #3177, #3187)
+
+### Updated
+
+- **cosh-ng**: Updated to v0.24.1, improves prompt routing, terminal redraws, history recall, custom Tab behavior, login-profile PATH loading, credential redaction, and Hook trust visibility while removing the system OpenSSL requirement, users can keep their existing shell configuration and receive reliable Agent assistance without losing commands, output, or sensitive-history protection (#2967, #2983, #2996, #2999, #3004, #3030, #3050, #3058, #3156)
+- **agent-sec-core**: Updated to v0.12.0, applies the same Skill policies across legacy cosh and cosh-ng, reduces scanner false positives, reports every integrity outcome through `skill-ledger` and `check`, and speeds up container health checks, users get consistent enforcement, clearer verification results, and faster readiness checks (#2707, #2871, #2879, #2928)
+- **agentsight**: Updated to v0.12.1, adds collection without eBPF, native DashScope and Kubernetes deployment support, Agent resource monitoring, and cosh-ng traffic capture while improving attribution accuracy, tool-result retention, enforcement synchronization, Token accounting, stream completion, duplicate suppression, startup recovery, and automatic capture recovery, operators can trust timelines and usage totals while keeping monitoring and protection running through long-lived workloads and transient failures (#2916, #2954, #2976, #2979, #3005, #3011, #3016, #3081, #3087, #3135, #3147, #3191)
+- **tokenless**: Updated to v0.8.1, adds QwenPaw integration, reversible reduction for large JSON collections, build logs, and CSV/TSV output, omitted-content retrieval through existing Shell tools, and trace correlation while fixing installation and compatibility issues across supported hosts, agents can use less context across more tool results and recover the exact omitted data when needed (#2249, #3009, #3047, #3052, #3067, #3068, #3075, #3085, #3089, #3094)
+- **anolisa**: Updated to v0.3.11, adds QwenPaw adapter lifecycle management and ktuner discovery from configured repositories, permits declared config edits without false corruption reports, records hook-modified files correctly, avoids false pending operations after package conflicts, enables component-index previews without root, and improves cleanup, logs, dry-run, and audit guidance, administrators can inspect and recover installations with state that better reflects the actual system (#2084, #2618, #2922, #2926, #2994, #3075, #3118, #3127, #3141, #3142, #3158)
+- **agent-memory**: Updated to v0.2.7, negotiates OpenClaw installation capabilities, distinguishes permission and configuration failures, returns readable and accurately windowed corpus results, validates configuration before binary discovery, and prepares Node.js and npm dependencies for source builds, agents and operators get more reliable installation, diagnosis, and memory recall (#2560, #3149, #3155, #3177, #3187)
+
+### Compatibility
+
+- **Tokenless Protocol v2**: `tokenless compress` now accepts only `before_model`, `pre_tool`, `post_tool`, and `retrieve` lifecycle requests; Protocol v1 and `tokenless mcp serve` have been removed. Upgrade Tokenless Core, CLI, SDKs, and adapters together and declare recovery capability explicitly to avoid protocol or retrieval mismatches (#2978, #3068).
+- **Tokenless Rust APIs**: Replace `TokenlessRuntime::compress` with the Runtime lifecycle methods. Direct response-compression callers must migrate from the removed `tokenless-pipeline` crate and `tokenless_schema::ResponseCompressor` to the Runtime or `tokenless-compressors` APIs (#2974, #2978).
+- **Tokenless Python and AgentScope APIs**: Replace the removed `ModelRequest`, `ToolCall`, `ToolResult`, and `ToolResponseCompressor` types with typed `before_model`, `pre_tool`, `post_tool`, and `retrieve` lifecycle requests. AgentScope integrations must add `ToolContract` metadata for custom tools and expose one static retrieval tool (#2986, #3029).
+- **Tokenless retrieval configuration**: Custom `retrieve_tool_name` values must satisfy the tool-name rules. Lifecycle schema compression now requires an authorized static retrieval tool and an available Stash; without both, hooks preserve the original schemas. Recovering omitted content also requires a reachable CLI or static tool and a host that can replace the current tool result, including Claude Code 2.1.121 or newer. Existing `<<tokenless:HASH>>` markers remain readable (#2978, #2995, #3029, #3052, #3068).
+- **Tokenless adapter configuration**: OpenClaw now uses `post_tool_enabled` for PostTool optimization; its former response, TOON, skip-tool, and shell-tool policy settings have been removed and no longer control compression. Remove those obsolete settings and configure `post_tool_enabled` when upgrading. DeepSeek Harness users must also remove adapter-specific thresholds and tool lists and use the shared compression policy. OpenClaw remains limited to lossless transcript updates without same-turn replacement or retrieval (#3009, #3036).
+- **Tokenless statistics fields**: Dashboards and integrations must replace `seam` and `compressor_chain` with `content_origin`, `applied_operations`, and `recoverability`. The legacy SQLite columns remain for compatibility, but new records no longer populate them, so queries that keep using the old fields can return empty or incorrect reports after upgrading (#2978).
+- **AgentSight timestamps**: Kernel event timestamps are now calibrated to host wall-clock time instead of container uptime. If NTP or an administrator steps the host wall clock while kernel events are queued, affected historical wall-clock timestamps cannot be reconstructed; persisted records are unaffected. Mark each wall-clock adjustment when analyzing timelines across it (#3128).
+- **agent-sec-core Python dependency**: Python deployments and source builds now require `cryptography` 50.0.1 or newer. Refresh the environment from the exported requirements before upgrading custom installations (#3015).
+- **agent-memory source builds**: Building the OpenClaw adapter from source now requires Node.js 20 or newer and npm. The unified user-mode build provisions them automatically; system-mode builds report missing tools during preflight (#3187).
+- **anolisa RPM previews**: On DNF 4 systems, RPM install `--dry-run` requires `sudo` and may refresh repository metadata while checking solver conflicts. The check now runs before recovery journals are created (#3158).
+- **anolisa editable configs and state format**: Allowing content edits to raw-installed `type = "config"` files does not change update or uninstall semantics, so back up customized configs before either operation. The new `kind = "config"` state records are unreadable by older CLI versions; before downgrading, also back up state and convert affected owned-file entries to `kind = "file"` to restore content-digest validation (#3142).
+
 ## [1.3] - 2026-08-31
 
 ### Component Versions

--- a/CHANGELOG_zh.md
+++ b/CHANGELOG_zh.md
@@ -6,6 +6,57 @@
 
 格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，项目遵循[语义化版本](https://semver.org/lang/zh-CN/spec/v2.0.0.html)。
 
+## [1.4] - 2026-09-10
+
+### 组件版本
+
+| 组件 | 版本 |
+|------|------|
+| copilot-shell | 2.8.0 |
+| agent-sec-core | 0.12.0 |
+| agentsight | 0.12.1 |
+| tokenless | 0.8.1 |
+| agent-memory | 0.2.7 |
+| os-skills | 0.6.3 |
+| anolisa | 0.3.11 |
+| skillfs | 0.4.2 |
+| ws-ckpt | 0.4.5 |
+| cosh-ng | 0.24.1 |
+
+> **说明：** copilot-shell、os-skills、skillfs 与 ws-ckpt 自 v1.3 起未更新；版本表保留这些组件以展示完整组件组合。
+
+### 重点特性
+
+- **cosh-ng**：更新到 v0.24.1，在 Enhanced Assisted Zsh 中将自然语言和路径类输入交给 Agent，同时保留普通 Shell 行为与用户的终端定制，用户无需重建现有配置即可获得更自然的 Zsh 交互（#3004、#3156）
+- **agent-sec-core**：更新到 v0.12.0，使 legacy cosh 与 cosh-ng 的 Skill 调用一致接受已配置策略校验，并降低误报，用户可在两种 Shell 中获得一致的 Skill 策略执行与更少的错误安全告警（#2871、#2928）
+- **agentsight**：更新到 v0.12.1，新增无 eBPF 采集、DashScope 原生支持、Kubernetes 打包和更可靠的长期采集，运维人员可在受限环境与生产环境中持续获得准确的可观测数据（#2954、#2976、#3135、#3147）
+- **tokenless**：更新到 v0.8.1，新增 QwenPaw 支持，以及大型 JSON、构建日志和 CSV/TSV 的可恢复压缩，Agent 可压缩更多类型的上下文并按需精确取回省略内容（#3047、#3052、#3067、#3075、#3089）
+- **anolisa**：更新到 v0.3.11，新增 QwenPaw Adapter 管理，并可在已配置仓库提供 ktuner 时发现该组件，同时改进安装、恢复和审计行为，管理员可获得更可信的生命周期状态，并可在无需 root 的情况下预览组件索引（#2084、#3075、#3127、#3141、#3142、#3158）
+- **agent-memory**：更新到 v0.2.7，改进 OpenClaw 安装、语料检索、配置校验和源码构建准备，Agent 可通过更可靠的安装和召回能力共享持久化记忆（#2560、#3149、#3155、#3177、#3187）
+
+### 组件更新
+
+- **cosh-ng**：更新到 v0.24.1，改进提示词路由、终端重绘、历史召回、自定义 Tab 行为、登录 profile PATH 加载、凭据脱敏和 Hook 信任信息，并移除系统 OpenSSL 依赖，用户可保留现有 Shell 配置并稳定使用 Agent 协助，不会丢失命令、输出或敏感历史保护（#2967、#2983、#2996、#2999、#3004、#3030、#3050、#3058、#3156）
+- **agent-sec-core**：更新到 v0.12.0，在 legacy cosh 与 cosh-ng 中执行相同的 Skill 策略，降低扫描误报，通过 `skill-ledger` 与 `check` 报告全部完整性结果，并加快容器健康检查，用户可获得一致执行、更清晰的校验结论和更快的就绪检查（#2707、#2871、#2879、#2928）
+- **agentsight**：更新到 v0.12.1，新增无 eBPF 采集、DashScope 原生与 Kubernetes 部署支持、Agent 资源监控和 cosh-ng 流量采集，并改进归因准确性、工具结果保留、策略同步、Token 计量、流式请求收尾、重复记录抑制、启动恢复和采集自动恢复，运维人员可信任时间线与用量统计，并让监控和防护在长期负载及短暂故障后持续运行（#2916、#2954、#2976、#2979、#3005、#3011、#3016、#3081、#3087、#3135、#3147、#3191）
+- **tokenless**：更新到 v0.8.1，新增 QwenPaw 集成、大型 JSON 集合、构建日志和 CSV/TSV 输出的可恢复缩减、通过现有 Shell 工具取回省略内容以及 Trace 关联，并修复各支持宿主的安装与兼容问题，Agent 可对更多工具结果减少上下文占用，并在需要时恢复精确原文（#2249、#3009、#3047、#3052、#3067、#3068、#3075、#3085、#3089、#3094）
+- **anolisa**：更新到 v0.3.11，新增 QwenPaw Adapter 生命周期管理和从已配置仓库发现 ktuner，允许已声明 config 文件修改而不产生错误损坏告警，正确记录 Hook 修改后的文件，避免包冲突后产生虚假 pending 操作，支持无需 root 的组件索引预览，并改进清理、日志、dry-run 和审计指引，管理员可依据更贴近系统实际状态的信息检查和恢复安装（#2084、#2618、#2922、#2926、#2994、#3075、#3118、#3127、#3141、#3142、#3158）
+- **agent-memory**：更新到 v0.2.7，协商 OpenClaw 安装能力，区分权限与配置故障，返回可读取且窗口范围准确的语料结果，在查找二进制前校验配置，并为源码构建准备 Node.js 与 npm 依赖，Agent 与运维人员可获得更可靠的安装、诊断和记忆召回（#2560、#3149、#3155、#3177、#3187）
+
+### 兼容性
+
+- **Tokenless Protocol v2**：`tokenless compress` 现在仅接受 `before_model`、`pre_tool`、`post_tool` 和 `retrieve` 生命周期请求；Protocol v1 与 `tokenless mcp serve` 已移除。应同步升级 Tokenless Core、CLI、SDK 与 Adapter，并显式声明恢复能力，避免协议或检索能力不匹配（#2978、#3068）。
+- **Tokenless Rust API**：使用 Runtime 生命周期方法替代 `TokenlessRuntime::compress`。直接调用响应压缩的代码须从已移除的 `tokenless-pipeline` Crate 和 `tokenless_schema::ResponseCompressor` 迁移至 Runtime 或 `tokenless-compressors` API（#2974、#2978）。
+- **Tokenless Python 与 AgentScope API**：使用类型化的 `before_model`、`pre_tool`、`post_tool` 和 `retrieve` 生命周期请求，替代已移除的 `ModelRequest`、`ToolCall`、`ToolResult` 和 `ToolResponseCompressor` 类型。AgentScope 集成须为自定义工具补充 `ToolContract` 元数据，并暴露一个静态恢复工具（#2986、#3029）。
+- **Tokenless 恢复配置**：自定义 `retrieve_tool_name` 必须符合工具名规则。生命周期 Schema 压缩现在要求具备已授权的静态恢复工具和可用 Stash；缺少任一条件时，Hook 会保留原始 Schema。取回省略内容还要求 CLI 或静态工具可访问，且宿主能够替换当前工具结果，其中 Claude Code 要求 2.1.121 或更新版本。已有 `<<tokenless:HASH>>` 标记仍可读取（#2978、#2995、#3029、#3052、#3068）。
+- **Tokenless Adapter 配置**：OpenClaw 现在使用 `post_tool_enabled` 控制 PostTool 优化；原有的响应、TOON、skip-tool 和 shell-tool 策略设置已移除，不再控制压缩行为。升级时应删除这些废弃设置，并按需配置 `post_tool_enabled`。DeepSeek Harness 用户也须移除 Adapter 专用阈值和工具列表，改用共享压缩策略。OpenClaw 仍仅支持无损 transcript 更新，不支持同轮替换或检索（#3009、#3036）。
+- **Tokenless 统计字段**：Dashboard 和集成须使用 `content_origin`、`applied_operations` 与 `recoverability` 替代 `seam` 和 `compressor_chain`。旧 SQLite 列仍为兼容性保留，但新记录不再写入这些列；升级后继续查询旧字段可能得到空值或错误报表（#2978）。
+- **AgentSight 时间戳**：内核事件时间戳改为校准至主机墙钟时间，不再基于容器 uptime 计算。若内核事件仍在队列中时 NTP 或管理员跳变主机墙钟，受影响事件的历史墙钟时间将无法重建；已持久化记录不受影响。跨越墙钟调整分析时间线时，应标记每次调整点（#3128）。
+- **agent-sec-core Python 依赖**：Python 部署和源码构建现在要求 `cryptography` 50.0.1 或更新版本。自定义安装在升级前应根据导出的 requirements 刷新环境（#3015）。
+- **agent-memory 源码构建**：从源码构建 OpenClaw Adapter 现在要求 Node.js 20 或更新版本以及 npm。统一用户模式构建会自动准备这些工具；系统模式构建会在预检时报告缺失工具（#3187）。
+- **anolisa RPM 预览**：在 DNF 4 系统上，RPM 安装的 `--dry-run` 需要使用 `sudo`，并可能在检查依赖冲突时刷新仓库元数据。该检查现在会在创建恢复日志前完成（#3158）。
+- **anolisa 可编辑 config 与状态格式**：允许修改 raw 安装的 `type = "config"` 文件内容不会改变 update 或 uninstall 语义，因此执行任一操作前都应备份已定制配置。新的 `kind = "config"` 状态记录无法由旧版 CLI 读取；降级前还应备份状态，并将相关自有文件条目改回 `kind = "file"`，以恢复内容摘要校验（#3142）。
+
 ## [1.3] - 2026-08-31
 
 ### 组件版本


### PR DESCRIPTION
## Why

ANOLISA 1.4 releases on 2026-09-10 with six components updated and three breaking compatibility changes, but the repository CHANGELOG still stops at 1.3. Without a 1.4 entry, users have no in-repo reference for the shipped component versions, or the migration steps required by the Tokenless Protocol v2 removal — they would have to reconstruct that from per-component changelogs.

## What changed

Add the `[1.4] - 2026-09-10` entry to both `CHANGELOG.md` and `CHANGELOG_zh.md`, derived from the Agentic OS release note:

- **Component Versions**: full ten-component table (`cosh-ng` 0.24.1, `agent-sec-core` 0.12.0, `agentsight` 0.12.1, `tokenless` 0.8.1, `anolisa` 0.3.11, `agent-memory` 0.2.7, plus the four unchanged components).
- **Highlights / Updated**: one entry per updated component, each stating the version and the user-visible outcome.
- **Compatibility**: Tokenless Protocol v2 lifecycle-only requests, AgentSight wall-clock timestamp calibration, and the `anolisa` `kind = "config"` state record format, each with its migration or downgrade note.

Two deliberate choices: the version table keeps all ten components (matching the 1.3 and earlier entries as a complete stack manifest) rather than listing only the changed ones, with unchanged components called out in a note; and the release date and image identifier are preserved verbatim from the source release note rather than derived from commit dates.

## Related issue

`no-issue: release documentation for an already-decided 1.4 release; no behavior change`

## User / Agent impact

No code, CLI, or runtime behavior change. Users reading the repository root now find the 1.4 version manifest and the three compatibility notes they need before upgrading; the breaking changes themselves were introduced by the component PRs, this only documents them.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk — documentation only, no shipped artifact is affected. The migration guidance in the Compatibility section describes changes already landed in the component PRs; this PR does not introduce them.

## Validation

- `./scripts/docs-lint.sh` — documentation lint per `specs/documentation-standard.md`
- `python3 scripts/docs-link-check.py` — no broken links in the new entry
- Manual: EN/ZH entries checked for section parity and identical version numbers; each listed version cross-checked against the corresponding component's `CHANGELOG.md`; heading format verified against the existing 1.3 entry (Keep a Changelog + SemVer).

## Documentation and rollback

Documentation is the entire change: `CHANGELOG.md` and `CHANGELOG_zh.md` gain the 1.4 entry; no user-guide or component docs touched. Rollback is a plain `git revert c6772eb` — nothing depends on this content at build or runtime.