### PR TITLE
feat(cosh-ng): [shell] complete Composer commands

### DIFF
--- a/docs/user-guide/en/user-entrypoint/cosh-ng/shell/interactive-mode.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/shell/interactive-mode.md
@@ -76,6 +76,27 @@ as a multiline editor without changing how later shell input is routed. Enter
 sends the request, `Shift+Enter` adds a line, and `Esc` cancels it and restores
 the shell prompt.
 
+Type `/` as the first token to browse public slash commands. Continue typing to
+filter by prefix (`/ho` suggests `/hooks`); Up/Down selects a candidate and
+scrolls through the six-row list. Tab replaces the command token and adds a
+space for arguments. When a single-line draft contains only the command token,
+Enter accepts and executes the selected candidate (the first candidate by
+default). Drafts with arguments or multiple lines are submitted as written.
+Esc cancels the Composer, including when the list is open.
+Slash commands use the same local command handlers and confirmation cards as
+at the shell prompt. A command submission ends the Composer: its interactive
+card takes over input, or the shell prompt returns when the command finishes.
+Unknown command names display a local error instead of starting an Agent turn.
+
+`/skill:<name>` still selects a Skill for an Agent request; `/skills` manages
+Skills. Existing absolute paths such as `/tmp` and `/etc`, and paths containing
+another slash such as `/tmp/file`, remain Agent text. Bare `/` opens the command
+menu; exact registered command names take precedence over same-named paths.
+Prefix a request with `??` to discuss a slash command literally,
+for example `?? /help explain this command`. Commands in later tokens do not
+activate the menu. Tabs and newlines inside bracketed paste remain text.
+Ordinary shell prompts retain their native path completion.
+
 The first token may select one Skill, and any later whitespace-separated token
 that starts with `@` requests a file or directory from the current workspace:
 

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/shell/interactive-mode.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/shell/interactive-mode.md
@@ -72,6 +72,22 @@
 编辑器，但不会改变后续 Shell 输入的路由方式。按 Enter 发送请求，按
 `Shift+Enter`插入换行，按`Esc`取消并恢复 Shell prompt。
 
+在第一个 token 输入 `/` 可浏览公开的 slash 命令。继续输入按前缀筛选（`/ho`
+会提示 `/hooks`）；上/下键选择候选并滚动六行列表。Tab 替换命令 token，追加一个
+空格以便输入参数。单行草稿只有命令 token 时，Enter 接受并执行选中的候选
+（默认第一项）；带参数或多行的草稿按原文提交。即使列表已打开，Esc 也会取消
+Composer。Slash 命令复用 Shell prompt 中的本地处理器和确认卡片。
+提交命令后 Composer 结束：交互卡片接管输入，或在命令完成后恢复 Shell prompt。
+未知命令名会显示本地错误，不会启动 Agent turn。
+
+`/skill:<name>` 仍为 Agent 请求选择 Skill，`/skills` 用于管理 Skill。已存在的绝对
+路径（如 `/tmp`、`/etc`），以及包含另一个斜杠的路径（如 `/tmp/file`）仍作为
+Agent 文本。单独的 `/` 打开命令菜单；完整的已注册命令名优先于同名路径。
+要在请求中讨论 slash 命令，
+可显式添加 `??` 前缀，例如 `?? /help explain this command`。后续 token 中的命令
+不会激活候选列表。括号粘贴中的 Tab 和换行仍为文本。普通 Shell prompt 保留原生
+路径补全。
+
 第一个 token 可以选择一个 Skill，后续任何以`@`开头、由空白分隔的 token 都可以
 引用当前工作空间内的文件或目录。
 

--- a/src/cosh-ng/README.md
+++ b/src/cosh-ng/README.md
@@ -108,7 +108,11 @@ for confirmation. Approval settings use `recommend`, `auto`, or `trust` across
 the shell and Core. In enhanced integration, the cosh-core runtime makes
 `/agent` open a one-shot
 Composer that accepts a leading `/skill:<name>` and validated workspace-local
-`@path` references.
+`@path` references. Type `/` in the Composer to browse slash commands, use
+Up/Down to select, and press Enter to execute the selected command. Use Tab to
+complete a command before adding arguments; Enter submits drafts with arguments
+or multiple lines as written.
+Ordinary shell prompts keep native path completion.
 
 To run one locally installed ACP adapter without entering the interactive
 Shell, verify it first and then pipe the prompt through stdin:

--- a/src/cosh-ng/README_zh.md
+++ b/src/cosh-ng/README_zh.md
@@ -101,7 +101,9 @@ bash: hello: command not found
 调用工具前都等待确认，运行 `/mode approval recommend`。Shell 和 Core 的审批设置
 统一使用 `recommend`、`auto` 或 `trust`。增强集成使用 cosh-core runtime 时，`/agent`
 会打开一次性 Composer，可在开头指定 `/skill:<name>`，并添加经过验证的工作空间内
-`@路径`引用。
+`@路径`引用。在 Composer 中输入 `/` 可浏览 slash 命令，用上/下键选择、Enter 执行。
+需要填写参数时先按 Tab 补全；带参数或多行的草稿由 Enter 按原文提交。
+普通 Shell prompt 保留原生路径补全。
 
 如果要在不进入交互式 Shell 的情况下运行本机已安装的 ACP Adapter，可以先检查
 Adapter，再通过 stdin 发送 prompt。

--- a/src/cosh-ng/crates/cosh-shell/src/agent/composer.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/composer.rs
@@ -2,6 +2,8 @@
 
 use std::path::{Component, Path, PathBuf};
 
+use crate::input::composer::{slash_completions, token_prefix_at_cursor};
+
 use crate::types::composer::{
     replace_composer_submission, ComposerReference, ComposerReferenceKind, ComposerSubmission,
 };
@@ -86,29 +88,13 @@ pub(crate) fn completions(
             })
             .collect();
     }
-    Vec::new()
-}
-
-fn token_prefix_at_cursor(
-    input: &str,
-    cursor_row: usize,
-    cursor_col: usize,
-) -> Option<(String, bool)> {
-    let line = input.split('\n').nth(cursor_row)?;
-    let chars = line.chars().collect::<Vec<_>>();
-    let cursor_col = cursor_col.min(chars.len());
-    let start = chars[..cursor_col]
-        .iter()
-        .rposition(|ch| ch.is_whitespace())
-        .map_or(0, |index| index + 1);
-    let prefix = chars[start..cursor_col].iter().collect::<String>();
-    let prior_lines_are_empty = input
-        .split('\n')
-        .take(cursor_row)
-        .all(|prior| prior.trim().is_empty());
-    let first_token =
-        prior_lines_are_empty && chars[..start].iter().collect::<String>().trim().is_empty();
-    Some((prefix, first_token))
+    slash_completions(input, cursor_row, cursor_col)
+        .into_iter()
+        .map(|name| ComposerCompletion {
+            display: name.to_string(),
+            replacement: format!("{name} "),
+        })
+        .collect()
 }
 
 fn path_completions(prefix: &str, workspace_cwd: Option<&str>) -> Vec<ComposerCompletion> {

--- a/src/cosh-ng/crates/cosh-shell/src/agent/composer_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/composer_tests.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use super::composer::{attach_submission, completions, ComposerReferenceRejection};
+use crate::input::composer::{is_slash_submission, slash_completions};
 use crate::types::{
     AgentMode, AgentRequest, CommandBlock, CommandOrigin, CommandStatus, OutputRefs,
 };
@@ -79,6 +80,12 @@ fn skill_completion_only_applies_to_the_leading_directive() {
         vec!["/skill:release-notes", "/skill:repo-review"]
     );
     assert_eq!(matches[0].replacement, "/skill:release-notes ");
+    assert_eq!(completions("/skill", 0, 6, None, &skills), matches);
+    assert!(completions("/skill", 0, 6, None, &[]).is_empty());
+    assert_eq!(
+        completions("/skills", 0, 7, None, &skills)[0].display,
+        "/skills"
+    );
     assert!(completions("inspect /skill:r", 0, 16, None, &skills).is_empty());
 }
 
