### PR TITLE
feat(sec-core): add pii-checker skill

### DIFF
--- a/docs/user-guide/en/agent-security/agent-sec-core/pii-checker.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/pii-checker.md
@@ -6,6 +6,19 @@ PII Checker detects personal data and credentials in Agent inputs and outputs. I
 structured verdict, produces safe evidence and optional redacted text, and records sanitized
 Security Events for audit and Observability correlation.
 
+## Use the bundled Skill
+
+With V1 `agent-sec-cli` installed and the `pii-checker` Skill available to the Agent,
+ask it to check a specified file for personal data or credentials, or to generate
+a redacted copy. The Skill reports redacted evidence and does not rewrite the input
+file unless requested. A completed scan with no findings is not a guarantee that the
+content contains no sensitive information.
+
+The Skill ships in `agent-sec-skills` for RPM installations and in the ANOLISA raw
+package's shared skills directory. Cosh-NG discovers that directory; the OpenClaw and
+Hermes adapters declare `pii-checker` for delivery into their respective Skill directories.
+Other Agent installations must make the Skill available through their own discovery paths.
+
 ## Scan text
 
 Provide exactly one input source: inline text, standard input, or a UTF-8 file.

--- a/docs/user-guide/zh/agent-security/agent-sec-core/pii-checker.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/pii-checker.md
@@ -5,6 +5,16 @@
 PII Checker 用于检测 Agent 输入和输出中的个人数据与凭据。它返回结构化 verdict，生成安全的
 evidence 和可选脱敏文本，并记录经过清理的 Security Event，供审计和 Observability 关联使用。
 
+## 使用随包 Skill
+
+安装 V1 `agent-sec-cli` 且 Agent 能发现 `pii-checker` Skill 后，可以要求它检查指定文件中的
+个人信息或凭证，或生成脱敏副本。Skill 报告脱敏证据，仅在用户要求时改写输入文件。
+扫描完成且没有命中，不代表内容一定不含敏感信息。
+
+RPM 安装通过 `agent-sec-skills` 分发此 Skill，ANOLISA raw 包将其放入共享 Skill 目录。
+Cosh-NG 会发现该目录；OpenClaw 和 Hermes adapter 声明了 `pii-checker`，用于分发到各自的
+Skill 目录。其他 Agent 安装需通过其自身的发现路径提供此 Skill。
+
 ## 扫描文本
 
 必须且只能提供一种输入来源：内联文本、标准输入或 UTF-8 文件。

--- a/src/agent-sec-core/.anolisa/component.toml
+++ b/src/agent-sec-core/.anolisa/component.toml
@@ -177,6 +177,10 @@ name = "prompt-scanner"
 source = "{datadir}/skills/prompt-scanner/"
 
 [[adapters.openclaw.skills]]
+name = "pii-checker"
+source = "{datadir}/skills/pii-checker/"
+
+[[adapters.openclaw.skills]]
 name = "skill-ledger"
 source = "{datadir}/skills/skill-ledger/"
 
@@ -209,6 +213,10 @@ source = "{datadir}/skills/code-scanner/"
 [[adapters.hermes.skills]]
 name = "prompt-scanner"
 source = "{datadir}/skills/prompt-scanner/"
+
+[[adapters.hermes.skills]]
+name = "pii-checker"
+source = "{datadir}/skills/pii-checker/"
 
 [[adapters.hermes.skills]]
 name = "skill-ledger"

--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -102,7 +102,7 @@ agent-sec-core/
 ├── qwen-code-extension/       # Qwen Code hooks
 ├── qoder-plugin/              # Qoder CLI hooks
 ├── codex-plugin/              # Codex hooks
-├── skills/                    # Security skills: code-scanner, prompt-scanner, skill-ledger
+├── skills/                    # Bundled security scanning and audit skills
 ├── tools/                     # sign-skill.sh — PGP skill signing utility
 ├── packaging/                 # raw package build + systemd unit template
 ├── scripts/                   # CLI/daemon wrappers and CI helpers
