### PR TITLE
feat(anolisa): restore OpenClaw activation

### DIFF
--- a/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
@@ -157,6 +157,8 @@ pub enum PreparedEnable {
     OpenClaw {
         /// The host's installer supports accepting the plugin's declared capabilities.
         supports_accept_capabilities: bool,
+        /// The host's enable command supports accepting declared capabilities.
+        supports_enable_accept_capabilities: bool,
         /// The host's `plugins install --help` exposes the unsafe flag.
         supports_unsafe_install: bool,
         /// The host's `plugins inspect --help` exposes `--json`.

--- a/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
@@ -1,8 +1,8 @@
 //! OpenClaw framework driver.
 //!
 //! OpenClaw plugin adapters use the CLI-managed registry: `enable` runs
-//! `openclaw plugins install <resource_root>` and `disable` runs
-//! `openclaw plugins uninstall <plugin_id>`. Skill-only adapters
+//! `openclaw plugins install <resource_root>` then `plugins enable <plugin_id>`;
+//! `disable` runs `openclaw plugins uninstall <plugin_id>`. Skill-only adapters
 //! (`adapter_type = "skill_bundle"`) skip registry operations and only
 //! copy declared skills into the OpenClaw skills directory. Status is the
 //! read-only `openclaw plugins list` for plugin adapters. All CLI and
@@ -16,12 +16,11 @@
 //!
 //! Before the first framework mutation — during `prepare_enable` (and, for
 //! `--dry-run`, `plan_enable`) — `enable` builds a read-only
-//! `OpenClawHostProfile` from all three probes (`openclaw --version`,
-//! `plugins install --help`, `plugins inspect --help`). From it the driver
-//! gates on the adapter's declared framework version, chooses
-//! version-conditioned config, decides the install argv (`--force`, and
-//! `--accept-capabilities` when advertised, because enable consents to the
-//! plugin's declared capabilities), adds
+//! `OpenClawHostProfile` from read-only probes (`openclaw --version`,
+//! `plugins install --help`, `plugins enable --help`, `plugins inspect --help`).
+//! From it the driver gates on the adapter's declared framework version, chooses
+//! version-conditioned config, requires install `--force`, and accepts declared
+//! capabilities when each subcommand advertises `--accept-capabilities`. It adds
 //! `--dangerously-force-unsafe-install` only when both authorized and
 //! advertised as effective by the host, and records the inspect capabilities.
 //! The install/verify capabilities flow to `apply_enable` as typed
@@ -156,6 +155,7 @@ impl FrameworkDriver for OpenClawDriver {
         let home = require_home(ctx)?;
         let mut actions = Vec::new();
         let mut register_command = None;
+        let mut enable_command = None;
         // Plugin adapters resolve a read-only host profile so the dry-run
         // plan shows the exact install command (including whether the
         // authorized unsafe flag is used) and only the config the host
@@ -168,6 +168,12 @@ impl FrameworkDriver for OpenClawDriver {
             let plugin_id = require_plugin_id(bundle)?;
             validate_plugin_id(&plugin_id)?;
             let preflight = self.plugin_preflight(&bundle.resource_root, ctx)?;
+            enable_command = Some(display_command(&build_enable_cmd(
+                &plugin_id,
+                &home,
+                ctx.user_home.as_deref(),
+                preflight.supports_enable_accept_capabilities,
+            )));
             selected_config = preflight.selected_config;
             register_command = Some(display_command(&preflight.install_cmd));
             actions.push(format!(
@@ -195,6 +201,10 @@ impl FrameworkDriver for OpenClawDriver {
                 cfg.key,
                 config_value_display(&cfg.value)
             ));
+        }
+
+        if let Some(command) = enable_command {
+            actions.push(format!("enable openclaw plugin: {command}"));
         }
 
         Ok(DriverPlan {
@@ -264,6 +274,7 @@ impl FrameworkDriver for OpenClawDriver {
             let preflight = self.plugin_preflight(&bundle.resource_root, ctx)?;
             PreparedEnable::OpenClaw {
                 supports_accept_capabilities: preflight.supports_accept_capabilities,
+                supports_enable_accept_capabilities: preflight.supports_enable_accept_capabilities,
                 supports_unsafe_install: preflight.supports_unsafe_install,
                 supports_inspect_json: preflight.supports_inspect_json,
                 supports_inspect_runtime: preflight.supports_inspect_runtime,
@@ -423,8 +434,8 @@ impl FrameworkDriver for OpenClawDriver {
         // rebuilt from the typed `ctx` and prepared consent support; the unsafe
         // flag still requires explicit authorization. Config selection comes from
         // prepared state, and runtime verification uses the prepared
-        // `--runtime` capability. Each probe (`--version`, install `--help`,
-        // inspect `--help`) thus runs exactly once per enable, all in prepare,
+        // `--runtime` capability. Each probe (`--version`, install/enable/inspect
+        // `--help`) thus runs exactly once per enable, all in prepare,
         // and no two probe generations are ever mixed.
         //
         // Defense in depth: `PreparedEnable` and this trait are public, so a
@@ -435,6 +446,7 @@ impl FrameworkDriver for OpenClawDriver {
         // `--runtime`, or add the unsafe flag on an unverified host).
         let (
             accept_capabilities,
+            enable_accept_capabilities,
             host_supports_unsafe,
             verify_with_runtime,
             selected_config_indices,
@@ -446,11 +458,12 @@ impl FrameworkDriver for OpenClawDriver {
             }
             // Skill bundles run no plugin install and no runtime verification;
             // these values are unused for them.
-            (false, false, false, Vec::new())
+            (false, false, false, false, Vec::new())
         } else {
             match prepared {
                 PreparedEnable::OpenClaw {
                     supports_accept_capabilities,
+                    supports_enable_accept_capabilities,
                     supports_unsafe_install,
                     supports_inspect_json,
                     supports_inspect_runtime,
@@ -475,6 +488,7 @@ impl FrameworkDriver for OpenClawDriver {
                     validate_prepared_config_indices(selected_config_indices, ctx)?;
                     (
                         *supports_accept_capabilities,
+                        *supports_enable_accept_capabilities,
                         *supports_unsafe_install,
                         *supports_inspect_runtime,
                         selected_config_indices.clone(),
@@ -574,7 +588,18 @@ impl FrameworkDriver for OpenClawDriver {
                 progress.persist_claim(claim)?;
             }
 
-            // Post-install runtime verification: the plugin must report
+            // Install preserves an explicit disabled entry left by uninstall.
+            let cmd = build_enable_cmd(plugin_id, &home, user_home, enable_accept_capabilities);
+            let program = cmd.program.clone();
+            let output = ctx.ops.run_framework_cli(cmd)?;
+            if !output.success() {
+                return Err(AdapterError::FrameworkCli {
+                    program,
+                    reason: full_failure_reason("plugins enable", &output),
+                });
+            }
+
+            // Post-enable runtime verification: the plugin must report
             // loaded. A non-loaded status surfaces the framework diagnostics
             // and, via the Manager's receipt-first model, leaves a
             // cleanup_failed receipt for later disable.
@@ -866,9 +891,8 @@ impl OpenClawDriver {
 // ---------------------------------------------------------------------------
 
 /// Read-only pre-install facts about the installed OpenClaw CLI, gathered by
-/// [`OpenClawDriver::host_profile`] from all three probes (`openclaw
-/// --version`, `plugins install --help`, `plugins inspect --help`) before the
-/// first mutation. Private typed data — never persisted into a receipt.
+/// [`OpenClawDriver::host_profile`] from version and install/enable/inspect
+/// help probes before the first mutation. Never persisted into a receipt.
 #[derive(Debug, Clone)]
 struct OpenClawHostProfile {
     /// Parsed `openclaw --version`, when the output was recognizable.
@@ -879,6 +903,8 @@ struct OpenClawHostProfile {
     supports_install_force: bool,
     /// `openclaw plugins install --help` exposes `--accept-capabilities`.
     supports_accept_capabilities: bool,
+    /// `plugins enable --help` exposes `--accept-capabilities`.
+    supports_enable_accept_capabilities: bool,
     /// `openclaw plugins install --help` exposes
     /// `--dangerously-force-unsafe-install`, including whether the advertised
     /// option is still effective or has become a deprecated no-op.
@@ -910,6 +936,8 @@ impl UnsafeInstallSupport {
 struct PluginPreflight<'a> {
     /// The host's installer supports accepting declared plugin capabilities.
     supports_accept_capabilities: bool,
+    /// `plugins enable --help` exposes `--accept-capabilities`.
+    supports_enable_accept_capabilities: bool,
     /// The host's `plugins install --help` exposes the unsafe flag.
     supports_unsafe_install: bool,
     /// The host's `plugins inspect --help` exposes `--json`.
@@ -978,7 +1006,7 @@ impl OpenClawDriver {
     }
 
     /// Probe the host CLI read-only for every pre-install fact: version,
-    /// `plugins install --help`, and `plugins inspect --help`. All probing
+    /// `plugins install/enable/inspect --help`. All probing
     /// happens here — before the first mutation — and the inspect
     /// capabilities are carried forward to `apply_enable` as
     /// [`PreparedEnable`] so apply never re-probes. Fails closed when a probe
@@ -1003,6 +1031,14 @@ impl OpenClawDriver {
         let supports_accept_capabilities = help_lists_flag(&install_help, "--accept-capabilities");
         let unsafe_install_support = unsafe_install_support(&install_help);
 
+        let enable_help = self.run_read_probe(
+            ctx,
+            build_enable_cmd("--help", &home, user_home, false),
+            "openclaw plugins enable --help",
+        )?;
+        let supports_enable_accept_capabilities =
+            help_lists_flag(&enable_help, "--accept-capabilities");
+
         let inspect_help = self.run_read_probe(
             ctx,
             build_inspect_help_cmd(&home, user_home),
@@ -1016,6 +1052,7 @@ impl OpenClawDriver {
             version_display,
             supports_install_force,
             supports_accept_capabilities,
+            supports_enable_accept_capabilities,
             unsafe_install_support,
             supports_inspect_json,
             supports_inspect_runtime,
@@ -1094,7 +1131,7 @@ impl OpenClawDriver {
     }
 
     /// Resolve the full plugin preflight before any mutation: profile (all
-    /// three probes), version precondition, `--json` inspect precondition,
+    /// read-only probes), version precondition, `--json` inspect precondition,
     /// version gate, install command, and selected config. Fails closed — the
     /// version must be parseable, the host must expose machine-readable
     /// (`--json`) inspect output for verification, and the `--force` /
@@ -1145,6 +1182,7 @@ impl OpenClawDriver {
         let selected_config = self.select_config(ctx, &profile)?;
         Ok(PluginPreflight {
             supports_accept_capabilities: profile.supports_accept_capabilities,
+            supports_enable_accept_capabilities: profile.supports_enable_accept_capabilities,
             supports_unsafe_install: profile.unsafe_install_support.is_effective(),
             supports_inspect_json: profile.supports_inspect_json,
             supports_inspect_runtime: profile.supports_inspect_runtime,
@@ -2331,6 +2369,24 @@ fn install_argv(
     args
 }
 
+/// Build explicit activation, or its read-only `--help` probe.
+fn build_enable_cmd(
+    plugin_id: &str,
+    home: &Path,
+    user_home: Option<&Path>,
+    accept_capabilities: bool,
+) -> FrameworkCommand {
+    let mut args = vec![
+        "plugins".to_string(),
+        "enable".to_string(),
+        plugin_id.to_string(),
+    ];
+    if accept_capabilities {
+        args.push("--accept-capabilities".to_string());
+    }
+    base_cmd(args, home, user_home)
+}
+
 /// Whether `help` lists `flag` as a standalone option token — not merely as a
 /// prefix of a longer flag. A flag token continues through any character that
 /// can appear inside an option name (ASCII alphanumeric, `-`, `_`, `.`), so a
@@ -3292,6 +3348,7 @@ mod tests {
             version_display: "2026.4.14".to_string(),
             supports_install_force: force,
             supports_accept_capabilities: false,
+            supports_enable_accept_capabilities: false,
             unsafe_install_support: if unsafe_install {
                 UnsafeInstallSupport::Effective
             } else {
@@ -4029,6 +4086,7 @@ mod tests {
                 &mut skill_claim,
                 &PreparedEnable::OpenClaw {
                     supports_accept_capabilities: false,
+                    supports_enable_accept_capabilities: false,
                     supports_unsafe_install: true,
                     supports_inspect_json: true,
                     supports_inspect_runtime: true,
@@ -4046,6 +4104,7 @@ mod tests {
                 &mut plugin_claim,
                 &PreparedEnable::OpenClaw {
                     supports_accept_capabilities: false,
+                    supports_enable_accept_capabilities: false,
                     supports_unsafe_install: true,
                     supports_inspect_json: false,
                     supports_inspect_runtime: false,
@@ -4064,6 +4123,7 @@ mod tests {
                 &mut plugin_claim,
                 &PreparedEnable::OpenClaw {
                     supports_accept_capabilities: false,
+                    supports_enable_accept_capabilities: false,
                     supports_unsafe_install: false,
                     supports_inspect_json: true,
                     supports_inspect_runtime: false,

--- a/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
@@ -248,6 +248,7 @@ const OWNED_ENV: &[&str] = &[
     "FAKE_OC_VERSION",
     "FAKE_OC_INSTALL_FORCE",
     "FAKE_OC_INSTALL_ACCEPT",
+    "FAKE_OC_ENABLE_ACCEPT",
     "FAKE_OC_INSTALL_UNSAFE",
     "FAKE_OC_INSTALL_UNSAFE_NOOP",
     "FAKE_OC_INSPECT_JSON",
@@ -402,6 +403,7 @@ fn stage() -> World {
 /// - `plugins install --help` lists `--force` unless `FAKE_OC_INSTALL_FORCE=0`
 ///   and `--dangerously-force-unsafe-install` when `FAKE_OC_INSTALL_UNSAFE=1`;
 ///   `FAKE_OC_INSTALL_UNSAFE_NOOP=1` marks that option as a deprecated no-op.
+/// - `plugins enable --help` advertises consent when `FAKE_OC_ENABLE_ACCEPT=1`.
 /// - `plugins inspect --help` lists `--json` unless `FAKE_OC_INSPECT_JSON=0`
 ///   and `--runtime` when `FAKE_OC_INSPECT_RUNTIME=1`.
 ///
@@ -411,9 +413,9 @@ fn stage() -> World {
 /// - `plugins inspect <id> [--runtime] --json` prints an optional legacy
 ///   diagnostic line (when `FAKE_OC_INSPECT_DIAG` is set) followed by the JSON
 ///   `{"plugin":{"id":..,"status":"$FAKE_OC_RUNTIME_STATUS"}}` (default
-///   `loaded`).
-/// - `plugins uninstall <id> ...` removes the marker; `plugins list` prints
-///   markers; `config set` echoes.
+///   `loaded` unless uninstall left a persistent disabled marker).
+/// - `plugins uninstall <id> ...` removes registration and persists disabled state;
+///   `plugins enable <id>` clears it. `plugins list` prints registry markers.
 /// - `FAKE_OPENCLAW_FAIL=untracked` refuses uninstall without changing the
 ///   registry; `FAKE_OC_LIST_JSON` overrides JSON listing, and
 ///   `FAKE_OC_PROBE_FAIL=list` makes listing fail.
@@ -500,6 +502,26 @@ case "$action" in
     if [ "${FAKE_OPENCLAW_FAIL:-}" = "install_after_register" ]; then echo "boom-after-register" >&2; exit 10; fi
     echo "installed $id"
     ;;
+  enable)
+    if [ "$arg3" = "--help" ]; then
+      echo "Usage: openclaw plugins enable [options] <id>"
+      [ "${FAKE_OC_ENABLE_ACCEPT:-0}" = "1" ] && echo "  --accept-capabilities  accept declared capabilities"
+      [ "${FAKE_OC_ENABLE_ACCEPT:-0}" = "near_match" ] && echo "  --accept-capabilities-only  unrelated option"
+      [ "${FAKE_OC_PROBE_FAIL:-}" = "enable_help" ] && exit 4
+      exit 0
+    fi
+    if [ "${FAKE_OPENCLAW_FAIL:-}" = "enable" ]; then echo "boom-enable" >&2; exit 16; fi
+    accepted=0
+    for option in "$@"; do [ "$option" = "--accept-capabilities" ] && accepted=1; done
+    if [ "${FAKE_OC_ENABLE_ACCEPT:-0}" = "1" ]; then
+      if [ "$accepted" != 1 ]; then echo "Plugin requires capability consent" >&2; exit 15; fi
+    elif [ "$accepted" = 1 ]; then
+      echo "unknown option --accept-capabilities" >&2; exit 2
+    fi
+    if [ ! -e "$OPENCLAW_STATE_DIR/registry/$arg3" ]; then echo "Plugin not found: $arg3" >&2; exit 1; fi
+    rm -f "$OPENCLAW_STATE_DIR/disabled/$arg3"
+    echo "enabled $arg3"
+    ;;
   inspect)
     if [ "$arg3" = "--help" ]; then
       echo "Usage: openclaw plugins inspect <id> [options]"
@@ -509,6 +531,7 @@ case "$action" in
       exit 0
     fi
     status="${FAKE_OC_RUNTIME_STATUS:-loaded}"
+    [ -e "$OPENCLAW_STATE_DIR/disabled/$arg3" ] && status=disabled
     [ -n "${FAKE_OC_INSPECT_DIAG:-}" ] && echo "legacy: reading plugin registry for $arg3 ..."
     echo "{\"plugin\":{\"id\":\"$arg3\",\"status\":\"$status\"}}"
     ;;
@@ -521,6 +544,8 @@ case "$action" in
     fi
     if [ ! -e "$reg/$arg3" ]; then echo "Plugin not found: $arg3" >&2; exit 1; fi
     rm -f "$reg/$arg3"
+    mkdir -p "$OPENCLAW_STATE_DIR/disabled"
+    : > "$OPENCLAW_STATE_DIR/disabled/$arg3"
     echo "uninstalled $arg3"
     ;;
   list)
@@ -683,6 +708,35 @@ fn enable_status_disable_happy_path() {
             .is_none(),
         "receipt must be gone after successful disable"
     );
+}
+
+#[test]
+fn enable_after_disable_restores_loaded_plugin() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("first enable");
+    manager
+        .disable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("disable");
+    let disabled = world.openclaw_home.join("disabled").join(COMPONENT);
+    assert!(
+        disabled.exists(),
+        "uninstall preserves explicit disabled state"
+    );
+    for _ in 0..2 {
+        let outcome = manager
+            .enable(COMPONENT, Some(FRAMEWORK), false)
+            .expect("re-enable");
+        let EnableOutcome::Enabled(claim) = outcome else {
+            panic!("expected enabled")
+        };
+        assert_eq!(claim.status, ClaimStatus::Enabled);
+        assert!(!disabled.exists(), "explicit enable clears disabled state");
+    }
 }
 
 #[test]
@@ -3206,8 +3260,8 @@ fn missing_inspect_json_blocks_before_mutation() {
     assert!(!world.has_claim());
 }
 
-/// P1 fail-closed: every read-only probe — `--version`, install `--help`, and
-/// inspect `--help` — is performed before the first mutation, so a non-zero
+/// P1 fail-closed: every read-only probe — `--version`, install/enable/inspect
+/// `--help` — is performed before the first mutation, so a non-zero
 /// exit from any of them blocks enable with no install and no receipt, even
 /// when the output would otherwise look like a capability answer.
 #[test]
@@ -3222,6 +3276,7 @@ fn nonzero_probe_exit_blocks_enable_before_mutation() {
             "inspect_help",
             "a non-zero inspect --help still mentioning --json",
         ),
+        ("enable_help", "a non-zero enable --help"),
     ] {
         let guard = OpenClawEnvGuard::acquire();
         let world = stage();
@@ -3241,8 +3296,8 @@ fn nonzero_probe_exit_blocks_enable_before_mutation() {
     }
 }
 
-/// Each probe runs exactly once in a real enable: all three (`--version`,
-/// install `--help`, inspect `--help`) happen in prepare, and apply re-probes
+/// Each probe runs exactly once in a real enable (`--version`,
+/// install/enable/inspect `--help`) happen in prepare, and apply re-probes
 /// nothing (it reuses the prepared capabilities).
 #[test]
 fn each_probe_runs_exactly_once_per_enable() {
@@ -3268,6 +3323,11 @@ fn each_probe_runs_exactly_once_per_enable() {
         "one install --help probe: {lines:?}"
     );
     assert_eq!(
+        count(&|l| l.as_str() == "plugins enable --help"),
+        1,
+        "one enable --help probe: {lines:?}"
+    );
+    assert_eq!(
         count(&|l| l.as_str() == "plugins inspect --help"),
         1,
         "one inspect --help probe: {lines:?}"
@@ -3275,12 +3335,19 @@ fn each_probe_runs_exactly_once_per_enable() {
 }
 
 #[test]
-fn enable_accepts_capabilities_only_when_install_help_supports_it() {
+fn enable_accepts_capabilities_per_subcommand_help() {
     let guard = OpenClawEnvGuard::acquire();
-    for support in ["1", "0", "near_match"] {
+    for (support, enable_support) in [
+        ("1", "1"),
+        ("1", "0"),
+        ("0", "1"),
+        ("0", "0"),
+        ("near_match", "near_match"),
+    ] {
         let world = stage();
         world.apply_env(&guard, None);
         guard.set("FAKE_OC_INSTALL_ACCEPT", support);
+        guard.set("FAKE_OC_ENABLE_ACCEPT", enable_support);
         let argv_log = world.argv_log();
         guard.set("FAKE_OC_ARGV_LOG", &argv_log);
         let manager = world.manager();
@@ -3296,8 +3363,19 @@ fn enable_accepts_capabilities_only_when_install_help_supports_it() {
                 .contains("--accept-capabilities"),
             support == "1"
         );
+        let activation = plan.actions.last().expect("activation preview");
+        assert!(activation.contains("plugins enable tokenless"));
+        assert_eq!(
+            activation.contains("--accept-capabilities"),
+            enable_support == "1"
+        );
         assert!(!world.has_claim());
         assert!(!world.registry_marker_exists());
+        assert!(
+            argv_lines(&argv_log)
+                .iter()
+                .all(|line| line == "--version" || line.ends_with("--help"))
+        );
         std::fs::write(&argv_log, "").expect("reset probe log");
         manager
             .enable(COMPONENT, Some(FRAMEWORK), false)
@@ -3315,8 +3393,52 @@ fn enable_accepts_capabilities_only_when_install_help_supports_it() {
             .expect("install argv");
         assert_eq!(install.contains("--accept-capabilities"), support == "1");
         assert!(!install.contains("--dangerously-force-unsafe-install"));
+        let activation = log
+            .lines()
+            .find(|line| line.starts_with("plugins enable tokenless"))
+            .expect("activation argv");
+        assert_eq!(
+            activation.contains("--accept-capabilities"),
+            enable_support == "1"
+        );
+        assert!(!activation.contains("--dangerously-force-unsafe-install"));
         assert!(world.registry_marker_exists());
     }
+}
+
+#[test]
+fn explicit_enable_failure_keeps_receipt_for_cleanup() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, Some("enable"));
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+    let manager = world.manager();
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("activation failure");
+    assert!(
+        matches!(err, AdapterError::FrameworkCli { reason, .. } if reason.contains("plugins enable") && reason.contains("boom-enable"))
+    );
+    assert!(world.registry_marker_exists());
+    assert_eq!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, FRAMEWORK)
+            .expect("cleanup receipt")
+            .status,
+        ClaimStatus::CleanupFailed
+    );
+    assert!(
+        inspect_argv(&argv_lines(&world.argv_log())).is_none(),
+        "do not verify after activation fails"
+    );
+    guard.unset("FAKE_OPENCLAW_FAIL");
+    assert!(
+        manager
+            .disable(COMPONENT, Some(FRAMEWORK), false)
+            .expect("cleanup")
+            .claim_removed
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Why

After `anolisa adapter disable`, OpenClaw 2026.9.2 preserves an explicit disabled entry. Reinstalling the plugin leaves that entry disabled, so the next adapter enable fails runtime verification.

## What changed

Run `plugins enable <id>` after installation and selected configuration writes, then retain the existing `loaded` verification. Probe enable-command capability consent separately from install consent before any mutation, carry the result in transient prepared state, and include activation in dry-run plans. Extend the existing fake CLI to preserve disabled state across uninstall/reinstall and cover activation failures and repeated enable.

## Related issue

closes #3220

## User / Agent impact

OpenClaw plugin adapters can be enabled again after disable. Activation failures remain visible and retain a receipt for cleanup.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

This restores the existing adapter-enable contract without changing CLI flags or the persisted receipt schema. `PreparedEnable::OpenClaw` gains one transient capability field. The enable command receives `--accept-capabilities` only when its own help advertises support, using the same consent policy already applied to install. No unsafe-install authorization is added. Existing command environment, timeout, and receipt-first failure handling are reused; skill-only bundles skip activation. An enable-help probe failure stops before mutation; older upstream versions already expose the enable command.

## Validation

Linux, from `src/anolisa`:

- Regression test failed before the driver fix with `disabled` instead of `loaded`.
- `cargo test --locked -p anolisa-core --test adapter_manager`: 86 passed.
- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`: 2,514 passed, 1 ignored.
- `cargo doc --workspace --no-deps --locked`
- Independent agent review: approved with no actionable findings.
- The local copilot-shell pre-commit hook could not load its missing `lint-staged` dependency. Its configured globs exclude Rust; `HUSKY=0` was used only for this commit after all Rust checks passed.

The fake-CLI tests cover enable/disable/re-enable, repeat enable, independent consent support, read-only dry-run, probe failure, activation failure and cleanup. A live OpenClaw 2026.9.2 run was not performed.

## Documentation and rollback

Updated driver rustdoc to describe explicit activation and its preflight probe. Public command syntax is unchanged. Revert this commit to roll back; no receipt migration is required.
