### PR TITLE
fix(anolisa): distinguish RPM query failures

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/component_observation.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/component_observation.rs
@@ -553,6 +553,67 @@ mod tests {
     }
 
     #[test]
+    fn native_rpm_query_failure_is_unavailable_not_absent() {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        use anolisa_platform::command::{CommandOutput, CommandRunner};
+        use anolisa_platform::rpm_query::RpmPackageQuery;
+
+        struct Runner(Rc<RefCell<Option<CommandOutput>>>);
+
+        impl CommandRunner for Runner {
+            fn run(&self, program: &str, args: &[&str]) -> std::io::Result<CommandOutput> {
+                assert_eq!(program, "rpm");
+                assert_eq!(
+                    args,
+                    [
+                        "-q",
+                        "--qf",
+                        "%{NAME}|%{EPOCH}|%{VERSION}|%{RELEASE}|%{ARCH}\n",
+                        "tokenless"
+                    ]
+                );
+                Ok(self.0.borrow_mut().take().expect("exactly one RPM query"))
+            }
+        }
+
+        for stderr in ["", "error: cannot open Packages database in /dev/null\n"] {
+            let reply = Rc::new(RefCell::new(Some(CommandOutput {
+                code: Some(1),
+                stdout: "package tokenless is not installed\n".into(),
+                stderr: stderr.into(),
+            })));
+            let query = RpmPackageQuery::with_runner(Runner(Rc::clone(&reply)));
+            let observation =
+                observe_native_package(NativePm::Rpm, "tokenless", &query, "2026-09-11T00:00:00Z");
+            assert!(reply.borrow().is_none());
+            assert!(observation.installed_version.is_none());
+            if stderr.is_empty() {
+                assert!(observation.query_error.is_none());
+                assert!(
+                    matches!(observation.evidence, ProbeEvidence::Absent { provenance }
+                    if provenance.manager == NativePm::Rpm && provenance.package == "tokenless")
+                );
+            } else {
+                let expected_error = PackageQueryError::QueryFailed {
+                    command: "rpm".into(),
+                    code: Some(1),
+                    stderr: stderr.into(),
+                };
+                assert!(
+                    matches!(observation.evidence, ProbeEvidence::Unavailable { provenance, reason }
+                    if provenance.manager == NativePm::Rpm && provenance.package == "tokenless"
+                        && reason == expected_error.to_string())
+                );
+                assert!(matches!(observation.query_error,
+                    Some(PackageQueryError::QueryFailed { command, code: Some(1), stderr: actual })
+                        if command == "rpm" && actual == stderr));
+            }
+        }
+    }
+
+    #[test]
     fn native_package_evidence_preserves_query_outcomes() {
         let present = observe_native_package(
             NativePm::Rpm,

--- a/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
@@ -3,9 +3,9 @@
 //! Uses `rpm -q` for installed packages and `dnf repoquery` for available
 //! candidates. Output is parsed from a stable `--qf` pipe-delimited format
 //! rather than the locale-sensitive default `nevra` string, so field
-//! extraction does not depend on the host locale. The not-installed signal
-//! still relies on an English message marker, which is pinned by
-//! [`SystemCommandRunner`]'s `LC_ALL=C`.
+//! extraction does not depend on the host locale. A normal miss requires exit
+//! 1, blank stderr, and the complete English response for the queried argument,
+//! pinned by [`SystemCommandRunner`]'s `LC_ALL=C`.
 
 use crate::command::{CommandOutput, CommandRunner, SystemCommandRunner};
 use crate::pkg_files::{
@@ -284,6 +284,11 @@ fn unexpected_file_inventory(detail: &str) -> PackageQueryError {
     }
 }
 
+fn is_expected_miss(out: &CommandOutput, expected: &[&str]) -> bool {
+    // RPM can emit a missing notice even when opening its database failed.
+    out.code == Some(1) && out.stderr.trim().is_empty() && expected.contains(&out.stdout.trim())
+}
+
 impl<R: CommandRunner> PackageQuery for RpmPackageQuery<R> {
     fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
         let out = self
@@ -295,11 +300,7 @@ impl<R: CommandRunner> PackageQuery for RpmPackageQuery<R> {
             return parse_installed(&out);
         }
 
-        // Non-zero exit: distinguish "not installed" from a real failure.
-        // rpm writes the not-installed notice to stdout (structural signal:
-        // hard errors go to stderr with stdout empty), and under LC_ALL=C the
-        // English marker is stable. Both signals agree here.
-        if out.stdout.contains("is not installed") {
+        if is_expected_miss(&out, &[&format!("package {package} is not installed")]) {
             return Ok(None);
         }
 
@@ -376,13 +377,13 @@ impl<R: CommandRunner> PackageQuery for RpmPackageQuery<R> {
             return Ok(names);
         }
 
-        // "Nothing provides it" is a normal empty result, but only for rpm's
-        // expected miss exit. File path lookups use a separate unowned-file
-        // marker from virtual capabilities.
-        let expected_miss = out.code == Some(1)
-            && (out.stdout.contains("no package provides")
-                || out.stdout.contains("is not owned by any package"));
-        if expected_miss {
+        if is_expected_miss(
+            &out,
+            &[
+                &format!("no package provides {capability}"),
+                &format!("file {capability} is not owned by any package"),
+            ],
+        ) {
             return Ok(Vec::new());
         }
 
@@ -429,7 +430,7 @@ impl<R: CommandRunner> PackageQuery for RpmPackageQuery<R> {
             return Ok(dedup_nonempty_lines(&out.stdout));
         }
 
-        if out.stdout.contains("is not installed") {
+        if is_expected_miss(&out, &[&format!("package {package} is not installed")]) {
             return Ok(Vec::new());
         }
 
@@ -880,6 +881,132 @@ mod tests {
         );
         assert_eq!(q.query_installed("tokenless").unwrap(), None);
         assert!(!q.is_installed("tokenless").unwrap());
+    }
+
+    #[test]
+    fn installed_queries_require_complete_clean_miss_evidence() {
+        use std::cell::RefCell;
+
+        struct SingleQueryRunner<'a> {
+            args: &'a [&'a str],
+            reply: RefCell<Option<io::Result<CommandOutput>>>,
+        }
+
+        impl CommandRunner for SingleQueryRunner<'_> {
+            fn run(&self, program: &str, args: &[&str]) -> io::Result<CommandOutput> {
+                assert_eq!(program, RPM);
+                assert_eq!(args, self.args);
+                self.reply.borrow_mut().take().expect("exactly one query")
+            }
+        }
+
+        let cases: &[(&[&str], &str, &str)] = &[
+            (
+                &["-q", "--qf", INSTALLED_QF, "ghost"],
+                "package ghost is not installed",
+                "ghost|(none)|1.0|1.al4|x86_64\n",
+            ),
+            (
+                &["-q", "--provides", "ghost"],
+                "package ghost is not installed",
+                "ghost = 1.0\nghost = 1.0\n",
+            ),
+            (
+                &["-q", "--whatprovides", "--qf", PROVIDES_NAME_QF, "ghost"],
+                "no package provides ghost",
+                "ghost\nghost\n",
+            ),
+            (
+                &["-q", "--whatprovides", "--qf", PROVIDES_NAME_QF, "/ghost"],
+                "file /ghost is not owned by any package",
+                "ghost\nghost\n",
+            ),
+        ];
+        for (kind, &(args, missing, present)) in cases.iter().enumerate() {
+            let lookup = |query: &RpmPackageQuery<SingleQueryRunner<'_>>| match kind {
+                0 => query.query_installed("ghost").map(|info| info.is_none()),
+                1 => query.provided_capabilities_installed("ghost").map(|items| {
+                    assert!(items.len() <= 1, "preserve deduplication");
+                    items.is_empty()
+                }),
+                _ => query.what_provides_installed(args[4]).map(|items| {
+                    assert!(items.len() <= 1, "preserve deduplication");
+                    items.is_empty()
+                }),
+            };
+            for (code, stdout, stderr, expected_missing) in [
+                (
+                    Some(0),
+                    present.to_string(),
+                    "warning: existing behavior",
+                    Some(false),
+                ),
+                (Some(1), missing.to_string(), "", Some(true)),
+                (Some(1), format!(" \n{missing}\n\t"), " \n\t", Some(true)),
+                (
+                    Some(1),
+                    missing.to_string(),
+                    "error: cannot open Packages database in /dev/null\n",
+                    None,
+                ),
+                (
+                    Some(1),
+                    missing.to_string(),
+                    "warning: database issue\n",
+                    None,
+                ),
+                (Some(2), missing.to_string(), "", None),
+                (Some(100), missing.to_string(), "", None),
+                (None, missing.to_string(), "", None),
+                (Some(1), missing.replace("ghost", "other"), "", None),
+                (Some(1), format!("{missing}\nextra output"), "", None),
+                (Some(1), format!("prefix {missing} suffix"), "", None),
+                (Some(1), String::new(), "", None),
+                (Some(1), String::new(), "  rpmdb failure\n \n", None),
+            ] {
+                let query = RpmPackageQuery::with_runner(SingleQueryRunner {
+                    args,
+                    reply: RefCell::new(Some(Ok(CommandOutput {
+                        code,
+                        stdout: stdout.clone(),
+                        stderr: stderr.to_string(),
+                    }))),
+                });
+                let result = lookup(&query);
+                assert!(query.runner.reply.borrow().is_none());
+                match expected_missing {
+                    Some(expected) => assert_eq!(result.unwrap(), expected),
+                    None => assert!(
+                        matches!(result, Err(PackageQueryError::QueryFailed { command, code: actual_code, stderr: actual_stderr })
+                            if command == RPM && actual_code == code && actual_stderr == stderr),
+                        "kind={kind}, code={code:?}, stdout={stdout:?}, stderr={stderr:?}"
+                    ),
+                }
+            }
+            for error in [
+                io::ErrorKind::NotFound,
+                io::ErrorKind::PermissionDenied,
+                io::ErrorKind::Other,
+            ] {
+                let query = RpmPackageQuery::with_runner(SingleQueryRunner {
+                    args,
+                    reply: RefCell::new(Some(Err(io::Error::new(error, "spawn failed")))),
+                });
+                let result = lookup(&query).unwrap_err();
+                assert!(query.runner.reply.borrow().is_none());
+                match error {
+                    io::ErrorKind::NotFound => assert!(
+                        matches!(result, PackageQueryError::CommandMissing { command } if command == RPM)
+                    ),
+                    io::ErrorKind::PermissionDenied => assert!(
+                        matches!(result, PackageQueryError::PermissionDenied { command } if command == RPM)
+                    ),
+                    _ => assert!(
+                        matches!(result, PackageQueryError::QueryFailed { command, code: None, stderr } if command == RPM && stderr == "spawn failed")
+                    ),
+                }
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Why

RPM can exit 1 with a missing-package notice on stdout and a database error on stderr. The installed-package and provides queries previously treated such failures as normal missing results, potentially producing `Absent` instead of `Unavailable` downstream.

## What changed

Require exit 1, blank stderr, and the complete expected response for the queried argument before returning a normal miss from `query_installed`, `provided_capabilities_installed`, or `what_provides_installed`. Share this private check while preserving exit-zero parsing, original stderr, and existing typed errors. Add scripted query coverage and a real RPM-adapter-to-component-observation regression.

## Related issue

Closes #3229

R4 tracking: #2628 (remains open).

## User / Agent impact

RPM query failures previously masked by missing-result text now follow existing error/unavailable paths. Normal missing packages, capabilities, and existing unowned files still return the existing empty result. Nonzero results with nonblank stderr, including warnings, are deliberately not considered conclusive evidence of absence.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

This intentionally changes classification of ambiguous/failed queries, not CLI arguments, JSON schema, or error-to-exit-code mappings. Successful parsing and deduplication remain unchanged. English response parsing stays confined to the RPM adapter under the existing `LC_ALL=C` runner; no new public API, retries, rollback, DNF behavior, or RPM transaction changes are introduced.

## Validation

```text
cargo fmt --all
cargo fmt --all -- --check
cargo test -p anolisa-platform rpm_query --locked
cargo test -p anolisa-cli component_observation --locked
cargo test -p anolisa-cli observation_conformance --locked
cargo test -p anolisa-cli resolution --locked
cargo test -p anolisa-cli update_check --locked
cargo test -p anolisa-cli self_update --locked
cargo test -p anolisa-cli status --locked
cargo test -p anolisa-cli doctor --locked
cargo check --workspace --locked
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo test -p anolisa-cli --locked
cargo test --workspace --locked
cargo doc --workspace --no-deps --locked
git diff --check
```

- New regression fails against the old implementation and passes with the fix. Covers exact/incorrect target messages, extra output, database errors and warnings, blank stderr, nonzero/signal exits, spawn errors, command arguments, and exactly-once calls.
- Full host validation: CLI unit tests 1,073 passed / 1 pre-existing ignored; core 1,078 passed, plus workspace and integration suites.
- All eight targeted groups passed in `anolisa/alinux4-rust-selftest:20260824` (ALinux 4.0.3 / Rust 1.93.1), with an ordinary user, no network, read-only source/vendor mounts, separate target directory, and fake package/service collaborators.
- Eleven real RPM 4.18.2 read-only cases passed in a separate ordinary-user, read-only-root, network-disabled disposable container: installed/missing packages, capabilities, temporary unowned files, and invalid database paths. Package inventory checksums remained unchanged after each query.
- No host RPM database, service, helper socket, or existing container was modified. Submission rebase contains no ANOLISA component changes relative to the container-tested tree.

## Documentation and rollback

The Chinese refactoring roadmap is updated locally but remains untracked and excluded from this PR. No migration is required. Reverting this commit restores the previous behavior, including the query-failure misclassification.
