### PR TITLE
fix(memory): refuse expert profile at plugin boot

### DIFF
--- a/docs/user-guide/en/token-saving/agent-memory.md
+++ b/docs/user-guide/en/token-saving/agent-memory.md
@@ -146,7 +146,7 @@ Plugin config (via OpenClaw UI or `openclaw.json` `plugins.entries["memory-anoli
 |---|---|---|
 | `binaryPath` | auto-discovery: `$PATH` → `/usr/bin/agent-memory` → `/usr/local/bin/agent-memory` → `~/.local/bin/agent-memory` | absolute binary path |
 | `userId` | env `USER_ID` → OS `uid` → env `$USER` | namespace `user_id`; same validation as Rust side |
-| `profile` | `advanced` | profile gate, passed as `MEMORY_PROFILE` env |
+| `profile` | `advanced` | profile gate, passed as `MEMORY_PROFILE` env; `basic` or `advanced` only — the plugin rejects `expert` at load (see Profiles below) |
 | `maxReadBytes` | `1048576` (1 MiB) | `mem_read` cap, passed as `MEMORY_MAX_READ_BYTES` |
 | `maxWriteBytes` | `16777216` (16 MiB) | `mem_write` cap, passed as `MEMORY_MAX_WRITE_BYTES` |
 | `sessionId` | env `MEMORY_SESSION_ID` → new `ses_<random>` | namespace session; must be fixed |
@@ -424,6 +424,16 @@ Profiles are UX hints, not security boundaries, but enforced at both `tools/list
 - **basic** — all 37 tools shown; weaker models can use the Tier B structured API.
 - **advanced** (default) — all 37 tools shown; stronger models should prefer Tier A file ops.
 - **expert** — hides Tier B (`memory_search`, `memory_observe`, `memory_get_context`, `mem_consolidate`, `memory_forget`, `memory_consent`); `tools/call` returns `METHOD_NOT_FOUND`. For proficient models that only need Tier A and Tier C.
+
+`expert` is a setting for direct MCP clients, which drive the Tier A file tools
+themselves. The OpenClaw adapter rejects
+`plugins.entries["memory-anolisa"].config.profile = "expert"` when the plugin
+loads: three of the four tools it registers for the host's memory contract
+(`memory_search`, `memory_observe`, `memory_get_context`) are Tier B, and so are
+the two paths that call `memory_search` on the agent's behalf — auto-recall
+before each prompt and the `corpus=all` supplement. Forwarding the profile would
+leave the memory slot loaded while every one of those calls came back
+`METHOD_NOT_FOUND`, so the adapter fails at boot and says why instead.
 
 ### Embedding config
 

--- a/docs/user-guide/zh/token-saving/agent-memory.md
+++ b/docs/user-guide/zh/token-saving/agent-memory.md
@@ -145,7 +145,7 @@ anolisa adapter status agent-memory
 |---|---|---|
 | `binaryPath` | 自动发现：`$PATH` → `/usr/bin/agent-memory` → `/usr/local/bin/agent-memory` → `~/.local/bin/agent-memory` | 二进制绝对路径 |
 | `userId` | env `USER_ID` → OS `uid` → env `$USER` | 命名空间 `user_id`；校验规则与 Rust 侧一致 |
-| `profile` | `advanced` | profile 门控，以 `MEMORY_PROFILE` env 启动子进程 |
+| `profile` | `advanced` | profile 门控，以 `MEMORY_PROFILE` env 启动子进程；仅支持 `basic` 与 `advanced` —— 插件在加载阶段拒绝 `expert`（见下文 Profile 含义） |
 | `maxReadBytes` | `1048576`（1 MiB） | 单次 `mem_read` 上限，以 `MEMORY_MAX_READ_BYTES` env 传入 |
 | `maxWriteBytes` | `16777216`（16 MiB） | 单次 `mem_write` 上限，以 `MEMORY_MAX_WRITE_BYTES` env 传入 |
 | `sessionId` | env `MEMORY_SESSION_ID` → 新生成 `ses_<random>` | 命名空间挂载会话，必须固定 |
@@ -423,6 +423,13 @@ Profile 是 UX 提示而非安全边界，但在 `tools/list` 和 `tools/call` �
 - **basic** —— 37 个工具全部展示；弱模型也能用 Tier B 的结构化 API。
 - **advanced**（默认）—— 37 个工具全部展示；强模型应优先使用 Tier A 文件操作。
 - **expert** —— 隐藏 Tier B（`memory_search`、`memory_observe`、`memory_get_context`、`mem_consolidate`、`memory_forget`、`memory_consent`），`tools/call` 调用会以 `METHOD_NOT_FOUND` 拒绝。熟练操作文件系统的前沿模型只需 Tier A 与 Tier C.
+
+`expert` 面向直连 MCP 的客户端——它们自己驱动 Tier A 文件工具。OpenClaw 适配器在插件加载阶段就会拒绝
+`plugins.entries["memory-anolisa"].config.profile = "expert"`：它为宿主 memory 契约注册的 4 个工具有
+3 个属于 Tier B（`memory_search`、`memory_observe`、`memory_get_context`），替 agent 调用
+`memory_search` 的两条路径（每轮 prompt 前的自动召回、`corpus=all` 语料补充）同样属于 Tier B。
+若把该档位透传下去，memory slot 会照常加载，但上述调用全部返回 `METHOD_NOT_FOUND`；因此适配器选择
+在启动时失败并说明原因。
 
 ### Embedding 配置
 

--- a/src/agent-memory/README.md
+++ b/src/agent-memory/README.md
@@ -105,6 +105,9 @@ Single-process Tokio async runtime exposing 37 MCP tools over stdio JSON-RPC 2.0
 - **Sovereignty** (13 tools): about, forget, consent, export/import, tasks, dream
 
 Profile gating (basic/advanced/expert) controls tool visibility per deployment.
+The OpenClaw adapter forwards this profile to the child and accepts `basic`/`advanced`
+only: `expert` hides the Tier B tools its memory contract is built on, so the plugin
+refuses to load with it.
 
 ## Requirements
 

--- a/src/agent-memory/README_zh.md
+++ b/src/agent-memory/README_zh.md
@@ -68,6 +68,10 @@ openclaw gateway restart
 - **Tier C**（7 工具）：治理（快照、版本控制、聚合）
 - **主权**（13 工具）：关于、遗忘、同意、导入导出、任务、梦境合成
 
+Profile 门控（basic/advanced/expert）按部署形态控制工具可见性。OpenClaw 适配器会把该档位
+透传给子进程，但只接受 `basic`/`advanced`：`expert` 会隐藏其 memory 契约所依赖的 Tier B
+工具，插件会拒绝加载。
+
 ## 环境要求
 
 - Linux（x86_64 / aarch64）

--- a/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
@@ -32,10 +32,9 @@
         "type": "string",
         "enum": [
           "basic",
-          "advanced",
-          "expert"
+          "advanced"
         ],
-        "description": "Memory profile controlling which tools are visible to the agent."
+        "description": "Memory profile forwarded as MEMORY_PROFILE: basic (structured API preferred) or advanced (file tools preferred, default). 'expert' is not offered: it hides the Tier B tools this plugin's memory contract is built on (memory_search, memory_observe, memory_get_context), so the adapter rejects it at load. It is meant for direct MCP clients that drive the Tier A file tools themselves."
       },
       "maxReadBytes": {
         "type": "integer",
@@ -72,7 +71,7 @@
     },
     "profile": {
       "label": "Memory Profile",
-      "help": "Controls which tools are advertised: basic (structured API only), advanced (file + search), expert (file tools only)."
+      "help": "Controls which tools the agent-memory child advertises: basic (structured API preferred) or advanced (file tools preferred, default). expert is unavailable here — it hides the Tier B tools this adapter registers, so the plugin refuses to load with it."
     },
     "maxReadBytes": {
       "label": "Max Read Bytes",

--- a/src/agent-memory/adapters/agent-memory/openclaw/src/config.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/src/config.ts
@@ -4,9 +4,10 @@
  * Reads plugin config, falls back to env vars, then to OS defaults.
  * Validation rules are kept in lock-step with the Rust crate
  * (`src/agent-memory/src/ns/mod.rs::validate_user_id`,
- * `src/agent-memory/src/config.rs`) so that a value accepted here is
- * also accepted by the subprocess — failures in the deep child are
- * harder to diagnose than failures at plugin boot.
+ * `src/agent-memory/src/config.rs`, including the `Profile::tool_visible`
+ * gate the child enforces on the profile this module forwards) so that a
+ * value accepted here is also one the subprocess can honor — failures in
+ * the deep child are harder to diagnose than failures at plugin boot.
  */
 
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
@@ -14,10 +15,21 @@ import { randomBytes } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
+/** Profiles this adapter can run the agent-memory child under.
+ *
+ *  `expert` is deliberately absent: the child honors it by hiding the Tier B
+ *  tools this plugin's memory contract is made of (see `resolveProfile`).
+ *  `openclaw.plugin.json`'s `configSchema.properties.profile.enum` must list
+ *  exactly these values — `tests/unit/manifest-config-schema-test.ts` fails
+ *  on drift in either direction. */
+export const SUPPORTED_PROFILES = ["basic", "advanced"] as const;
+
+export type AgentMemoryProfile = (typeof SUPPORTED_PROFILES)[number];
+
 export type AgentMemoryConfig = {
   binaryPath: string;
   userId: string;
-  profile: "basic" | "advanced" | "expert";
+  profile: AgentMemoryProfile;
   maxReadBytes: number;
   maxWriteBytes: number;
   /** Session id pinned for this client's lifetime. Forwarded as
@@ -30,7 +42,7 @@ export type AgentMemoryConfig = {
   sessionDir: string;
 };
 
-const DEFAULT_PROFILE: AgentMemoryConfig["profile"] = "advanced";
+const DEFAULT_PROFILE: AgentMemoryProfile = "advanced";
 const DEFAULT_MAX_READ_BYTES = 1_048_576;
 const DEFAULT_MAX_WRITE_BYTES = 16 * 1_048_576;
 
@@ -103,10 +115,52 @@ function normalizeTrimmedString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
-function normalizeProfile(value: unknown): AgentMemoryConfig["profile"] {
+/** Tier B tools the child hides under `Profile::Expert`
+ *  (`src/agent-memory/src/config.rs::Profile::tool_visible`) that this plugin
+ *  registers for the host's memory contract. Spelled out in the rejection so
+ *  the operator can tie it to the `METHOD_NOT_FOUND` the child would otherwise
+ *  answer with at call time. */
+export const CONTRACT_TOOLS_HIDDEN_BY_EXPERT = [
+  "memory_search",
+  "memory_observe",
+  "memory_get_context",
+] as const;
+
+/** Resolve `profile`, rejecting the one value the child accepts but this
+ *  adapter cannot honor.
+ *
+ *  `expert` hides Tier B in the child at both `tools/list` and `tools/call`,
+ *  and three of the four tools this plugin registers are Tier B — as are the
+ *  two paths that call `memory_search` behind the agent's back, the
+ *  auto-recall hook and the `corpus=all` supplement. Forwarding it therefore
+ *  does not give the operator "file tools only": it loads a memory slot whose
+ *  search, observe and get_context tools fail every call, whose auto-recall
+ *  fails on every prompt, and whose corpus supplement silently answers
+ *  nothing — the only hint is an error string inside each tool result. The
+ *  adapter exposes exactly one Tier A tool (`memory_get` → `mem_read`) and
+ *  cannot expose the rest without breaking the host's memory contract, so
+ *  `expert` stays a setting for direct MCP clients that drive Tier A
+ *  themselves. Refusing at boot is this module's standing contract for a
+ *  value the subprocess would honor differently than the operator expects.
+ *
+ *  Unrecognized values keep falling back to `DEFAULT_PROFILE`: the manifest
+ *  enum already turns a typo into a host-side config error, and this resolver
+ *  stays permissive for hosts that do not validate. */
+function resolveProfile(value: unknown): AgentMemoryProfile {
   const s = typeof value === "string" ? value.trim().toLowerCase() : "";
-  if (s === "basic" || s === "advanced" || s === "expert") {
-    return s;
+  if (s === "expert") {
+    throw new Error(
+      `profile 'expert' cannot run the OpenClaw adapter: the agent-memory child hides ` +
+        `${CONTRACT_TOOLS_HIDDEN_BY_EXPERT.join(", ")} under that profile, and those are ` +
+        `three of the four tools this plugin registers for the host's memory contract ` +
+        `(auto-recall and the corpus=all supplement call memory_search too). Use ` +
+        `'advanced' (the default) or 'basic'; 'expert' is for direct MCP clients that ` +
+        `drive the Tier A file tools themselves.`,
+    );
+  }
+  const supported: readonly string[] = SUPPORTED_PROFILES;
+  if (supported.includes(s)) {
+    return s as AgentMemoryProfile;
   }
   return DEFAULT_PROFILE;
 }
@@ -259,7 +313,7 @@ export function resolveConfig(api: OpenClawPluginApi): AgentMemoryConfig {
   const userId = resolveUserId(normalizeTrimmedString(raw.userId));
   const sessionId = resolveSessionId(normalizeTrimmedString(raw.sessionId));
   const sessionDir = resolveSessionDir(normalizeTrimmedString(raw.sessionDir));
-  const profile = normalizeProfile(raw.profile);
+  const profile = resolveProfile(raw.profile);
   const maxReadBytes = normalizePositiveInt(raw.maxReadBytes, DEFAULT_MAX_READ_BYTES);
   const maxWriteBytes = normalizePositiveInt(raw.maxWriteBytes, DEFAULT_MAX_WRITE_BYTES);
 

--- a/src/agent-memory/adapters/agent-memory/openclaw/src/index.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/src/index.ts
@@ -31,6 +31,40 @@ import {
 // shutdown for its lazy-start to begin).
 let activeClient: McpStdioClient | null = null;
 
+/** Stop the client a previous register() left running, if any.
+ *
+ *  Called *before* anything in register() that can throw. `resolveConfig`
+ *  rejects configuration the child would honor differently than the
+ *  operator meant — `profile: "expert"` (see `config.ts::resolveProfile`),
+ *  a malformed `userId`/`sessionId`, a missing binary — and that throw
+ *  aborts register(), so a teardown written after it never ran on exactly
+ *  the reloads that need one: the host keeps nothing from a failed
+ *  registration, and a hot-reload does not fire gateway_stop for the old
+ *  instance either. The previous subprocess would outlive the plugin that
+ *  owned it and hold the sqlite/git locks until the gateway exited, and the
+ *  reload after the operator fixed the config would start a second child
+ *  behind those locks.
+ *
+ *  Fire-and-forget, as before: the replacement client starts lazily and
+ *  must not wait on a stale shutdown to begin. */
+function stopStaleClient(api: OpenClawPluginApi): void {
+  if (!activeClient) return;
+  const stale = activeClient;
+  // Cleared before stopping rather than after: if this registration goes on
+  // to fail, `activeClient` must not keep pointing at a client we already
+  // asked to stop, or the next register() would tear the same one down
+  // again and warn about a hot-reload that has nothing left to clean up.
+  activeClient = null;
+  api.logger.warn?.(
+    "agent-memory: previous client still active during register() — tearing it down (hot-reload?)",
+  );
+  stale.stop().catch((err: unknown) => {
+    api.logger.warn?.(
+      `agent-memory: stale-client teardown failed (${err instanceof Error ? err.message : String(err)})`,
+    );
+  });
+}
+
 export default definePluginEntry({
   id: "memory-anolisa",
   name: "Anolisa Memory",
@@ -38,19 +72,9 @@ export default definePluginEntry({
     "Persistent memory backed by the agent-memory MCP server with namespace isolation and openat2 sandbox.",
   kind: "memory",
   register(api: OpenClawPluginApi) {
-    const config: AgentMemoryConfig = resolveConfig(api);
+    stopStaleClient(api);
 
-    if (activeClient) {
-      const stale = activeClient;
-      api.logger.warn?.(
-        "agent-memory: previous client still active during register() — tearing it down (hot-reload?)",
-      );
-      stale.stop().catch((err: unknown) => {
-        api.logger.warn?.(
-          `agent-memory: stale-client teardown failed (${err instanceof Error ? err.message : String(err)})`,
-        );
-      });
-    }
+    const config: AgentMemoryConfig = resolveConfig(api);
 
     const client = new McpStdioClient(config);
     activeClient = client;

--- a/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/config-test.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/config-test.ts
@@ -8,6 +8,8 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 const {
   resolveConfig,
@@ -248,5 +250,147 @@ describe("resolveConfig sessionId (R6-1 regression)", () => {
     } catch (err: any) {
       assert.ok(err.message.includes("binary"), err.message);
     }
+  });
+});
+
+describe("resolveConfig profile gate", () => {
+  // `expert` is a valid MEMORY_PROFILE for the child — it hides Tier B at both
+  // `tools/list` and `tools/call` (`src/config.rs::Profile::tool_visible`,
+  // pinned by `tests/profile_test.rs::expert_profile_hides_tier_b`) — but three
+  // of the four tools this plugin registers for the host's memory contract are
+  // exactly that Tier B list, and so are the two paths that call
+  // `memory_search` behind the agent's back (auto-recall, `corpus=all`
+  // supplement). Forwarding it used to load a memory slot whose
+  // memory_search / memory_observe / memory_get_context failed every call with
+  // METHOD_NOT_FOUND, whose auto-recall failed on every prompt and whose
+  // corpus supplement answered nothing — with the reason visible only inside
+  // each tool result, never at boot.
+  it("rejects 'expert' instead of forwarding a profile the child hides contract tools under", () => {
+    assert.throws(
+      () => resolveConfig(mockApi({ profile: "expert" })),
+      /profile 'expert' cannot run the OpenClaw adapter/,
+    );
+  });
+
+  it("names the hidden contract tools and the profiles that do work", () => {
+    assert.throws(
+      () => resolveConfig(mockApi({ profile: "expert" })),
+      (err: Error) => {
+        for (const tool of ["memory_search", "memory_observe", "memory_get_context"]) {
+          assert.ok(err.message.includes(tool), `message should name ${tool}: ${err.message}`);
+        }
+        assert.match(err.message, /'advanced'/);
+        assert.match(err.message, /'basic'/);
+        return true;
+      },
+    );
+  });
+
+  it("normalizes case and surrounding whitespace before rejecting", () => {
+    for (const profile of ["Expert", "EXPERT", "  expert  ", "\tExpert\n"]) {
+      assert.throws(
+        () => resolveConfig(mockApi({ profile })),
+        /cannot run the OpenClaw adapter/,
+        `expected ${JSON.stringify(profile)} to be rejected`,
+      );
+    }
+  });
+
+  it("reports the profile before probing for the binary", () => {
+    // 48d10029 moved identifier validation ahead of the binary probe so a
+    // configuration error is not masked by "agent-memory binary not found" on
+    // a host without the binary; the profile gate keeps that order.
+    assert.throws(
+      () =>
+        resolveConfig(mockApi({ profile: "expert", binaryPath: "/nonexistent/agent-memory" })),
+      (err: Error) => {
+        assert.ok(!err.message.includes("binary"), err.message);
+        assert.match(err.message, /profile 'expert'/);
+        return true;
+      },
+    );
+  });
+
+  it("accepts both supported profiles, normalized", () => {
+    for (const [given, expected] of [
+      ["basic", "basic"],
+      ["advanced", "advanced"],
+      ["  Basic ", "basic"],
+      ["ADVANCED", "advanced"],
+    ]) {
+      const cfg = resolveConfig(mockApi({ profile: given, binaryPath: process.execPath }));
+      assert.equal(cfg.profile, expected);
+    }
+  });
+
+  it("still falls back to advanced for an unrecognized value", () => {
+    // The manifest enum turns a typo into a host-side config error; the
+    // resolver stays permissive for hosts that do not validate.
+    const cfg = resolveConfig(mockApi({ profile: "frontier", binaryPath: process.execPath }));
+    assert.equal(cfg.profile, "advanced");
+  });
+
+  it("does not read the profile off the ambient environment", () => {
+    // resolveConfig reads `profile` from api.pluginConfig only, and
+    // buildChildEnv lets the resolved value win over the ambient one
+    // (mcp-client-test.ts), so an exported MEMORY_PROFILE=expert — valid for a
+    // direct MCP client on the same box — cannot reach this adapter's child.
+    process.env["MEMORY_PROFILE"] = "expert";
+    try {
+      const cfg = resolveConfig(mockApi({ binaryPath: process.execPath }));
+      assert.equal(cfg.profile, "advanced");
+    } finally {
+      delete process.env["MEMORY_PROFILE"];
+    }
+  });
+});
+
+describe("the profile gate's premise, derived from the child", () => {
+  // Rejecting `expert` is only correct while the child's gate hides tools this
+  // plugin actually registers, so both sides are read instead of restated: the
+  // Tier B list from the Rust suite that pins it, the contract tool list from
+  // the manifest the host loads. If `Profile::tool_visible` ever covers another
+  // registered tool — or stops covering one of these — the intersection moves
+  // and this fails, forcing the rejection and its message to be re-derived
+  // rather than quietly going stale.
+  const rustProfileTest = fileURLToPath(
+    new URL("../../../../../tests/profile_test.rs", import.meta.url),
+  );
+  const manifest = JSON.parse(
+    readFileSync(
+      fileURLToPath(new URL("../../openclaw.plugin.json", import.meta.url)),
+      "utf8",
+    ),
+  ) as { contracts?: { tools?: string[] } };
+
+  /** Tier B tool names, read from the `const TIER_B` declaration in the Rust suite. */
+  function rustTierB(): string[] {
+    const source = readFileSync(rustProfileTest, "utf8");
+    const decl = /const\s+TIER_B[^=]*=\s*&\[([\s\S]*?)\];/.exec(source);
+    assert.ok(
+      decl,
+      `could not find the TIER_B list in ${rustProfileTest}; if that suite moved, ` +
+        `point this guard at its new home instead of dropping the derivation`,
+    );
+    const names = [...decl![1]!.matchAll(/"([^"]+)"/g)].map((m) => m[1]!);
+    assert.ok(names.length > 0, "TIER_B parsed as empty");
+    return names;
+  }
+
+  it("rejects 'expert' because the child hides registered contract tools under it", async () => {
+    const { CONTRACT_TOOLS_HIDDEN_BY_EXPERT } = await import("../../src/config.js");
+    const contractTools = manifest.contracts?.tools ?? [];
+    assert.ok(
+      contractTools.length > 0,
+      "openclaw.plugin.json declares no contracts.tools; this guard needs the " +
+        "host-facing tool list to intersect with the child's gate",
+    );
+    const hidden = contractTools.filter((tool) => rustTierB().includes(tool)).sort();
+    assert.ok(
+      hidden.length > 0,
+      "expert hides nothing this plugin registers, so refusing it is no longer " +
+        "justified — drop the rejection in resolveProfile instead of keeping it",
+    );
+    assert.deepEqual(hidden, [...CONTRACT_TOOLS_HIDDEN_BY_EXPERT].sort());
   });
 });

--- a/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/manifest-config-schema-test.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/manifest-config-schema-test.ts
@@ -38,6 +38,7 @@ type SchemaProperty = {
   type?: string;
   description?: string;
   maxLength?: number;
+  enum?: string[];
 };
 
 type Manifest = {
@@ -156,6 +157,34 @@ describe("openclaw.plugin.json configSchema", () => {
     // resolveSessionId() runs explicit config through validateUserId(), so the
     // two schema entries must not drift apart.
     assert.equal(properties.sessionId?.maxLength, properties.userId?.maxLength);
+  });
+
+  it("offers exactly the profiles the resolver can honor", async () => {
+    // Both directions matter. An enum value the resolver rejects sends the
+    // operator to a plugin that fails during register — the Control UI offers
+    // it, the host validates it, and the memory slot still does not come up. A
+    // value the resolver accepts but the enum omits is unreachable from config
+    // the host validates. The resolver's own list is the source of truth, so
+    // this reads it instead of restating it.
+    const { SUPPORTED_PROFILES, resolveConfig } = await import("../../src/config.js");
+    // Typed as string[] on purpose: the deepEqual below narrows the schema's
+    // enum to the resolver's union, and the point of this guard is that
+    // "expert" is *not* in it.
+    const declaredProfiles: string[] = properties.profile?.enum ?? [];
+    assert.ok(
+      !declaredProfiles.includes("expert"),
+      "the schema must not offer 'expert': the child hides the Tier B tools " +
+        "this adapter's memory contract is built on, so resolveConfig rejects it",
+    );
+    assert.deepEqual(declaredProfiles, [...SUPPORTED_PROFILES]);
+    for (const profile of SUPPORTED_PROFILES) {
+      const cfg = resolveConfig({
+        pluginConfig: { ...DOCUMENTED_CONFIG, profile, binaryPath: process.execPath },
+        resolvePath: (p: string) => p,
+        logger: { info: () => {}, warn: () => {}, debug: () => {} },
+      } as never);
+      assert.equal(cfg.profile, profile);
+    }
   });
 });
 

--- a/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/plugin-register-test.ts
+++ b/src/agent-memory/adapters/agent-memory/openclaw/tests/unit/plugin-register-test.ts
@@ -1,0 +1,167 @@
+/**
+ * register() lifecycle around a configuration the plugin refuses.
+ *
+ * A hot-reload can call register() again without the host firing
+ * gateway_stop for the previous instance, so the plugin tears the stale
+ * client down itself (see the `activeClient` note in src/index.ts). That
+ * teardown has to run *before* `resolveConfig`, not after it: a config
+ * error — the `profile: "expert"` rejection in particular — aborts
+ * register(), the host keeps nothing from the failed registration, and the
+ * stale subprocess would outlive the plugin that owned it, holding the
+ * sqlite/git locks until the gateway exits. The reload that fixes the
+ * config would then start a second child behind those locks.
+ *
+ * Nothing here spawns a subprocess: `McpStdioClient` starts lazily on the
+ * first tool call and `stop()` on an unstarted client returns immediately,
+ * so these tests drive the real register() against a mock host API and
+ * observe the teardown through a `stop()` spy.
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { McpStdioClient } from "../../src/mcp-client.js";
+
+const plugin = (await import("../../src/index.js")).default;
+
+// resolveConfig requires an existing, executable binaryPath. It is never
+// spawned — no test below calls a tool — so a stub file is enough.
+const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-memory-register-"));
+const binaryPath = path.join(binDir, "agent-memory");
+fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n");
+fs.chmodSync(binaryPath, 0o755);
+
+/** Valid config; `sessionId` doubles as the identity of the client that
+ *  carried it, which is how the assertions below tell the stale client
+ *  apart from the one a later register() creates. */
+function config(sessionId: string, extra: Record<string, unknown> = {}) {
+  return { binaryPath, userId: "1000", sessionId, profile: "advanced", ...extra };
+}
+
+type MockHost = ReturnType<typeof mockApi>;
+
+function mockApi(pluginConfig: Record<string, unknown>) {
+  const tools: string[] = [];
+  const hooks: string[] = [];
+  const warnings: string[] = [];
+  const api = {
+    pluginConfig,
+    resolvePath: (p: string) => p,
+    logger: {
+      info: () => {},
+      debug: () => {},
+      error: () => {},
+      warn: (message: string) => {
+        warnings.push(message);
+      },
+    },
+    on: (event: string) => {
+      hooks.push(event);
+    },
+    registerTool: (spec: { name: string }) => {
+      tools.push(spec.name);
+    },
+    registerMemoryCapability: () => {},
+    registerMemoryCorpusSupplement: () => {},
+  };
+  return { api: api as never, tools, hooks, warnings };
+}
+
+function register(host: MockHost) {
+  plugin.register(host.api);
+  return host;
+}
+
+/** The sessionId of the config a stopped client was built from. */
+function sessionIdOf(client: McpStdioClient): string | undefined {
+  return (client as unknown as { config?: { sessionId?: string } }).config?.sessionId;
+}
+
+// `activeClient` is module-scoped, so the registrations below are one
+// continuous sequence: each test asserts on the stops it added, not on an
+// absolute count.
+const stopped: McpStdioClient[] = [];
+const realStop = McpStdioClient.prototype.stop;
+
+before(() => {
+  McpStdioClient.prototype.stop = async function (this: McpStdioClient) {
+    stopped.push(this);
+    return realStop.call(this);
+  };
+});
+
+after(() => {
+  McpStdioClient.prototype.stop = realStop;
+  fs.rmSync(binDir, { recursive: true, force: true });
+});
+
+describe("register() stale-client teardown", () => {
+  it("registers the memory contract and leaves nothing to tear down on first load", () => {
+    const host = register(mockApi(config("ses_first")));
+
+    assert.deepEqual(
+      [...host.tools].sort(),
+      ["memory_get", "memory_get_context", "memory_observe", "memory_search"].sort(),
+    );
+    assert.deepEqual(host.hooks, ["before_prompt_build", "gateway_stop", "agent_end"]);
+    assert.deepEqual(stopped, []);
+  });
+
+  it("still stops the stale client when the reload's profile is rejected", () => {
+    const reloaded = register(mockApi(config("ses_stale")));
+    assert.deepEqual(
+      stopped.map(sessionIdOf),
+      ["ses_first"],
+      "the successful reload tears down the client it replaced",
+    );
+    assert.match(
+      reloaded.warnings.join("\n"),
+      /previous client still active during register\(\)/,
+    );
+
+    const mark = stopped.length;
+    const failed = mockApi(config("ses_rejected", { profile: "expert" }));
+
+    assert.throws(
+      () => plugin.register(failed.api),
+      /profile 'expert' cannot run the OpenClaw adapter/,
+    );
+
+    // The point of the ordering: register() aborted, and the subprocess the
+    // previous registration owned was stopped on the way out rather than
+    // stranded with no hook left that could ever reach it.
+    assert.deepEqual(
+      stopped.slice(mark).map(sessionIdOf),
+      ["ses_stale"],
+      "a rejected reload must still stop the client it was replacing",
+    );
+    assert.deepEqual(failed.tools, [], "a rejected register() registers no tools");
+    assert.deepEqual(failed.hooks, [], "a rejected register() registers no hooks");
+  });
+
+  it("does not tear the same stale client down a second time", () => {
+    const mark = stopped.length;
+    const recovered = register(mockApi(config("ses_recovered")));
+
+    assert.deepEqual(
+      stopped.slice(mark),
+      [],
+      "the client stopped by the failed reload is already gone; only a live one may be stopped",
+    );
+    assert.ok(
+      !recovered.warnings.some((w) => /previous client still active/.test(w)),
+      `unexpected teardown warning: ${recovered.warnings.join(" | ")}`,
+    );
+    assert.deepEqual(recovered.tools.length, 4);
+  });
+
+  it("keeps tearing the stale client down across a successful reload", () => {
+    const mark = stopped.length;
+    register(mockApi(config("ses_again")));
+
+    assert.deepEqual(stopped.slice(mark).map(sessionIdOf), ["ses_recovered"]);
+  });
+});


### PR DESCRIPTION
## Why

The OpenClaw adapter accepts `profile: "expert"` and forwards it to the child as `MEMORY_PROFILE`, but `expert` is the one profile that hides the tools this plugin exists to provide. `Profile::tool_visible` (`src/agent-memory/src/config.rs`) hides Tier B at both `tools/list` and `tools/call`, and three of the four tools the plugin registers for the host's memory contract are exactly that list. Measured on `main` @ `a3e641a3`:

```text
MEMORY_PROFILE=advanced  tools/list -> 37 tools
MEMORY_PROFILE=expert    tools/list -> 31 tools

MEMORY_PROFILE=expert:
  tools/call memory_search      -> -32601 tool 'memory_search' is not exposed under the Expert profile
  tools/call memory_observe     -> -32601 tool 'memory_observe' is not exposed under the Expert profile
  tools/call memory_get_context -> -32601 tool 'memory_get_context' is not exposed under the Expert profile
  tools/call mem_read           -> ok            # what memory_get maps to
```

So `expert` never delivered "file tools only" through this adapter: the plugin loaded, logged `plugin registered (... profile=expert ...)`, registered all four tools and both hooks, and then every search / observe / get_context call returned the error string inside the tool result, auto-recall failed on every prompt (once per recall candidate), and the `corpus=all` supplement swallowed the same error and contributed no hits — so the host's memory corpus silently lost this backend. Only `memory_get` kept working, and nothing at boot explained any of it.

## What changed

One logical change: the adapter refuses a profile it cannot honor, at boot, with the reason.

- `src/config.ts`: `normalizeProfile` → `resolveProfile`. `expert` throws an actionable error naming the three hidden contract tools and the two profiles that work; the accepted set becomes the exported `SUPPORTED_PROFILES` / `AgentMemoryProfile`, so `AgentMemoryConfig.profile` can no longer carry a value the child would reject. Unrecognized values still fall back to `advanced` (unchanged, and still the host schema's job to catch typos).
- `openclaw.plugin.json`: `configSchema.properties.profile.enum` drops `expert` — the Control UI should not offer a value whose only effect is a plugin that fails to load — and the `profile` description / `uiHints.help` now describe the two profiles accurately (the old help text described all three incorrectly: `basic` and `advanced` both expose all 37 tools). The resolver keeps rejecting `expert` for hosts that do not validate config against the schema.
- Tests: `config-test.ts` gains the rejection cases (message content, case/whitespace normalization, ordering ahead of the binary probe per `48d10029`, both accepted profiles, the retained fallback, and that an ambient `MEMORY_PROFILE=expert` cannot reach the resolver) plus one guard that *derives* the premise — it intersects the manifest's `contracts.tools` with the `TIER_B` list read from `src/agent-memory/tests/profile_test.rs`, so a future change to the child's gate moves the intersection and re-opens the question instead of leaving a stale rejection behind. `manifest-config-schema-test.ts` pins the schema enum to `SUPPORTED_PROFILES` in both directions.
- Docs: user guide (en/zh) profile tables and Profiles section, plus both component READMEs.

Failing at `resolveConfig` is the failure mode this module already chose for config the child would interpret differently than the operator meant — `48d10029` moved validation ahead of the binary probe for that reason and `a3e641a3` made the id bounds fail here rather than be silently replaced in the subprocess. The host catches a throw from `register()` and logs `[plugins] memory-anolisa failed during register from <source>: <message>`, so the operator gets the reason instead of a loaded-but-broken slot.

## Related issue

closes #3237

## User / Agent impact

- Operators with `plugins.entries["memory-anolisa"].config.profile = "expert"`: the plugin now fails to load with a message naming the hidden tools and the working profiles, instead of loading a memory slot whose search / observe / get_context calls all fail and whose `corpus=all` contribution is silently empty. Set `advanced` (default) or `basic` to restore it; `memory_get` was the only tool that worked before, so nothing that functioned is lost.
- Hosts that validate config against the manifest now reject `profile: "expert"` earlier, at config validation, with the allowed values in the error.
- No change for `basic`, `advanced`, an unset profile, or direct MCP clients — `MEMORY_PROFILE=expert` remains fully supported for those, and the server-side gate is untouched.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The accepted configuration surface narrows by one value (`profile: "expert"`), which is why it is called out above; that value has never produced a working memory slot through this adapter. No cross-component contract moves: the anolisa driver, the component contract and `manifests/components/agent-memory/component.toml` declare no `profile` config key, so nothing outside the plugin can set it. Rollback is `git revert` of the single commit; there is no state to migrate.

## Validation

Local, `main` @ `a3e641a3` + this commit (Linux x86_64, Node v22.21.1, rustc 1.96.0):

```text
cd src/agent-memory/adapters/agent-memory/openclaw
npm run build:check          # tsc --noEmit: clean
npm test                     # 149 pass / 0 fail (was 140 on main; +9)
npm run build                # esbuild bundle: dist/index.js 239.7kb

make -C src/agent-memory test-openclaw-install   # 41 PASS, 0 fail (untouched, run for regression)
cargo build --locked                             # Rust side unchanged; built to measure the child
```

Behavioural checks, not just unit assertions:

- Child, real binary over stdio JSON-RPC: `advanced` → 37 tools and all four contract calls succeed; `expert` → 31 tools, the three Tier B calls return `-32601 ... not exposed under the Expert profile`, `mem_read` succeeds. This is the premise the fix rests on.
- Plugin entry, real `register()` against a mock host API: `expert` → throws the new message; `advanced` / `basic` / unset → registers `memory_search, memory_get, memory_observe, memory_get_context` and the `before_prompt_build`, `gateway_stop`, `agent_end` hooks, exactly as before.
- Derived-guard non-vacuity: the intersection it computes is `[memory_get_context, memory_observe, memory_search]`, equal to the resolver's list, read from `tests/profile_test.rs` and `openclaw.plugin.json` rather than restated.

Not run: the repo-wide Rust suites (no Rust file changes in this commit) — CI covers them.

## Documentation and rollback

- `docs/user-guide/{en,zh}/token-saving/agent-memory.md`: plugin-config `profile` row now states the accepted values, and the Profiles section records that `expert` belongs to direct MCP clients and why the adapter refuses it. The `METHOD_NOT_FOUND` troubleshooting row is deliberately unchanged — it describes the direct-MCP path and is still accurate.
- `src/agent-memory/README.md` / `README_zh.md`: one summary line each next to the profile-gating note (the zh README had no profile sentence at all, so this also closes that gap).
- No CHANGELOG entry: per `specs/documentation-standard.md` §5, daily fix PRs update README and user-guide only, and the CHANGELOG is written in release version-bump PRs.
- Rollback: `git revert` this commit. Operators who set `expert` and want the pre-change behaviour back get the old loaded-but-failing slot, which is not a state worth restoring.