@@ -125,4 +132,57 @@ fn valid_reference_limit_reports_every_excess_reference() {
     assert!(!prompt.contains("- file: \"file-16.txt\""), "{prompt}");
     assert!(prompt.contains("rejected_reference_count: 2"), "{prompt}");
     let _ = std::fs::remove_dir_all(workspace);
+}
+
+#[test]
+fn composer_commands_are_public_unique_and_prefix_filtered() {
+    let all = slash_completions("/", 0, 1);
+    assert!(all.contains(&"/help"));
+    assert!(all.contains(&"/mcp"));
+    assert_eq!(all.iter().filter(|name| **name == "/mode").count(), 1);
+    assert!(!all.contains(&"/details"));
+    assert!(!all.contains(&"/approve"));
+    assert_eq!(slash_completions("/ho", 0, 3), ["/hooks"]);
+    assert!(slash_completions("/skill", 0, 6).is_empty());
+    assert_eq!(slash_completions("/skills", 0, 7), ["/skills"]);
+    assert_eq!(slash_completions("/sta", 0, 4), ["/status", "/stats"]);
+    assert!(slash_completions("/tmp/", 0, 5).is_empty());
+    for path in ["/tmp", "/etc"] {
+        assert!(std::path::Path::new(path).exists());
+        for col in 1..=path.len() {
+            assert!(slash_completions(path, 0, col).is_empty());
+            assert!(completions(path, 0, col, None, &[]).is_empty());
+        }
+    }
+    assert!(slash_completions("/hooks/file", 0, 3).is_empty());
+    assert!(slash_completions("/skill:review", 0, 3).is_empty());
+    assert!(slash_completions("explain /ho", 0, 11).is_empty());
+    assert!(slash_completions("/hooks /", 0, 8).is_empty());
+    assert_eq!(slash_completions("\n  /he", 1, 5), ["/help", "/health"]);
+}
+
+#[test]
+fn composer_routing_keeps_paths_skills_and_explicit_prompts_as_agent_text() {
+    for input in [
+        "/",
+        "/ho",
+        " /hooks ",
+        "/unknown",
+        "/mode approval auto",
+        "/cancel",
+    ] {
+        assert!(is_slash_submission(input), "{input}");
+    }
+    for input in [
+        "",
+        "/tmp",
+        "/etc explain this",
+        "/tmp/file explain this",
+        "/skill:repo-review inspect",
+        "/skill:team/review",
+        "?? /help",
+        "explain /help",
+    ] {
+        assert!(!is_slash_submission(input), "{input}");
+    }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
@@ -14,11 +14,12 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
             "Enter send · Shift+Enter newline · Esc cancel"
         }
         MessageId::PromptDraftFooterSubmitted => "Sent to agent",