@@ -335,6 +335,9 @@ Host hook modes: [Code Scanner Hook Configuration](../../docs/user-guide/en/agen
 ## PII Checker
 
 Detects personal data and credentials, and can emit redacted text.
+
+The bundled [pii-checker Skill](skills/pii-checker/SKILL.md) lets an Agent scan
+specified text or files and generate redacted text with the V1 CLI.
 
 ```bash
 agent-sec-cli scan-pii --text "contact alice@example.com" --source manual

--- a/src/agent-sec-core/README_zh.md
+++ b/src/agent-sec-core/README_zh.md
@@ -98,7 +98,7 @@ agent-sec-core/
 ├── qwen-code-extension/       # Qwen Code hooks
 ├── qoder-plugin/              # Qoder CLI hooks
 ├── codex-plugin/              # Codex hooks
-├── skills/                    # 安全 skill：code-scanner、prompt-scanner、skill-ledger
+├── skills/                    # 随包提供的安全扫描与审计 Skill
 ├── tools/                     # sign-skill.sh — PGP 技能签名工具
 ├── packaging/                 # raw 包构建 + systemd unit 模板
 ├── scripts/                   # CLI/daemon wrapper 与 CI 辅助脚本
@@ -317,6 +317,9 @@ shell 历史和集群凭证模式，例如 `/etc/kubernetes/` 与 `kubeconfig`�
 ## PII Checker
 
 检测个人数据与凭证，可输出脱敏文本。
+
+随包提供的 [pii-checker Skill](skills/pii-checker/SKILL.md) 支持 Agent 通过 V1 CLI
+检查指定文本或文件，并生成脱敏文本。
 
 ```bash
 agent-sec-cli scan-pii --text "contact alice@example.com" --source manual

--- a/src/agent-sec-core/skills/pii-checker/SKILL.md
+++ b/src/agent-sec-core/skills/pii-checker/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: pii-checker
+description: 使用 agent-sec-cli 检查文本、UTF-8 文件或日志中的个人信息与凭证，报告脱敏证据，并按需生成脱敏文本。当用户要求检查敏感信息、查找泄露的密钥或对内容脱敏时使用；查询已发生的安全事件使用 security-observability。
+---
+
+# PII Checker
+
+复用 V1 `agent-sec-cli scan-pii` 的本地检测规则，检查个人信息和凭证。
+支持邮箱、中国手机号、身份证号、银行卡号、API Key、Bearer Token、JWT、
+私钥及自定义规则。仅检查用户指定的内容，不主动扩大到整个目录或历史会话。
+
+## 调用
+
+已知文件路径时直接扫描文件，无需先将原文读取到对话中：
+
+```bash
+agent-sec-cli scan-pii --input /absolute/path/to/input.txt --source manual --format json
+```
+
+用户要求脱敏时追加 `--redact-output`：
+
+```bash
+agent-sec-cli scan-pii --input /absolute/path/to/input.txt --source manual --format json --redact-output
+```
+
+内容来自文本或上游工具时，通过工具的标准输入接口或已有数据流传给下面的命令；
+不要启动无人提供输入的交互式读取：
+
+```bash
+agent-sec-cli scan-pii --stdin --source manual --format json
+```
+
+- `--input` 只接受单个 UTF-8 文本文件，不解析目录、PDF、图片或压缩包。
+- `--input`、`--stdin`、`--text` 三者必须且只能选一个。敏感正文优先走文件或
+  stdin，避免放入命令参数；不要将待扫描文本拼接为 shell 代码。
+- 替换路径时优先使用参数数组；必须经 shell 时，对整个路径使用可靠的 shell
+  quoting（例如 `shlex.quote`），不能只在任意路径两侧加单引号。
+- 普通主动检查使用 `--source manual`。此标签用于审计，不会更改输入或 Hook 策略。
+- `--include-low-confidence` 可用于用户要求的更广泛复核，包含默认被过滤的低置信度
+  命中；这些分值是启发式评分，不是经过校准的概率。
+- 默认扫描完整输入。只有明确限定范围时才设置正整数 `--max-bytes`，并报告截断。
+- CLI 不可用、不支持 `scan-pii`、输入不可读或命令失败时，报告未完成检查；
+  不以模型自行猜测代替扫描结果，不安装软件或更改安全配置来绕过失败。
+
+## 解释结果
+
+解析 JSON 的 `ok`、`verdict`、`summary`、`findings`；不能只看退出码。
+`warn` 和 `deny` 也可能返回退出码 0，表示扫描完成。
+
+| 字段 / 值 | 解释与处理 |
+|---|---|
+| `ok=false` 或 `verdict=error` | 扫描失败，本次未完成检查 |
+| `verdict=pass` | 在本次规则、置信度过滤和扫描范围内未检出问题 |
+| `verdict=warn` | 存在告警级命中，没有 `deny` 级命中 |
+| `verdict=deny` | 存在 `deny` 级命中；这是扫描判定，不代表已经阻断或撤销凭证 |
+| `summary.truncated=true` | 只扫描了部分输入，不能给出全文结论 |
+| `summary.custom_rules.status=invalid` | 自定义规则未生效，内置规则的结果仍可报告 |
+| `summary.custom_rules.runtime_error_count>0`、`budget_exhausted=true` 或 `truncated=true` | 自定义规则执行或结果不完整，必须说明覆盖限制 |
+
+未配置自定义规则（`status=absent`）是正常状态，不算扫描失败。
+JSON 缺失、解析失败、关键字段缺失或出现未知 verdict 时，报告无法取得有效判定。
+`pass` 只表示未检出，不能承诺不存在敏感信息或内容可以安全外发。
+
+报告实际扫描范围、判定、`summary.total` / `summary.by_type` 的命中统计，
+必要时列出 finding 的 `type`、`severity`、`span` 和 `evidence_redacted`。
+不要使用 `--raw-evidence`，也不要从原文或对话历史补回已脱敏的值。
+
+## 脱敏与审计
+
+只在用户要求脱敏时返回 `redacted_text`；它只替换检出的内容。
+如果扫描或自定义规则不完整，要说明脱敏结果也不完整，不能把截断的片段当作全文。
+`--redact-output` 不修改原文件；仅在用户要求保存或替换文件时执行对应写入。
+
+扫描会记录经过脱敏的 `pii_scan` 安全事件。此 Skill 不调整 Hook 开关、阻断策略
+或自定义规则配置；历史安全事件的查询与复盘由 `security-observability` 处理。

--- a/src/agent-sec-core/tests/e2e/cli/test_scan_pii_e2e.py
+++ b/src/agent-sec-core/tests/e2e/cli/test_scan_pii_e2e.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import re
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -90,6 +92,42 @@ def test_scan_pii_text_json(mode: str, tmp_path: Path) -> None:
     assert any(finding["type"] == "email" for finding in data["findings"])
     assert "redacted_text" not in data
     assert all("raw_evidence" not in finding for finding in data["findings"])
+
+
+@pytest.mark.parametrize("mode", _MODES)
+def test_bundled_pii_skill_commands(mode: str, tmp_path: Path) -> None:
+    skill = Path(__file__).resolve().parents[3] / "skills/pii-checker/SKILL.md"
+    commands = re.findall(r"```bash\n(.*?)\n```", skill.read_text(), flags=re.DOTALL)
+    assert commands, "the bundled skill must provide executable CLI examples"
+    text = "Contact alice@securecorp.cn; token=secret-value-1234567890"
+    input_path = tmp_path / "report's input.txt"
+    input_path.write_text(text, encoding="utf-8")
+
+    for index, command in enumerate(commands):
+        argv = shlex.split(command)
+        assert argv[0] == "agent-sec-cli"
+        args = [
+            str(input_path) if arg == "/absolute/path/to/input.txt" else arg
+            for arg in argv[1:]
+        ]
+        result = _run_cli(
+            mode,
+            *args,
+            data_dir=tmp_path / mode / str(index),
+            input_text=text if "--stdin" in args else None,
+        )
+        data = _load_json(result)
+        assert data["ok"] is True
+        assert data["verdict"] == "deny"
+        assert data["summary"]["source"] == "manual"
+        assert data["summary"]["truncated"] is False
+        assert "secret-value-1234567890" not in result.stdout
+        assert all("raw_evidence" not in finding for finding in data["findings"])
+        if "--redact-output" in args:
+            assert data["redacted_text"] != text
+        else:
+            assert "redacted_text" not in data
+        assert input_path.read_text(encoding="utf-8") == text
 
 
 @pytest.mark.parametrize("mode", _MODES)

--- a/src/agent-sec-core/tests/packaging/test-package-raw.sh
+++ b/src/agent-sec-core/tests/packaging/test-package-raw.sh
@@ -37,10 +37,7 @@ install -d -m 0755 \
     "$BUILD/qoder-plugin/.qoder-plugin" \
     "$BUILD/qoder-plugin/hooks" \
     "$BUILD/qwen-code-extension/hooks" \
-    "$BUILD/cosh-extension/hooks" \
-    "$BUILD/skills/code-scanner" \
-    "$BUILD/skills/prompt-scanner" \
-    "$BUILD/skills/skill-ledger/references"
+    "$BUILD/cosh-extension/hooks"
 
 printf '__version__ = "%s"\n' "$VERSION" > \
     "$BUILD/site-packages/agent_sec_cli/__init__.py"
@@ -124,10 +121,7 @@ printf 'print("fixture")\n' > "$BUILD/qwen-code-extension/hooks/hook.py"
 cp "$ROOT/cosh-extension/cosh-extension.json" "$BUILD/cosh-extension/"
 printf 'print("fixture")\n' > "$BUILD/cosh-extension/hooks/hook.py"
 
-for skill in code-scanner prompt-scanner skill-ledger; do
-    printf '# %s\n' "$skill" > "$BUILD/skills/$skill/SKILL.md"
-done
-printf '# fixture\n' > "$BUILD/skills/skill-ledger/references/protocol.md"
+make -C "$ROOT" stage-skills BUILD_DIR="$BUILD"
 
 run_package() {
     local output="$1"
@@ -170,6 +164,12 @@ cmp "$ROOT/.anolisa/component.toml" \
     "$MANIFEST_STAGE/share/anolisa/components/sec-core/component.toml"
 make -C "$ROOT" install-component-manifest install-systemd-user \
     DESTDIR="$RPM_STAGE"
+make -C "$ROOT" install-skills BUILD_DIR="$BUILD" DESTDIR="$RPM_STAGE"
+for skill_dir in "$ROOT"/skills/*; do
+    skill="$(basename "$skill_dir")"
+    cmp "$skill_dir/SKILL.md" "$STAGE/share/anolisa/skills/$skill/SKILL.md"
+    cmp "$skill_dir/SKILL.md" "$RPM_STAGE/usr/share/anolisa/skills/$skill/SKILL.md"
+done
 cmp "$ROOT/.anolisa/component.toml" \
     "$RPM_STAGE/usr/share/anolisa/components/sec-core/component.toml"
 if [ -e "$ROOT/adapters/component.toml" ]; then
@@ -286,6 +286,8 @@ for expected in \
     "./adapters/sec-core/cosh/cosh-extension.json" \
     "./share/anolisa/skills/code-scanner/SKILL.md" \
     "./share/anolisa/skills/prompt-scanner/SKILL.md" \
+    "./share/anolisa/skills/pii-checker/SKILL.md" \
+    "./share/anolisa/skills/security-observability/SKILL.md" \
     "./share/anolisa/skills/skill-ledger/SKILL.md" \
     "./share/anolisa/sec-core/agent-sec-core.service.in" \
     "./share/doc/sec-core/LICENSE"; do
@@ -306,6 +308,19 @@ fi
 
 tar -xzOf "$OUT_ONE/$ARTIFACT" ./.anolisa/component.toml > "$TMP/contract.toml"
 cmp "$ROOT/.anolisa/component.toml" "$TMP/contract.toml"
+python3 - "$TMP/contract.toml" "$STAGE" <<'PY'
+import sys
+import tomllib
+from pathlib import Path
+
+manifest = tomllib.loads(Path(sys.argv[1]).read_text())
+stage = Path(sys.argv[2])
+for framework in ("openclaw", "hermes"):
+    adapter = next(item for item in manifest["adapters"] if item["framework"] == framework)
+    skill = next(item for item in adapter[framework]["skills"] if item["name"] == "pii-checker")
+    source = skill["source"].replace("{datadir}", str(stage / "share/anolisa"))
+    assert (Path(source) / "SKILL.md").is_file(), (framework, source)
+PY
 tar -xzOf "$OUT_ONE/$ARTIFACT" "./$ASSET_VERIFY_PACKAGE_PATH" \
     > "$TMP/asset-verify-config.conf"
 assert_asset_verify_config "$TMP/asset-verify-config.conf"


### PR DESCRIPTION
## Why

AgentSecCore already exposes PII and credential detection through the V1 `scan-pii` CLI, but does not bundle a Skill for Agents to invoke it. Add a small `pii-checker` Skill for scanning specified text or UTF-8 files and generating redacted text on request.

## What changed

Reuse the existing scanner and shared Skill packaging directory, and declare `pii-checker` in the OpenClaw and Hermes adapter manifests. Add executable tests for the Skill's command examples, check real Skill files and declared paths during packaging, and update the English and Chinese documentation.

## Related issue

no-issue: small bundled Skill addition wrapping the existing V1 PII scanner.

## User / Agent impact

Agents that discover the Skill can check user-specified content for personal data or credentials and request redacted output. Reports distinguish detection results from command success, identify incomplete scans, and use redacted evidence. The bundled Skill count increases from four to five.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The new surface is a Skill and its adapter delivery declarations; existing CLI flags, scanner behavior, dependencies, Hook policy, and runtime code are unchanged. The Skill defaults to file/stdin input and redacted evidence, and it does not rewrite source files unless requested. It explicitly reports that a successful scan with no findings is not proof that content is safe to disclose. Compatibility is limited to the existing V1 `scan-pii` interface; V2 implementation is out of scope. There is no data migration.

## Validation

Environment: macOS arm64, Python 3.11.6, repository-locked dependencies, source-only Python execution; no Linux-only component build.

- `PYTHONPATH=agent-sec-cli/src python -m pytest tests/unit-test/pii_checker tests/unit-test/security_middleware/backends/test_pii_scan_backend.py -q`: **153 passed**.
- `PYTHONPATH=agent-sec-cli/src python -m pytest tests/e2e/cli/test_scan_pii_e2e.py -k module -q`: **10 passed, 10 deselected**. Includes all three new Skill examples, stdin/file input, a quoted filename, deny with exit status 0, redacted output, and unchanged input files.
- The fixture-based staging subset from `tests/packaging/test-package-raw.sh` passed: real Skill files survive `stage-skills`, `stage-raw`, and `install-skills`; both declared host source paths resolve to the staged Skill.
- Skill frontmatter validation, `make python-code-pretty`, changed-file Ruff/Black/isort checks, `bash -n tests/packaging/test-package-raw.sh`, `git diff --check`, `bash scripts/docs-lint.sh`, and `python3 scripts/docs-link-check.py`: **passed**.
- Full `bash tests/packaging/test-package-raw.sh` remains **environment-blocked**: macOS tar does not support GNU `--sort=name`. Archive generation, installed Linux binary tests, and real Agent Skill invocation have not been accepted by this local run.

## Documentation and rollback

Updated both component README summaries and the English/Chinese PII Checker user guides. The Skill is self-contained and documents its V1 interface and result boundaries. Roll back by reverting this commit and redeploying the previous Skill package/adapter manifest; no stored data conversion is required.
