### PR TITLE
fix(memory): make `make dist` produce a buildable source tarball again

### DIFF
--- a/src/agent-memory/Cargo.toml
+++ b/src/agent-memory/Cargo.toml
@@ -16,7 +16,9 @@ categories = ["filesystem", "command-line-utilities"]
 
 # This crate targets Linux only. user_namespace, mount(2), cgroup v2,
 # inotify, journald are all required at runtime. Build on macOS/Windows
-# will fail — push to a Linux host (see docs/design.md) and build there.
+# will fail — push to a Linux host and build there (`make remote-build`
+# / `make remote-test`); ../../docs/BUILDING.md lists the host
+# prerequisites (CMake, libsystemd headers, Node.js).
 
 [dependencies]
 # MCP Server & Client

--- a/src/agent-memory/Makefile
+++ b/src/agent-memory/Makefile
@@ -270,8 +270,21 @@ dist: clean build-openclaw-plugin ## Create source + vendor tarballs for RPM bui
 	@mkdir -p dist
 	# Top-level dir is $(NAME)-$(VERSION) so it matches the spec's
 	# `%setup -n %{name}-%{version}` and the CI archive shape.
+	#
+	# `examples/` belongs in the copy list because Cargo.toml declares
+	# `[[example]] mcp-harness` with an explicit path, and cargo refuses
+	# to build a declared target whose file is missing — an archive
+	# without it breaks `cargo test` and `cargo build --examples` inside
+	# the unpacked source. The spec's own `%build` runs a plain
+	# `cargo build --release`, which does not select examples, so rpmbuild
+	# cannot catch that omission.
+	#
+	# `docs/` is deliberately not copied: the component manuals moved to
+	# the repository-level docs/user-guide tree (a46aea8d) and the spec
+	# packages CHANGELOG.md only. Listing the removed directory made
+	# `cp -R` exit non-zero, so this target failed outright.
 	@rm -rf dist/$(NAME)-$(VERSION) && mkdir -p dist/$(NAME)-$(VERSION)
-	@cp -R Cargo.toml Cargo.lock src config tests docs \
+	@cp -R Cargo.toml Cargo.lock src examples config tests \
 		Makefile agent-memory.spec.in CHANGELOG.md LICENSE \
 		.gitignore .anolisa dist/$(NAME)-$(VERSION)/
 	@mkdir -p dist/$(NAME)-$(VERSION)/.cargo
@@ -284,6 +297,29 @@ dist: clean build-openclaw-plugin ## Create source + vendor tarballs for RPM bui
 		--exclude='.tsbuildinfo' \
 		--exclude='tests' \
 		. | tar -xf - -C dist/$(NAME)-$(VERSION)/$(ADAPTER_SRC_DIR)/
+	# Fail here rather than inside rpmbuild: every path the spec's %build
+	# and %install read, plus every target path Cargo.toml declares, must
+	# be in the staged tree. A copy list that silently rots is what broke
+	# this target the first time.
+	@set -e; \
+	staged="dist/$(NAME)-$(VERSION)"; \
+	for f in src/main.rs src/lib.rs examples/mcp_harness.rs \
+			config/default.toml config/mcp-server.json \
+			config/systemd/anolisa-memory@.service \
+			config/systemd/anolisa-memory-tmpfiles.conf \
+			$(ADAPTER_SRC_DIR)/manifest.json \
+			$(OPENCLAW_PLUGIN_SRC_DIR)/dist/index.js \
+			$(OPENCLAW_PLUGIN_SRC_DIR)/openclaw.plugin.json \
+			$(OPENCLAW_PLUGIN_SRC_DIR)/package.json \
+			$(OPENCLAW_PLUGIN_SRC_DIR)/scripts/detect.sh \
+			$(OPENCLAW_PLUGIN_SRC_DIR)/scripts/install.sh \
+			$(OPENCLAW_PLUGIN_SRC_DIR)/scripts/uninstall.sh \
+			$(COMPONENT_CONTRACT) CHANGELOG.md LICENSE; do \
+		test -e "$$staged/$$f" || { \
+			echo "ERROR: $$f is missing from $$staged but agent-memory.spec.in or Cargo.toml requires it" >&2; \
+			exit 1; \
+		}; \
+	done
 	tar czf dist/$(NAME)-$(VERSION).tar.gz -C dist $(NAME)-$(VERSION)
 	@echo "==> Creating $(NAME)-$(VERSION)-vendor.tar.gz..."
 	# Top-level dir is `vendor/` (no $(NAME)-vendor wrapper) so that


### PR DESCRIPTION
## What is broken

`make -C src/agent-memory dist` — the target the Makefile documents as *"Create source + vendor tarballs for RPM build"*, and the prerequisite of `make rpm` / `make srpm` — fails on `main`:

```console
$ make dist                      # 8ba7a0f0
cp: cannot stat 'docs': No such file or directory
make: *** [Makefile:274: dist] Error 1
```

`a46aea8d` (*docs(docs): move user manuals to docs/user-guide*) moved `src/agent-memory/docs/{en,zh}/…user_manual.md` into the repository-level `docs/user-guide` tree, which left `src/agent-memory/docs/` empty and therefore gone. The `cp -R` list in `dist` still names `docs`, so the target aborts before writing either tarball. It has been broken since 2026‑07‑21.

Fixing only that exposes a second, older omission: the copy list never included `examples/`, while `Cargo.toml` declares an explicit target path —

```toml
[[example]]
name = "mcp-harness"
path = "examples/mcp_harness.rs"
```

Cargo refuses to resolve a declared target whose file is missing, so an archive built from a merely de-`docs`'d copy list still fails any invocation that selects examples:

```console
$ cargo build --offline --examples      # unpacked archive without examples/
error: can't find example `mcp-harness` at path `/…/agent-memory-0.2.7/examples/mcp_harness.rs`
error: could not compile due to 1 previous target resolution error
```

`%build` runs a plain `cargo build --release --locked --offline`, which does not select examples, so rpmbuild could never report this. `cargo test` does build them, and the archive ships `tests/` plus a Makefile whose `test` target runs `cargo test --locked` — i.e. it is meant to be test-capable.

Blast radius: the two CI release paths are unaffected (`.github/actions/package-source` copies the whole component tree; `scripts/rpm-build.sh` tars it minus build artefacts). This is the contributor/local release path.

## What changed

`src/agent-memory/Makefile` (`dist` only) and one stale comment in `src/agent-memory/Cargo.toml`:

- Drop the removed `docs/` from the copy list. The spec packages `CHANGELOG.md` only (`%doc %{_docdir}/%{name}/CHANGELOG.md`), and the manuals now live in `docs/user-guide`.
- Add `examples/` so every target `Cargo.toml` declares is present in the archive.
- Guard the staged tree before tarring: assert each path `agent-memory.spec.in`'s `%build`/`%install` reads (`src/main.rs`, `src/lib.rs`, `examples/mcp_harness.rs`, both configs, the two systemd units, `adapters/agent-memory/manifest.json`, the four openclaw bundle files, `.anolisa/component.toml`, `CHANGELOG.md`, `LICENSE`) and fail naming the missing one. Tradeoff: the list duplicates what the spec reads and can itself go stale — but it fails loudly at `make dist` instead of silently inside rpmbuild, which is exactly the failure mode that rotted this target.
- `Cargo.toml`'s "Linux only" note pointed at `docs/design.md`, which has never existed in this component (`git log --all --diff-filter=A -- 'src/agent-memory/docs/*'` shows only the two user manuals). It now points at `docs/BUILDING.md` and the `remote-build` / `remote-test` targets, which is where the Linux-host workflow is actually documented.

No workflow files are touched.

## Verification

Local, with only the crate-download step stubbed (`cargo vendor` writes a placeholder tree; every other line is the real recipe — this machine's registry fetch was ~1 crate/20 s):

| Check | Result |
| --- | --- |
| `make dist` before this change | exit 2 — `cp: cannot stat 'docs': No such file or directory` |
| `make dist` after | exit 0 — `dist/agent-memory-0.2.7.tar.gz` (367 KiB) + `dist/agent-memory-0.2.7-vendor.tar.gz` |
| Unpacked archive contents | top level `agent-memory-0.2.7/` (matches `%setup -n`); all 17 spec-required paths present incl. `examples/mcp_harness.rs` and `.cargo/config.toml`; no `docs/` |
| New guard, negative case (`examples/mcp_harness.rs` removed) | exit 2 — `ERROR: examples/mcp_harness.rs is missing from dist/agent-memory-0.2.7 but agent-memory.spec.in or Cargo.toml requires it`, no tarball written |
| `cargo build --offline --examples` on a staged tree without `examples/` | `error: can't find example 'mcp-harness'` (reproduces the second defect) |
| `make -n dist` | expands cleanly (recipe syntax) |
| `make help` | renders, `dist` description unchanged |
| `make test-openclaw-install` | 11/11 PASS |
| `python3 scripts/check-component-versions.py` | "Component version metadata is synchronized." |
| `git status` after the runs | only the two intended files modified (artefacts are gitignored) |

Not run: a full `rpmbuild` (needs mock + `systemd-devel`), and a real `cargo vendor` (registry throughput here). Neither is touched by this change — the vendor tarball recipe and the `%setup`/`%build` inputs are unchanged apart from the added `examples/`.