+        MessageId::PromptDraftFooterControlSubmitted => "Command submitted",
         MessageId::PromptDraftFooterCancelled => "Draft cancelled",
         MessageId::AgentComposerTitle => "Agent Composer",
         MessageId::PromptDraftRuntimeLabel => "Runtime",
         MessageId::AgentComposerFooterEditing => {
-            "Enter send · Shift+Enter newline · Tab complete · @path · /skill:name · Esc cancel"
+            "/ commands · ↑↓ select · Tab complete · Enter submit · Shift+Enter newline · Esc cancel"
         }
         MessageId::AgentComposerRejectedTitle => "References skipped",
         MessageId::AgentComposerRejectedInvalidPathLine => {

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -112,4 +112,5 @@ collect_message_ids!([
     hook_action_ids,
     enhanced_routing_mode_ids,
     managed_task_ids,
+    composer_control_submit_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
@@ -204,3 +204,10 @@ macro_rules! managed_task_ids {
         );
     };
 }
+
+// Append submission status separately to preserve existing MessageId values.
+macro_rules! composer_control_submit_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!($remaining, $($ids,)* PromptDraftFooterControlSubmitted,);
+    };
+}

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -185,22 +185,22 @@ mod tests {
         );
         assert_eq!(
             MessageId::ApprovalShellHandoffInputWaitTimeoutTitle as usize,
-            MessageId::ALL.len() - 45
+            MessageId::ALL.len() - 46
         );
         assert_eq!(
             MessageId::ShellInputWaitHintTimeoutForecastBody as usize,
-            MessageId::ALL.len() - 36
+            MessageId::ALL.len() - 37
         );
         // The #2068 startup auth-hint segment remains ahead of the appended
         // session-picker footer, Agent Composer, Trust-catalog, and hook-action
         // segments.
         assert_eq!(
             MessageId::StartupAuthHintLine as usize,
-            MessageId::ALL.len() - 35
+            MessageId::ALL.len() - 36
         );
         assert_eq!(
             MessageId::SessionPickerMarkedFooter as usize,
-            MessageId::ALL.len() - 34
+            MessageId::ALL.len() - 35
         );
         assert_eq!(
             MessageId::AgentComposerTitle as usize,
@@ -208,7 +208,7 @@ mod tests {
         );
         assert_eq!(
             MessageId::AgentComposerFooterEditing as usize,
-            MessageId::ALL.len() - 31
+            MessageId::ALL.len() - 32
         );
         assert_eq!(
             MessageId::AgentComposerRejectedTitle as usize,
@@ -220,53 +220,53 @@ mod tests {
         );
         assert_eq!(
             MessageId::ApprovalTrustUnknownToolReason as usize,
-            MessageId::ALL.len() - 23
+            MessageId::ALL.len() - 24
         );
         // The hook-action segment follows the Trust-catalog segment and remains
         // ahead of the appended Enhanced-routing segment.
         assert_eq!(
             MessageId::SlashHooksActionCancelledTitle as usize,
-            MessageId::ALL.len() - 22
+            MessageId::ALL.len() - 23
         );
         assert_eq!(
             MessageId::SlashHooksActionCancelledBody as usize,
-            MessageId::ALL.len() - 21
+            MessageId::ALL.len() - 22
         );
         assert_eq!(
             MessageId::SlashHooksActionVerbEnable as usize,
-            MessageId::ALL.len() - 20
+            MessageId::ALL.len() - 21
         );
         assert_eq!(
             MessageId::SlashHooksActionVerbDisable as usize,
-            MessageId::ALL.len() - 19
+            MessageId::ALL.len() - 20
         );
         assert_eq!(
             MessageId::SlashHooksActionQuestion as usize,
-            MessageId::ALL.len() - 18
+            MessageId::ALL.len() - 19
         );
         assert_eq!(
             MessageId::SlashHooksActionOptionShell as usize,
-            MessageId::ALL.len() - 17
+            MessageId::ALL.len() - 18
         );
         assert_eq!(
             MessageId::SlashHooksActionOptionAgent as usize,
-            MessageId::ALL.len() - 16
+            MessageId::ALL.len() - 17
         );
         assert_eq!(
             MessageId::SlashHooksActionOptionBoth as usize,
-            MessageId::ALL.len() - 15
+            MessageId::ALL.len() - 16
         );
         assert_eq!(
             MessageId::SlashHooksActionAgentEnabledBody as usize,
-            MessageId::ALL.len() - 14
+            MessageId::ALL.len() - 15
         );
         assert_eq!(
             MessageId::SlashHooksActionAgentDisabledBody as usize,
-            MessageId::ALL.len() - 13
+            MessageId::ALL.len() - 14
         );
         assert_eq!(
             MessageId::SlashHooksActionAgentErrorBody as usize,
-            MessageId::ALL.len() - 12
+            MessageId::ALL.len() - 13
         );
         assert_eq!(
             MessageId::HelpSummaryModeRouting as usize,
@@ -274,7 +274,7 @@ mod tests {
         );
         assert_eq!(
             MessageId::RoutingModeShellOnlyFooter as usize,
-            MessageId::ALL.len() - 2
+            MessageId::ALL.len() - 3
         );
         assert_eq!(
             MessageId::HelpSummaryTask as usize,
@@ -282,6 +282,14 @@ mod tests {
         );
         assert_eq!(
             MessageId::HelpSummaryTask as usize,
+            MessageId::ALL.len() - 2
+        );
+        assert_eq!(
+            MessageId::PromptDraftFooterControlSubmitted as usize,
+            MessageId::HelpSummaryTask as usize + 1
+        );
+        assert_eq!(
+            MessageId::PromptDraftFooterControlSubmitted as usize,
             MessageId::ALL.len() - 1
         );
     }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -14,11 +14,12 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
             "Enter 发送 · Shift+Enter 换行 · Esc 取消"
         }
         MessageId::PromptDraftFooterSubmitted => "已发送给 Agent",
+        MessageId::PromptDraftFooterControlSubmitted => "命令已提交",
         MessageId::PromptDraftFooterCancelled => "草稿已取消",
         MessageId::AgentComposerTitle => "Agent Composer",
         MessageId::PromptDraftRuntimeLabel => "Runtime",
         MessageId::AgentComposerFooterEditing => {
-            "Enter 发送 · Shift+Enter 换行 · Tab 补全 · @路径 · /skill:名称 · Esc 取消"
+            "/ 命令 · ↑↓ 选择 · Tab 补全 · Enter 提交 · Shift+Enter 换行 · Esc 取消"
         }
         MessageId::AgentComposerRejectedTitle => "已跳过引用",
         MessageId::AgentComposerRejectedInvalidPathLine => {

--- a/src/cosh-ng/crates/cosh-shell/src/input/composer.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/input/composer.rs
@@ -1,0 +1,66 @@
+//! Command discovery and routing for the Agent-owned composer.
+
+use crate::slash::registry::{active_slash_commands, exact_slash_control_commands};
+
+pub(crate) fn slash_completions(input: &str, row: usize, col: usize) -> Vec<&'static str> {
+    let Some((prefix, first_token)) = token_prefix_at_cursor(input, row, col) else {
+        return Vec::new();
+    };
+    if !first_token || !prefix.starts_with('/') || prefix == "/skill" || !is_slash_submission(input)
+    {
+        return Vec::new();
+    }
+    // Editing the start of a path or Skill directive must not replace the
+    // complete token with a command just because the cursor precedes `/` or `:`.
+    if input.split('\n').nth(row).is_some_and(|line| {
+        line.chars()
+            .skip(col)
+            .take_while(|ch| !ch.is_whitespace())
+            .any(|ch| matches!(ch, '/' | ':'))
+    }) {
+        return Vec::new();
+    }
+    let mut names = Vec::new();
+    for name in active_slash_commands().filter(|name| name.starts_with(&prefix)) {
+        if !names.contains(&name) {
+            names.push(name);
+        }
+    }
+    names
+}
+
+pub(crate) fn is_slash_submission(input: &str) -> bool {
+    let token = input.split_whitespace().next().unwrap_or_default();
+    // Explicit Agent prompts and skill directives keep their existing route.
+    // Keep the menu and exact commands ahead of filesystem paths, as at the
+    // shell prompt. Other existing paths remain ordinary Agent text.
+    token.strip_prefix('/').is_some_and(|name| {
+        !name.contains('/')
+            && !name.starts_with("skill:")
+            && (token == "/"
+                || exact_slash_control_commands().any(|command| command == token)
+                || !std::path::Path::new(token).exists())
+    })
+}
+
+pub(crate) fn token_prefix_at_cursor(
+    input: &str,
+    cursor_row: usize,
+    cursor_col: usize,
+) -> Option<(String, bool)> {
+    let line = input.split('\n').nth(cursor_row)?;
+    let chars = line.chars().collect::<Vec<_>>();
+    let cursor_col = cursor_col.min(chars.len());
+    let start = chars[..cursor_col]
+        .iter()
+        .rposition(|ch| ch.is_whitespace())
+        .map_or(0, |index| index + 1);
+    let prefix = chars[start..cursor_col].iter().collect::<String>();
+    let prior_lines_are_empty = input
+        .split('\n')
+        .take(cursor_row)
+        .all(|prior| prior.trim().is_empty());
+    let first_token =
+        prior_lines_are_empty && chars[..start].iter().collect::<String>().trim().is_empty();
+    Some((prefix, first_token))
+}

--- a/src/cosh-ng/crates/cosh-shell/src/input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/input/mod.rs
@@ -3,7 +3,7 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-
+pub(crate) mod composer;
 pub(crate) mod path_prompt;
 pub(crate) use path_prompt::{PathPromptIntercept, ShellPathCommandNames, ShellPromptCwd};
 

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
@@ -297,8 +297,10 @@ mod tests {
     fn prompt_draft_cancel_releases_the_capture_mode() {
         let capture = RawInputCapture::PromptDraft {
             id: "draft-1".to_string(),
-            initial_text: String::new(),
+            initial_text: "".into(),
             completion: None,
+            agent_composer: false,
+            workspace_cwd: None,
         };
         let input_mode = Arc::new(Mutex::new(RawInputMode::Capture {
             capture: capture.clone(),
@@ -333,8 +335,10 @@ mod tests {
     fn prompt_draft_submit_releases_the_capture_mode() {
         let capture = RawInputCapture::PromptDraft {
             id: "draft-1".to_string(),
-            initial_text: "hello".to_string(),
+            initial_text: "hello".into(),
             completion: None,
+            agent_composer: false,
+            workspace_cwd: None,
         };
         let input_mode = Arc::new(Mutex::new(RawInputMode::Capture {
             capture: capture.clone(),

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
@@ -29,7 +29,7 @@ pub(super) struct CardInputState {
     /// Bracketed paste passthrough inside the draft card: newlines paste as
     /// draft newlines instead of submitting.
     draft_paste: bool,
-    draft_completion: Option<String>,
+    draft_selection: Option<prompt_draft::DraftSlashSelection>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -72,7 +72,6 @@ enum CardInputKind {
 
 impl CardInputState {
     pub(super) fn apply_capture(&mut self, capture: &RawInputCapture) {
-        self.refresh_draft_completion(capture);
         let kind = match capture {
             RawInputCapture::Question {
                 id,
@@ -197,6 +196,7 @@ impl CardInputState {
         self.pending_input.clear();
         self.draft = PromptDraftEditor::default();
         self.draft_paste = false;
+        self.draft_selection = None;
     }
 
     pub(super) fn consume(
@@ -262,11 +262,10 @@ impl CardInputState {
                         idx = self.draft_pasted_newline(capture, &input, idx, &mut events);
                         continue;
                     }
+                    events.extend(self.draft_complete_command_on_submit(capture));
                     let event = self.submit(capture);
                     let submitted = event.is_some();
-                    if let Some(event) = event {
-                        events.push(event);
-                    }
+                    events.extend(event);
                     // Always clear free_text after a submit attempt so that a
                     // subsequent capture (e.g. the next auth field) starts with
                     // a clean buffer.  The outer consume_captured_input also
@@ -652,7 +651,7 @@ impl CardInputState {
                 Some(RawInputEvent::SessionResume(id.clone(), self.selected))
             }
             RawInputCapture::Evidence { id } => Some(RawInputEvent::EvidenceSend(id.clone())),
-            RawInputCapture::PromptDraft { id, .. } => self.draft_submit_event(id),
+            RawInputCapture::PromptDraft { id, .. } => self.draft_submit_event(id, capture),
         }
     }
 

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/navigation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/navigation.rs
@@ -175,6 +175,9 @@ impl CardInputState {
             }
             RawInputCapture::Evidence { .. } => None,
             RawInputCapture::PromptDraft { .. } => {
+                if self.draft_select_command(capture, code) {
+                    return self.input_event(capture);
+                }
                 match code {
                     b'A' => self.draft.move_up(),
                     b'B' => self.draft.move_down(),
@@ -240,13 +243,7 @@ impl CardInputState {
                 }
             }
             RawInputCapture::Evidence { .. } => None,
-            RawInputCapture::PromptDraft { .. } => {
-                let replacement = self.draft_completion.clone()?;
-                self.draft
-                    .replace_current_token(&replacement)
-                    .then(|| self.input_event(capture))
-                    .flatten()
-            }
+            RawInputCapture::PromptDraft { .. } => self.draft_complete(capture),
         }
     }
 

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/prompt_draft.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/prompt_draft.rs
@@ -6,15 +6,103 @@
 
 use super::{CardInputKind, CardInputState, RawInputCapture, RawInputEvent};
 
+use crate::input::composer::{is_slash_submission, slash_completions};
+
+#[derive(Debug)]
+pub(super) struct DraftSlashSelection {
+    text: String,
+    cursor: (usize, usize),
+    index: usize,
+}
+
 impl CardInputState {
-    /// Refreshes the first visible completion without resetting editor state.
-    pub(super) fn refresh_draft_completion(&mut self, capture: &RawInputCapture) {
-        self.draft_completion = match capture {
-            RawInputCapture::PromptDraft { completion, .. } => {
-                completion.as_deref().map(str::to_string)
+    fn draft_cursor(&self) -> (usize, usize) {
+        let view = self.draft.viewport();
+        (view.first_row + view.cursor.0, view.cursor.1)
+    }
+
+    fn draft_selected(&self) -> usize {
+        self.draft_selection
+            .as_ref()
+            .filter(|selection| {
+                selection.text == self.draft.text() && selection.cursor == self.draft_cursor()
+            })
+            .map_or(0, |selection| selection.index)
+    }
+
+    fn draft_commands(&self, capture: &RawInputCapture) -> Vec<&'static str> {
+        if !matches!(
+            capture,
+            RawInputCapture::PromptDraft {
+                agent_composer: true,
+                ..
             }
-            _ => None,
+        ) {
+            return Vec::new();
+        }
+        let (row, col) = self.draft_cursor();
+        slash_completions(&self.draft.text(), row, col)
+    }
+
+    pub(super) fn draft_select_command(&mut self, capture: &RawInputCapture, code: u8) -> bool {
+        let commands = self.draft_commands(capture);
+        if commands.is_empty() || !matches!(code, b'A' | b'B') || self.draft_paste {
+            return false;
+        }
+        let selected = self.draft_selected().min(commands.len() - 1);
+        let index = if code == b'A' {
+            selected.saturating_sub(1)
+        } else {
+            (selected + 1).min(commands.len() - 1)
         };
+        self.draft_selection = Some(DraftSlashSelection {
+            text: self.draft.text(),
+            cursor: self.draft_cursor(),
+            index,
+        });
+        true
+    }
+
+    pub(super) fn draft_complete(&mut self, capture: &RawInputCapture) -> Option<RawInputEvent> {
+        // Resolve slash names from the live editor, including keys in the same
+        // read chunk. Runtime-rendered completions can lag behind that input.
+        let commands = self.draft_commands(capture);
+        let replacement = if let Some(name) = commands.get(self.draft_selected()) {
+            format!("{name} ")
+        } else if let RawInputCapture::PromptDraft {
+            initial_text,
+            completion: Some(completion),
+            ..
+        } = capture
+        {
+            let (replacement, cursor) = completion.as_ref();
+            if initial_text.as_ref() != self.draft.text() || *cursor != self.draft_cursor() {
+                return None;
+            }
+            replacement.clone()
+        } else {
+            return None;
+        };
+        self.draft
+            .replace_current_token(&replacement)
+            .then(|| self.input_event(capture))
+            .flatten()
+    }
+
+    pub(super) fn draft_complete_command_on_submit(
+        &mut self,
+        capture: &RawInputCapture,
+    ) -> Option<RawInputEvent> {
+        // Only a lone command token accepts the menu selection on Enter;
+        // arguments and multiline drafts must retain the user's text.
+        if self.draft.line_count() == 1
+            && self.draft.text().split_whitespace().count() == 1
+            && !self.draft_commands(capture).is_empty()
+        {
+            self.draft_complete(capture)
+        } else {
+            None
+        }
     }
 
     /// A trailing bare ESC may be the first half of a split legacy
@@ -151,13 +239,28 @@ impl CardInputState {
 
     /// Enter submits the whole draft; blank drafts never submit (matrix #9)
     /// so the user can keep composing or cancel with Esc.
-    pub(super) fn draft_submit_event(&self, id: &str) -> Option<RawInputEvent> {
+    pub(super) fn draft_submit_event(
+        &self,
+        id: &str,
+        capture: &RawInputCapture,
+    ) -> Option<RawInputEvent> {
         if self.draft.is_blank() {
             return None;
         }
+        let RawInputCapture::PromptDraft { workspace_cwd, .. } = capture else {
+            return None;
+        };
         Some(RawInputEvent::PromptDraftSubmit {
             id: id.to_string(),
             text: self.draft.text(),
+            workspace_cwd: workspace_cwd.as_deref().map(str::to_owned),
+            slash: matches!(
+                capture,
+                RawInputCapture::PromptDraft {
+                    agent_composer: true,
+                    ..
+                }
+            ) && is_slash_submission(&self.draft.text()),
         })
     }
 
@@ -166,8 +269,13 @@ impl CardInputState {
         RawInputEvent::PromptDraftChanged {
             id: id.to_string(),
             text: self.draft.text(),
-            viewport: self.draft.viewport(),
+            viewport: Box::new(self.draft.viewport()),
             line_count: self.draft.line_count(),
+            selected_completion: self.draft_selected(),
         }
     }
 }
+
+#[cfg(test)]
+#[path = "prompt_draft_tests.rs"]
+mod tests;

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/prompt_draft_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/prompt_draft_tests.rs
@@ -1,0 +1,166 @@
+use super::*;
+
+fn capture(text: &str, agent_composer: bool) -> RawInputCapture {
+    RawInputCapture::PromptDraft {
+        id: "composer-1".into(),
+        initial_text: text.into(),
+        completion: None,
+        agent_composer,
+        workspace_cwd: None,
+    }
+}
+
+fn submitted(events: &[RawInputEvent]) -> (&str, bool) {
+    events
+        .iter()
+        .find_map(|event| match event {
+            RawInputEvent::PromptDraftSubmit { text, slash, .. } => Some((text.as_str(), *slash)),
+            _ => None,
+        })
+        .expect("submitted draft")
+}
+
+#[test]
+fn composer_completes_and_submits_from_live_input_in_one_chunk() {
+    let capture = capture("", true);
+    for (input, expected) in [
+        (b"/ho\t\r".as_slice(), "/hooks "),
+        (b"/ho\r".as_slice(), "/hooks "),
+        (b"/\r".as_slice(), "/help "),
+        (b"/sta\x1b[B\r".as_slice(), "/stats "),
+        (b"/sta\x1b[B\x7f\x7f\x7fho\r".as_slice(), "/hooks "),
+        (b"/sta\x1b[B\t\r".as_slice(), "/stats "),
+        (b"/sta\x1b[B\x1b[A\t\r".as_slice(), "/status "),
+        (b"/sta\x1b[B\x7f\x7f\x7fho\t\r".as_slice(), "/hooks "),
+    ] {
+        let mut state = CardInputState::default();
+        state.apply_capture(&capture);
+        let (events, remainder) = state.consume_split(&capture, input);
+        assert!(remainder.is_empty());
+        assert_eq!(submitted(&events), (expected, true));
+    }
+}
+
+#[test]
+fn composer_can_select_every_public_command_across_chunks() {
+    let capture = capture("/", true);
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+    let commands = slash_completions("/", 0, 1);
+    for index in 1..commands.len() {
+        let events = state.consume(&capture, b"\x1b[B");
+        assert!(
+            matches!(events.last(), Some(RawInputEvent::PromptDraftChanged {
+            selected_completion, ..
+        }) if *selected_completion == index)
+        );
+        // A delayed repaint must not reset the live editor's selection.
+        state.apply_capture(&capture);
+    }
+    let events = state.consume(&capture, b"\r");
+    assert_eq!(
+        submitted(&events),
+        (format!("{} ", commands.last().unwrap()).as_str(), true)
+    );
+}
+
+#[test]
+fn composer_enter_preserves_arguments_multiline_drafts_and_other_routes() {
+    for (text, composer, slash) in [
+        ("/ho details", true, true),
+        ("\n/ho", true, true),
+        ("/unknown", true, true),
+        ("/help", false, false),
+        ("/skill:repo-review", true, false),
+        ("/tmp/file", true, false),
+        ("?? /help", true, false),
+    ] {
+        let capture = capture(text, composer);
+        let mut state = CardInputState::default();
+        state.apply_capture(&capture);
+        let events = state.consume(&capture, b"\r");
+        assert_eq!(submitted(&events), (text, slash));
+    }
+}
+
+#[test]
+fn composer_enter_preserves_arguments_when_editing_the_command_token() {
+    let capture = capture("/ho details", true);
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+    let events = state.consume(&capture, b"\x01\x1b[C\x1b[C\x1b[C\r");
+    assert_eq!(submitted(&events), ("/ho details", true));
+}
+
+#[test]
+fn composer_paste_keeps_tabs_and_newlines_as_data() {
+    let capture = capture("", true);
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+    let events = state.consume(
+        &capture,
+        b"\x1b[200~/skill:repo-review\tinspect\n@src\x1b[201~\r",
+    );
+    assert_eq!(
+        submitted(&events),
+        ("/skill:repo-review\tinspect\n@src", false)
+    );
+}
+
+#[test]
+fn composer_rejects_runtime_completion_after_text_or_cursor_changes() {
+    let mut capture = capture("review @sr", true);
+    if let RawInputCapture::PromptDraft { completion, .. } = &mut capture {
+        *completion = Some(Box::new(("@src/".into(), (0, 10))));
+    }
+    for (input, expected) in [
+        (b"c\t\r".as_slice(), "review @src"),
+        (b"\x01\t\r".as_slice(), "review @sr"),
+    ] {
+        let mut state = CardInputState::default();
+        state.apply_capture(&capture);
+        let events = state.consume(&capture, input);
+        assert_eq!(submitted(&events), (expected, false));
+    }
+}
+
+#[test]
+fn composer_bare_skill_uses_the_runtime_skill_completion() {
+    let mut capture = capture("/skill", true);
+    if let RawInputCapture::PromptDraft { completion, .. } = &mut capture {
+        *completion = Some(Box::new(("/skill:repo-review ".into(), (0, 6))));
+    }
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+    let events = state.consume(&capture, b"\tinspect\r");
+    assert_eq!(submitted(&events), ("/skill:repo-review inspect", false));
+}
+
+#[test]
+fn composer_submit_retains_its_workspace() {
+    let mut capture = capture("/health", true);
+    if let RawInputCapture::PromptDraft { workspace_cwd, .. } = &mut capture {
+        *workspace_cwd = Some("/workspace/project".into());
+    }
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+    let events = state.consume(&capture, b"\r");
+    assert!(
+        matches!(events.last(), Some(RawInputEvent::PromptDraftSubmit {
+        workspace_cwd: Some(cwd), slash: true, ..
+    }) if cwd == "/workspace/project")
+    );
+}
+
+#[test]
+fn composer_existing_paths_survive_completion_and_submit() {
+    for path in ["/tmp", "/etc", "/tmp/file"] {
+        for keys in [b"\r".as_slice(), b"\t\r", b"\x01\x1b[C\t\r"] {
+            let capture = capture(path, true);
+            let mut state = CardInputState::default();
+            state.apply_capture(&capture);
+            let events = state.consume(&capture, keys);
+            assert_eq!(submitted(&events), (path, false));
+        }
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
@@ -1018,8 +1018,10 @@ fn secret_submit_clears_free_text_for_next_capture() {
 fn draft_capture() -> RawInputCapture {
     RawInputCapture::PromptDraft {
         id: "draft-1".to_string(),
-        initial_text: "第一行".to_string(),
+        initial_text: "第一行".into(),
         completion: None,
+        agent_composer: false,
+        workspace_cwd: None,
     }
 }
 
@@ -1027,8 +1029,10 @@ fn draft_capture() -> RawInputCapture {
 fn draft_tab_accepts_the_runtime_completion() {
     let capture = RawInputCapture::PromptDraft {
         id: "draft-1".to_string(),
-        initial_text: "review @sr".to_string(),
-        completion: Some("@src/".into()),
+        initial_text: "review @sr".into(),
+        completion: Some(Box::new(("@src/".into(), (0, 10)))),
+        agent_composer: true,
+        workspace_cwd: None,
     };
     let mut state = CardInputState::default();
     state.apply_capture(&capture);

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
@@ -115,13 +115,16 @@ pub(crate) enum RawInputEvent {
     PromptDraftChanged {
         id: String,
         text: String,
-        viewport: draft_editor::DraftViewport,
+        viewport: Box<draft_editor::DraftViewport>,
         line_count: usize,
+        selected_completion: usize,
     },
     /// Enter inside the draft card: submit the multi-line prompt.
     PromptDraftSubmit {
         id: String,
         text: String,
+        slash: bool,
+        workspace_cwd: Option<String>,
     },
     /// Esc/Ctrl+C inside the draft card: cancel composition (D15).
     PromptDraftCancel {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
@@ -242,8 +242,13 @@ pub enum RawInputCapture {
     /// until submit (Enter) or cancel (Esc/Ctrl+C).
     PromptDraft {
         id: String,
-        initial_text: String,
-        completion: Option<Box<str>>,
+        initial_text: Box<str>,
+        /// Replacement and its absolute editor cursor, boxed to keep mode snapshots small.
+        completion: Option<Box<(String, (usize, usize))>>,
+        /// Enables local slash completion and control-command submission.
+        agent_composer: bool,
+        /// Composer-owned directory, independent of later shell prompt events.
+        workspace_cwd: Option<Box<str>>,
     },
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/controller.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/controller.rs
@@ -218,14 +218,7 @@ pub(crate) fn render_inline_guidance<W: Write>(
 pub(crate) fn pending_card_capture(state: &InlineState) -> Option<RawInputCapture> {
     // #1721 D13: an open draft card owns every keystroke until submit/cancel.
     if let Some(draft) = state.prompt_draft.as_ref() {
-        return Some(RawInputCapture::PromptDraft {
-            id: draft.id.clone(),
-            initial_text: draft.text.clone(),
-            completion: draft
-                .completions
-                .first()
-                .map(|completion| completion.replacement.clone().into_boxed_str()),
-        });
+        return Some(draft.capture());
     }
     if let Some(capture) = crate::slash::pending_task_form_capture(state) {
         return Some(capture);

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
@@ -177,6 +177,13 @@ fn render_inline_guidance_from_batch<W: Write>(
         stop_active_agent_run_without_rendering(state, output)?;
         return Ok(());
     }
+    // Freeze/release the draft before any control consumer renders or opens a card.
+    crate::runtime::prompt_draft::handle_prompt_draft_events(
+        action_events,
+        state,
+        output,
+        adapter.name(),
+    )?;
     // Task forms reuse Question/TextQuestion captures. Route them first and
     // reserve their answer events so QuestionConsumer never emits a false
     // "No pending question" notice for Task-owned input.
@@ -253,12 +260,6 @@ fn render_inline_guidance_from_batch<W: Write>(
     render_pending_recommendation_notice(state, output)?;
     update_personal_shell_input_state(action_events, state);
     update_soft_newline_tip_state(action_events, state);
-    crate::runtime::prompt_draft::handle_prompt_draft_events(
-        action_events,
-        state,
-        output,
-        adapter.name(),
-    )?;
     let personal_idle = state.agent_run.active.is_none()
         && !state.personalization.shell_input_active
         && !action_events

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/prompt_draft.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/prompt_draft.rs
@@ -26,6 +26,7 @@ pub(crate) struct PromptDraftCardState {
     pub(crate) workspace_cwd: Option<String>,
     pub(crate) skill_names: Vec<String>,
     pub(crate) completions: Vec<ComposerCompletion>,
+    pub(crate) selected_completion: usize,
     pub(crate) text: String,
     pub(crate) rows: Vec<String>,
     pub(crate) hidden_above: usize,
@@ -35,6 +36,26 @@ pub(crate) struct PromptDraftCardState {
     /// First paint opens on a fresh line below the bash prompt (relay
     /// path); the slash path starts at a fresh column already (#1932).
     pub(crate) line_break_before: bool,
+}
+
+impl PromptDraftCardState {
+    pub(crate) fn capture(&self) -> crate::raw_input::RawInputCapture {
+        crate::raw_input::RawInputCapture::PromptDraft {
+            id: self.id.clone(),
+            initial_text: self.text.clone().into_boxed_str(),
+            completion: self
+                .completions
+                .get(self.selected_completion)
+                .map(|completion| {
+                    Box::new((
+                        completion.replacement.clone(),
+                        (self.hidden_above + self.cursor.0, self.cursor.1),
+                    ))
+                }),
+            agent_composer: self.kind == PromptDraftKind::AgentComposer,
+            workspace_cwd: self.workspace_cwd.as_deref().map(Into::into),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -75,6 +96,7 @@ fn card_width() -> usize {
 enum CardPhase {
     Editing,
     Submitted,
+    ControlSubmitted,
     Cancelled,
 }
 
@@ -145,6 +167,7 @@ fn open_prompt_editor<W: Write>(
         workspace_cwd: workspace_cwd.map(str::to_string),
         skill_names,
         completions: Vec::new(),
+        selected_completion: 0,
         text,
         rows: view.rows,
         hidden_above: view.hidden_above,
@@ -211,6 +234,9 @@ pub(crate) fn handle_prompt_draft_events<W: Write>(
                         &card.skill_names,
                     );
                 }
+                card.selected_completion = (value["selected_completion"].as_u64().unwrap_or(0)
+                    as usize)
+                    .min(card.completions.len().saturating_sub(1));
                 draw_card(&mut card, state, output, CardPhase::Editing)?;
                 state.prompt_draft = Some(card);
             }
@@ -218,7 +244,8 @@ pub(crate) fn handle_prompt_draft_events<W: Write>(
                 let Some(mut card) = state.prompt_draft.take() else {
                     continue;
                 };
-                if card.kind == PromptDraftKind::AgentComposer {
+                let slash = value["slash"].as_bool().unwrap_or(false);
+                if card.kind == PromptDraftKind::AgentComposer && !slash {
                     state.pending_agent_composer_submission =
                         Some(PendingAgentComposerSubmission {
                             text: value["text"]
@@ -228,10 +255,20 @@ pub(crate) fn handle_prompt_draft_events<W: Write>(
                             workspace_cwd: card.workspace_cwd.clone(),
                         });
                 }
+                if slash {
+                    state.pending_agent_composer_submission = None;
+                    state.agent_run.needs_prompt_after_run = true;
+                    state.agent_run.native_prompt_after_run = false;
+                }
                 card.completions.clear();
-                // The agent turn starts via the intercept event pushed in the
-                // same batch; here the card just freezes as history.
-                draw_card(&mut card, state, output, CardPhase::Submitted)?;
+                // The corresponding intercept dispatches after the editor
+                // releases input; its command may open another capture.
+                let phase = if slash {
+                    CardPhase::ControlSubmitted
+                } else {
+                    CardPhase::Submitted
+                };
+                draw_card(&mut card, state, output, phase)?;
             }
             Some("cancel") => {
                 let Some(mut card) = state.prompt_draft.take() else {
@@ -351,11 +388,12 @@ fn draw_card<W: Write>(
     let footer = match phase {
         CardPhase::Editing => i18n.t(MessageId::PromptDraftFooterEditing),
         CardPhase::Submitted => i18n.t(MessageId::PromptDraftFooterSubmitted),
+        CardPhase::ControlSubmitted => i18n.t(MessageId::PromptDraftFooterControlSubmitted),
         CardPhase::Cancelled => i18n.t(MessageId::PromptDraftFooterCancelled),
     };
     let border = match phase {
         CardPhase::Editing => "\x1b[36m",
-        CardPhase::Submitted | CardPhase::Cancelled => "\x1b[2m",
+        CardPhase::Submitted | CardPhase::ControlSubmitted | CardPhase::Cancelled => "\x1b[2m",
     };
     let reset = "\x1b[0m";
     let width = card_width();
@@ -432,12 +470,24 @@ fn draw_agent_composer<W: Write>(
         lines.push(format!("{prefix}{body}"));
     }
     if phase == CardPhase::Editing {
-        for (index, completion) in card.completions.iter().enumerate() {
-            let marker = if index == 0 { "›" } else { " " };
+        let start = card.selected_completion / 6 * 6;
+        for (index, completion) in card.completions.iter().enumerate().skip(start).take(6) {
+            let marker = if index == card.selected_completion {
+                "›"
+            } else {
+                " "
+            };
             let suggestion = format!("{marker} {}", completion.display);
-            let body = content_row(&suggestion, None, budget, index != 0);
+            let body = content_row(&suggestion, None, budget, index != card.selected_completion);
             lines.push(format!("  {body}"));
         }
+    }
+    if phase == CardPhase::Editing && card.completions.len() > 6 {
+        lines.push(format!(
+            "  {}/{}",
+            card.selected_completion + 1,
+            card.completions.len()
+        ));
     }
     if card.hidden_below > 0 {
         lines.push(format!("  \x1b[2m… ↓ {}\x1b[22m", card.hidden_below));
@@ -446,15 +496,17 @@ fn draw_agent_composer<W: Write>(
     let footer = match phase {
         CardPhase::Editing => i18n.t(MessageId::AgentComposerFooterEditing),
         CardPhase::Submitted => i18n.t(MessageId::PromptDraftFooterSubmitted),
+        CardPhase::ControlSubmitted => i18n.t(MessageId::PromptDraftFooterControlSubmitted),
         CardPhase::Cancelled => i18n.t(MessageId::PromptDraftFooterCancelled),
     };
     let status = format!(
-        "{} · {}: {} · {footer}",
+        "{} · {}: {}",
         i18n.t(MessageId::AgentComposerTitle),
         i18n.t(MessageId::PromptDraftRuntimeLabel),
         card.runtime
     );
     lines.push(format!("  {}", content_row(&status, None, budget, true)));
+    lines.push(format!("  {}", content_row(footer, None, budget, true)));
 
     repaint_editor(card, output, phase, &lines)
 }
@@ -507,6 +559,7 @@ mod tests {
             workspace_cwd: None,
             skill_names: Vec::new(),
             completions: Vec::new(),
+            selected_completion: 0,
             text: rows.join("\n"),
             rows: rows.iter().map(|row| row.to_string()).collect(),
             hidden_above: 0,
@@ -533,6 +586,12 @@ mod tests {
 
         let mut composer = card_with_rows(&[""], (0, 0));
         composer.kind = PromptDraftKind::AgentComposer;
+        composer.workspace_cwd = Some("/workspace/project".into());
+        assert!(
+            matches!(composer.capture(), crate::raw_input::RawInputCapture::PromptDraft {
+            workspace_cwd: Some(cwd), ..
+        } if cwd.as_ref() == "/workspace/project")
+        );
         composer.line_break_before = false;
         let mut out: Vec<u8> = Vec::new();
         draw_card(&mut composer, &mut state, &mut out, CardPhase::Editing).expect("draw");
@@ -608,7 +667,7 @@ mod tests {
         let rendered = String::from_utf8(out).expect("utf8");
         assert!(rendered.contains("◆ review @Car"), "{rendered}");
         assert!(rendered.contains("› @Cargo.toml"), "{rendered}");
-        assert_eq!(card.panel_height, 3, "input + result + status");
+        assert_eq!(card.panel_height, 4, "input + result + status + footer");
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
@@ -145,11 +145,13 @@ pub(super) fn drain_raw_input_events<W: Write>(
                 text,
                 viewport,
                 line_count,
+                selected_completion,
             } => {
                 let payload = serde_json::json!({
                     "id": id,
                     "text": text,
                     "line_count": line_count,
+                    "selected_completion": selected_completion,
                     "first_row": viewport.first_row,
                     "hidden_above": viewport.hidden_above,
                     "hidden_below": viewport.hidden_below,
@@ -160,18 +162,28 @@ pub(super) fn drain_raw_input_events<W: Write>(
                 .to_string();
                 parser.push_prompt_draft_event("changed", Some(&payload));
             }
-            RawInputEvent::PromptDraftSubmit { id, text } => {
-                let payload = serde_json::json!({ "id": id, "text": text }).to_string();
+            RawInputEvent::PromptDraftSubmit {
+                id,
+                text,
+                slash,
+                workspace_cwd,
+            } => {
+                let payload =
+                    serde_json::json!({ "id": id, "text": text, "slash": slash }).to_string();
                 parser.push_prompt_draft_event("submit", Some(&payload));
-                // The submitted draft rides the existing intercept path into
-                // the agent turn (D10 reason rules: `??` keeps AgentMarker).
+                // Preserve the owning capture's decision: controls use the same
+                // consumers as shell slash commands; other drafts stay Agent input.
                 let session_id = parser.session_id.clone();
-                let reason = if text.trim_start().starts_with("??") {
+                let reason = if slash {
+                    "slash"
+                } else if text.trim_start().starts_with("??") {
                     "agent_marker"
                 } else {
                     "natural_language"
                 };
-                parser.push_intercept_event(&session_id, text, None, reason);
+                let text = if slash { text.trim().to_string() } else { text };
+                let cwd = if slash { workspace_cwd } else { None };
+                parser.push_intercept_event(&session_id, text, cwd, reason);
             }
             RawInputEvent::PromptDraftCancel { id } => {
                 let payload = serde_json::json!({ "id": id }).to_string();

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay_tests.rs
@@ -387,6 +387,49 @@ fn any_pty_user_write_emits_the_prompt_cwd_invalidation_barrier() {
 }
 
 #[test]
+fn composer_slash_retains_workspace_before_the_next_shell_ready() {
+    let mut parser = parser_for_test("composer-workspace");
+    let (generation, mut prompt_replay) = tracker_for_test();
+    let (sender, receiver) = std::sync::mpsc::channel();
+    sender
+        .send(RawInputEvent::PtyUserWrite {
+            generation: generation.bump(),
+            line_submits: 0,
+        })
+        .unwrap();
+    sender
+        .send(RawInputEvent::PromptDraftSubmit {
+            id: "composer-1".into(),
+            text: "/health".into(),
+            slash: true,
+            workspace_cwd: Some("/workspace/project".into()),
+        })
+        .unwrap();
+    drain_raw_input_events(
+        &receiver,
+        &mut parser,
+        &mut Vec::new(),
+        "prompt$ ",
+        &mut 0,
+        &mut prompt_replay,
+        &PromptPresentation::new(false),
+    )
+    .unwrap();
+    assert!(!parser
+        .events
+        .iter()
+        .any(|event| event.kind == ShellEventKind::ShellReady));
+    let intercepts = parser
+        .events
+        .iter()
+        .filter(|event| event.component.as_deref() == Some("slash"))
+        .collect::<Vec<_>>();
+    assert_eq!(intercepts.len(), 1);
+    assert_eq!(intercepts[0].input.as_deref(), Some("/health"));
+    assert_eq!(intercepts[0].cwd.as_deref(), Some("/workspace/project"));
+}
+
+#[test]
 fn candidate_hint_uses_terminfo_cursor_save_restore() {
     let mut parser = parser_for_test("candidate-cursor-restore");
     let (_generation, mut prompt_replay) = tracker_for_test();

--- a/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
@@ -34,12 +34,16 @@ pub(super) fn render_slash_command<W: Write>(
     // COSH_SLASH_VIA_SHELL=0) creates events with cwd=None because
     // the input never reaches the shell; fall back to the last
     // ShellReady cwd tracked by the dispatcher so registry queries
-    // still resolve the correct project root. If both sources are
-    // unavailable the cached cwd may be stale (e.g. a `cd` whose OSC
+    // and local health checks resolve the correct project root. If both
+    // sources are unavailable the cached cwd may be stale (e.g. a `cd` whose OSC
     // 1337 markers were lost), so clear it rather than forwarding the
     // old project root.
+    let shell_cwd = shell_cwd
+        .map(str::to_string)
+        .or_else(|| state.shell_prompt_cwd.clone());
+    let shell_cwd = shell_cwd.as_deref();
     if let AdapterInstance::CoshCore(cosh_core) = adapter {
-        match shell_cwd.or(state.shell_prompt_cwd.as_deref()) {
+        match shell_cwd {
             Some(cwd) => cosh_core.set_shell_cwd(Some(cwd)),
             None => cosh_core.clear_shell_cwd(),
         }

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/composer.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/composer.rs
@@ -1,5 +1,186 @@
 use super::*;
 
+fn run_composer_slash_steps(steps: &[(&str, &[u8])]) -> String {
+    let home = tempfile::Builder::new()
+        .prefix("composer-slash-")
+        .tempdir_in(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target"))
+        .unwrap();
+    fs::write(home.path().join(".bashrc"), "PS1='composer-test$ '\n").unwrap();
+    let home_str = home.path().to_string_lossy().to_string();
+    let mut input = vec![("composer-test$", b"/agent\n".as_slice())];
+    input.extend_from_slice(steps);
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
+        "fake",
+        &["--shell", "bash"],
+        &[
+            ("HOME", &home_str),
+            ("COSH_SHELL_STARTUP_BANNER", "0"),
+            ("COSH_SHELL_ISOLATED", "0"),
+            ("COSH_SHELL_LANG", "en-US"),
+        ],
+        home.path(),
+        &input,
+    );
+    assert!(
+        !output.contains("Received shell prompt request:"),
+        "{output}"
+    );
+    assert!(!output.contains("Sent to agent"), "{output}");
+    output
+}
+
+#[test]
+fn raw_cli_agent_composer_lists_completes_and_executes_slash_commands() {
+    let output = run_composer_slash_steps(&[
+        ("Agent Composer", b"/"),
+        ("› /help", b"ho\t\r"),
+        ("Hook status", b"echo after-slash\n"),
+        ("after-slash", b"exit\n"),
+    ]);
+    assert!(output.contains("/hooks"), "{output}");
+    assert!(output.contains("Command submitted"), "{output}");
+    assert!(output.contains("after-slash"), "{output}");
+    assert!(!output.contains("bash: /hooks"), "{output}");
+}
+
+#[test]
+fn raw_cli_agent_composer_enter_executes_the_selected_command() {
+    let select_hooks = b"\x1b[B".repeat(11);
+    let output = run_composer_slash_steps(&[
+        ("Agent Composer", b"/"),
+        ("› /help", &select_hooks),
+        ("› /hooks", b"\r"),
+        ("Hook status", b"echo after-enter\n"),
+        ("after-enter", b"exit\n"),
+    ]);
+    assert!(output.contains("◆ /hooks"), "{output}");
+    assert!(output.contains("after-enter"), "{output}");
+}
+
+#[test]
+fn raw_cli_agent_composer_slash_completion_scrolls_to_the_last_command() {
+    let mut keys = b"/".to_vec();
+    for _ in 0..32 {
+        keys.extend_from_slice(b"\x1b[B");
+    }
+    let output = run_composer_slash_steps(&[
+        ("Agent Composer", &keys),
+        ("› /mcp", b"\x1b"),
+        ("Draft cancelled", b"exit\n"),
+    ]);
+    assert!(output.contains("› /mcp"), "{output}");
+}
+
+#[test]
+fn raw_cli_agent_composer_control_command_hands_input_to_its_card() {
+    let output = run_composer_slash_steps(&[
+        ("Agent Composer", b"/mode approval\r"),
+        ("User mode", b"\x1b"),
+        ("Mode unchanged:", b"echo after-mode\n"),
+        ("after-mode", b"exit\n"),
+    ]);
+    assert!(output.contains("after-mode"), "{output}");
+    assert!(!output.contains("bash: /mode"), "{output}");
+}
+
+#[test]
+fn raw_cli_agent_composer_unknown_command_is_local() {
+    let output = run_composer_slash_steps(&[
+        ("Agent Composer", b"/not-a-command\r"),
+        ("Unknown slash command:", b"echo after-unknown\n"),
+        ("after-unknown", b"exit\n"),
+    ]);
+    assert!(output.contains("after-unknown"), "{output}");
+    assert!(!output.contains("bash: /not-a-command"), "{output}");
+}
+
+#[test]
+fn raw_cli_agent_composer_hidden_controls_restore_prompt_after_their_output() {
+    for (command, notice) in [
+        (b"/cancel\r".as_slice(), "no active Agent run"),
+        (b"/details missing\r".as_slice(), "Details unavailable"),
+    ] {
+        let output = run_composer_slash_steps(&[
+            ("Agent Composer", command),
+            (notice, b""),
+            ("composer-test$", b"echo after-control\n"),
+            ("after-control", b"exit\n"),
+        ]);
+        assert!(
+            output.rfind("◆ ").unwrap() < output.find(notice).unwrap(),
+            "{output}"
+        );
+    }
+}
+
+#[test]
+fn raw_cli_agent_composer_health_uses_the_current_shell_workspace() {
+    let home = tempfile::Builder::new()
+        .prefix("composer-health-")
+        .tempdir_in(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target"))
+        .unwrap();
+    fs::write(home.path().join(".bashrc"), "PS1='health-test$ '\n").unwrap();
+    let hooks = home.path().join("project/.cosh/hooks");
+    fs::create_dir_all(&hooks).unwrap();
+    fs::write(hooks.join("check.sh"), "#!/bin/sh\nexit 0\n").unwrap();
+    let home_str = home.path().to_string_lossy().to_string();
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
+        "fake",
+        &["--shell", "bash"],
+        &[
+            ("HOME", &home_str),
+            ("COSH_SHELL_STARTUP_BANNER", "0"),
+            ("COSH_SHELL_ISOLATED", "0"),
+            ("COSH_SHELL_LANG", "en-US"),
+        ],
+        home.path(),
+        &[
+            ("health-test$", b"cd project\n"),
+            ("health-test$", b"/agent\n"),
+            ("Agent Composer", b"/health\r"),
+            ("review and trust project hooks under", b"exit\n"),
+        ],
+    );
+    assert!(output.contains("Health check"), "{output}");
+    assert!(
+        !output.contains("Received shell prompt request:"),
+        "{output}"
+    );
+}
+
+#[test]
+fn raw_cli_composer_change_preserves_bash_path_completion() {
+    let home = tempfile::Builder::new()
+        .prefix("composer-native-")
+        .tempdir_in(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target"))
+        .unwrap();
+    fs::write(home.path().join(".bashrc"), "PS1='path-test$ '\n").unwrap();
+    fs::create_dir(home.path().join("path-target")).unwrap();
+    let home_str = home.path().to_string_lossy().to_string();
+    let completion = format!("{home_str}/path-ta\t");
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
+        "fake",
+        &["--shell", "bash"],
+        &[
+            ("HOME", &home_str),
+            ("COSH_SHELL_STARTUP_BANNER", "0"),
+            ("COSH_SHELL_ISOLATED", "0"),
+            ("COSH_SHELL_LANG", "en-US"),
+        ],
+        home.path(),
+        &[
+            ("path-test$", completion.as_bytes()),
+            ("path-target/", b"\x15echo native-completion-ok\n"),
+            ("native-completion-ok", b"exit\n"),
+        ],
+    );
+    assert!(!output.contains("Agent Composer"), "{output}");
+    assert!(
+        !output.contains("Received shell prompt request:"),
+        "{output}"
+    );
+}
+
 #[test]
 fn raw_cli_removed_draft_alias_falls_through_to_shell() {
     let home = temp_shell_home("agent-composer-removed-draft-alias");

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/composer.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/composer.rs
@@ -106,7 +106,7 @@ fn raw_cli_agent_composer_completes_a_registry_skill_before_submit() {
     let (output, request) = run_agent_composer_steps(
         "cosh-core-agent-composer-skill-completion",
         &[
-            ("Agent Composer", b"/skill:repo"),
+            ("Agent Composer", b"/skill"),
             ("› /skill:repo-review", b"\tinspect this workspace\r"),
             ("COSH CORE COMPOSER FINAL", b"exit\n"),
         ],

--- a/src/cosh-ng/docs/design/shell-integration-and-card-types.md
+++ b/src/cosh-ng/docs/design/shell-integration-and-card-types.md
@@ -53,7 +53,7 @@ infer routing from the first character of user text.
 | None | Native | Child Shell | Every byte goes directly to the PTY. Cosh does not decorate the user's original prompt or observe command events. |
 | `◌` | Enhanced Shell-only | Child Shell, observed by Cosh | Ordinary input, including `hello`, `/`, and `??`, remains Shell input. Enhanced marker integration stays loaded so post-command insights and safe switching remain available. |
 | `◇` | Enhanced Assisted | Shell executes, Cosh may route | Cosh may observe, classify, or route the submitted line before Shell execution. |
-| `◆` | Agent | Agent runtime | `/agent` opens a borderless inline Composer that continuously shows `◆ ` before editable text. Any text, including `ls`, is an Agent request. |
+| `◆` | Agent | Agent runtime | `/agent` opens a borderless inline Composer that continuously shows `◆ ` before editable text. Ordinary text, including `ls`, is an Agent request; leading slash controls dispatch locally. |
 | `/` | Cosh Command | Cosh control plane | Explicit slash command, intercepted only in Enhanced Assisted. |
 
 `◇ ` and `◌ ` are outer-terminal decorations anchored to the Enhanced hook's
@@ -80,6 +80,27 @@ input ownership and background analysis are orthogonal states.
 Native input bypasses candidate buffering, prompt ghosts, slash routing, and
 card capture. Terminal control such as signals, resizing, and EOF still follows
 the PTY lifecycle.
+
+## Composer Command Submission
+
+The Composer capture explicitly carries its Agent input origin. Command
+candidates reuse public registry names, deduplicate by name, and retain the
+complete set while rendering the selected six-row window. The input thread
+computes slash candidates synchronously from the live editor text and cursor,
+so Tab or Enter in the same read chunk cannot accept a stale candidate. Enter
+reuses completion before submission only for a single-line, single-token command
+draft, emitting the updated editor snapshot before the submit event. Arguments
+and multiline drafts retain their text. Runtime path
+and Skill completions must match their text and cursor snapshot before acceptance.
+
+The capture and submit event retain the Composer's workspace snapshot. The input
+bridge attaches it to the slash intercept's cwd, independent of ShellReady timing
+or the global prompt cwd cache. The submit event carries a slash routing flag;
+the input bridge emits exactly one slash or Agent intercept. Slash submissions
+leave no pending Composer request metadata. Existing slash/control consumers own
+parsing, confirmation, execution, and prompt restoration. Rendering never executes commands or reopens
+the Composer over a subsequent card. Ordinary drafts and shell path completion
+keep their existing routing.
 
 ## Output Event Cards
 

--- a/src/cosh-ng/docs/design/shell-integration-and-card-types_zh.md
+++ b/src/cosh-ng/docs/design/shell-integration-and-card-types_zh.md
@@ -47,7 +47,7 @@ Enhanced 内部的路由子状态，不等同于没有 hook 的 Native 集成。
 | 无 | Native | 子 Shell | 每个字节直接写入 PTY。Cosh 不装饰用户原提示符，也不观察命令事件。 |
 | `◌` | Enhanced Shell-only | 子 Shell，Cosh 观察 | 包括 `hello`、`/` 和 `??` 在内的普通输入都交给 Shell。Enhanced marker 集成仍加载，因此执行后洞察和安全切换仍可用。 |
 | `◇` | Enhanced Assisted | Shell 执行，Cosh 可路由 | Cosh 可以在 Shell 执行前观察、分类或路由提交的输入。 |
-| `◆` | Agent | Agent runtime | `/agent` 打开无边框行内 Composer，并在可编辑文本前持续显示 `◆ `；任意文本，包括 `ls`，都按 Agent 请求处理。 |
+| `◆` | Agent | Agent runtime | `/agent` 打开无边框行内 Composer，并在可编辑文本前持续显示 `◆ `；普通文本（包括 `ls`）按 Agent 请求处理；开头的 slash 控制命令在本地分发。 |
 | `/` | Cosh Command | Cosh 控制面 | 明确的斜杠命令，只在 Enhanced Assisted 中拦截。 |
 
 `◇ ` 和 `◌ ` 是锚定在 Enhanced hook 的 `prompt_ready` 边界上的外层终端装饰，不会写入
@@ -68,6 +68,22 @@ prompt ghost 或卡牌处于活动状态时，保留原有的 `Shift+Tab` 行为
 
 原生输入绕过候选内容缓存、prompt ghost、斜杠路由和卡牌捕获。信号、终端尺寸
 变化和 EOF 等终端控制仍由 PTY 生命周期处理。
+
+## Composer 命令提交
+
+Composer 的 capture 明确携带 Agent 输入来源。命令候选复用 registry 的公开名称，
+按名称去重，保留完整集合，仅渲染当前选中项所在的六行窗口。输入线程使用当前
+编辑器文本和光标同步计算 slash 候选，避免同一读取块内的 Tab 或 Enter 接受旧候选。
+Enter 仅在单行草稿只有命令 token 时复用补全，并在提交事件前发送更新后的编辑器
+快照。带参数或多行的草稿保留原文。
+路径和 Skill 的 runtime 补全必须匹配文本与光标快照才能接受。
+
+Capture 和提交事件保留 Composer 的工作目录快照，输入事件桥将它填入 slash
+intercept 的 cwd，不依赖 ShellReady 时序或全局 prompt cwd 缓存。
+提交事件携带 slash 路由标记；输入事件桥只生成一次 slash 或 Agent intercept。
+Slash 提交不会保留待处理的 Composer 请求元数据。现有 slash/control consumer
+负责解析、确认、执行以及 prompt 恢复；渲染器不执行命令，也不会自动重开 Composer
+抢占后续卡片。普通草稿和 Shell 路径补全沿用原有路由。
 
 ## 输出事件卡牌
 


### PR DESCRIPTION
## Why

Inside `/agent`, typing `/` offered no command discovery and submitting a slash command sent it to the Agent as ordinary text. This implements the Composer-only acceptance scope agreed in #1705.

## What changed

Reuse public registry names for prefix filtering, deduplicated command candidates, six-row browsing, and Tab completion. Route submitted controls through existing handlers, retaining confirmation cards and prompt restoration. Carry the Composer workspace through capture and submission into the slash intercept, so commands use the correct project before the next `ShellReady`. Keep ordinary drafts, existing absolute paths, `/skill:name`, workspace references, and shell path completion intact. Control submissions show a dedicated submitted-state footer.

## Related issue

closes #1705

## User / Agent impact

In the Composer, type `/`, filter by prefix, select with Up/Down, and accept with Tab. For a single-line draft containing only the command token, Enter accepts and executes the selected candidate. Tab completes without executing, so arguments can be added. Drafts with arguments or multiple lines are submitted as written; unknown command names produce a local notice. Esc cancels composition.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed

Composer input semantics and in-process `PromptDraft` capture/event payloads change. Existing command validation and approval policy remain in effect; no Core wire protocol or persisted format changes. Ordinary shell prompts retain native completion.

## Validation

Linux; Bash/Zsh, fake adapter, and stub cosh-core. Passed:

```sh
cargo fmt --all -- --check
cargo test -p cosh-shell --bin cosh-shell composer -- --test-threads=4
cargo test -p cosh-shell --lib draft -- --test-threads=4
cargo test -p cosh-shell --lib i18n -- --test-threads=4
cargo test -p cosh-shell --test raw_cli composer -- --test-threads=4
cargo test -p cosh-shell --test raw_cli composer::raw_cli_composer_change_preserves_bash_path_completion -- --exact
cargo clippy -p cosh-shell --all-targets -- -D warnings
cargo doc -p cosh-shell --no-deps
crates/cosh-shell/scripts/check-layout.sh
git diff --check
```

Final revision `121d3bf5`: 18 Composer-filtered unit tests, 34 draft tests, 9 i18n-filtered tests, the deterministic pre-ShellReady workspace regression, the runtime capture assertion, and all 15 Composer integration tests pass. Coverage includes bare `/skill`, existing single-segment absolute paths during completion and submission, the command-submitted footer, arrow selection followed directly by Enter, arguments and multiline preservation, same-chunk input, current-project `/health`, control-card handoff, workspace references, and native Bash path completion. Scoped Clippy, formatting, documentation build, layout, and test-inventory audits pass; exact lib/bin overlap remains 696. Relative links in the updated Markdown documents pass. Independent agent review covered the initial implementation; subsequent review feedback is addressed in this revision. ECS screenshot verification will be performed by the author.

Additional targeted commands:

```sh
cargo test -p cosh-shell --lib composer_slash_retains_workspace_before_the_next_shell_ready
cargo test -p cosh-shell --bin cosh-shell runtime::prompt_draft::tests::slash_first_paint_skips_the_extra_blank_line -- --exact
scripts/check-test-inventory.sh
```

Full workspace gates are left to CI; no ECS or real-provider validation was performed.

## Documentation and rollback

Updated both languages of the component README, interactive-mode guide, and shell integration design. Roll back with `git revert 121d3bf5`.

