### PR TITLE
test(tokenless): fail the hook suite fast when the installed CLI is stale

### DIFF
--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -894,7 +894,7 @@ tool-output savings and retrieval overhead separately.
 | `make test-agentscope-integration` | Test both wheels with supported AgentScope versions |
 | `make install` | Build and install binaries to `BIN_DIR` (default: ~/.local/bin) |
 | `make test` | Run all tests (Rust + hooks) |
-| `make test-hooks` | Run hook integration tests |
+| `make test-hooks` | Run hook integration tests against the installed `tokenless` binary, whose version must match this checkout (`TOKENLESS_ALLOW_VERSION_SKEW=1` overrides) |
 | `make lint` | Run clippy checks |
 | `make fmt` | Format code |
 | `make clean` | Clean build artifacts |

--- a/src/tokenless/tests/run-all-tests.sh
+++ b/src/tokenless/tests/run-all-tests.sh
@@ -641,7 +641,35 @@ main() {
     if ! command -v tokenless &> /dev/null; then
         echo -e "${RED}ERROR: tokenless not found${NC}"; exit 1
     fi
-    log_info "Testing $(tokenless --version)"
+
+    # Every case below drives the installed release binary on PATH on purpose
+    # (see the note above test 5.0b), while the assertions track this
+    # checkout. A stale install therefore fails in places that have nothing to
+    # do with the change under test: `tokenless compress` only exists from
+    # 0.8.0 on, so an older binary dies with "unrecognized subcommand" and the
+    # run reports a dozen unrelated hook failures. Compare the versions up
+    # front and say so instead.
+    local cli_version workspace_version
+    cli_version=$(tokenless --version 2>/dev/null | awk '{print $2}')
+    workspace_version=$(sed -n 's/^version = "\(.*\)"$/\1/p' \
+        "$TOKENLESS_SOURCE_DIR/Cargo.toml" | head -1)
+    if [ -n "$workspace_version" ] && [ "$cli_version" != "$workspace_version" ]; then
+        if [ "${TOKENLESS_ALLOW_VERSION_SKEW:-0}" = "1" ]; then
+            log_info "WARNING: tokenless on PATH is $cli_version, this checkout is $workspace_version (TOKENLESS_ALLOW_VERSION_SKEW=1)"
+        else
+            echo -e "${RED}ERROR: tokenless on PATH is ${cli_version:-unknown} but this checkout is $workspace_version${NC}"
+            echo "This suite drives the installed release binary, so its assertions"
+            echo "track the checkout while the binary under test does not. Reinstall"
+            echo "the current build over it:"
+            echo ""
+            echo "    make -C src/tokenless build && make -C src/tokenless install"
+            echo ""
+            echo "Set TOKENLESS_ALLOW_VERSION_SKEW=1 to test the installed $cli_version anyway."
+            exit 1
+        fi
+    fi
+
+    log_info "Testing $(tokenless --version) at $(command -v tokenless)"
 
     test_schema_compression
     test_response_compression


### PR DESCRIPTION
## What

`src/tokenless/tests/run-all-tests.sh` — the suite behind `make test-hooks`, and one of the members of the aggregate `make test` — drives the installed release binary found on `PATH`. That is deliberate (see the note above test 5.0b: release-layout verification), but every assertion in the file tracks the checkout. When the installed release is older than the checkout, the suite fails in places that have nothing to do with the change under test and gives no hint why.

Reproduced with an installed `tokenless 0.7.4` against a `0.8.x` checkout: **15 of 70 cases fail**, taking the whole tool-ready and environment-attribution group with them. The root cause never surfaces in the output — `tokenless compress` only exists from 0.8.0 on, so the older binary dies with:

```text
[tokenless] WARNING: error: unrecognized subcommand 'compress'

  tip: some similar subcommands exist: 'decompress-toon', 'compress-response', 'compress-schema', 'compress-toon'
```

and the hook under test then reports `{}` where a compression or attribution decision was expected. Reading that as a hook regression sends you to the wrong file.

## Change

- `tests/run-all-tests.sh`: before the first case, compare `tokenless --version` against the workspace version parsed from `src/tokenless/Cargo.toml`. On mismatch print the reason plus the reinstall command and `exit 1`, so no case runs and no misleading failure is reported. `TOKENLESS_ALLOW_VERSION_SKEW=1` downgrades it to a warning for anyone who really means to test an installed release. The startup line now also logs the resolved binary path, so every run states which `tokenless` it exercised.
- `README.md`: the `make test-hooks` row states the precondition.

No production code, no Makefile target and no CI workflow is touched. The expected version is read at runtime, so the guard needs no bump on release.

## Test report

Environment: Linux x86_64, GNU bash 4.4.20, GNU Make 4.2.1, rustc/cargo 1.96.0, node v22.21.1, python3 3.8.17, shellcheck 0.10.0. Installed `tokenless` on `PATH`: 0.7.4; workspace build at this branch's base: 0.8.0.

Guard behaviour matrix — all four scenarios executed on this branch:

| Scenario | Command | Result |
| --- | --- | --- |
| Stale install, no override | `bash tests/run-all-tests.sh` | exit 1 before any case; message names both versions and the reinstall command |
| Stale install, override | `TOKENLESS_ALLOW_VERSION_SKEW=1 bash tests/run-all-tests.sh` | warning logged, then 55/70 — identical to the pre-change behaviour |
| Matching workspace build | `PATH="src/tokenless/target/debug:$PATH" bash src/tokenless/tests/run-all-tests.sh` | exit 0, **70/70 passed** |
| Matching build through make | `PATH="src/tokenless/target/debug:$PATH" make -C src/tokenless test-hooks` | exit 0: `run-hook install scope` passed, `tool-ready hard bypass` passed, 70/70 |

Before/after on the stale install: 15 confusing case failures → 1 actionable error. Same checkout, same binary, only the reporting changed.

Other suites re-run on this branch, all green:

| Command | Result |
| --- | --- |
| `cargo fmt --all -- --check` (in `src/tokenless`) | clean |
| `cargo clippy --workspace -- -D warnings` (in `src/tokenless`) | exit 0, no warnings |
| `cargo test -p tokenless-cli -- --test-threads=1` | 285 passed / 0 failed / 2 ignored |
| `make -C src/tokenless test-adapters` | exit 0 — OpenClaw installer, Protocol v2 lifecycle (`node --test`), native dsh bundle, Qoder 17/0, OpenCode 13/0 + plugin tests, QwenPaw 32/0 |
| `make -C src/tokenless test-claude-code-detect test-toon-cleanup` | both passed |
| `bash scripts/docs-lint.sh` | naming convention OK, en/zh tree parity OK |
| `python3 scripts/docs-link-check.py` | all relative links resolve |
| `shellcheck -S warning tests/run-all-tests.sh` | 45 findings — identical count to the pre-change baseline, and zero inside the added block (the new `local` declaration is kept separate from its assignments to stay SC2155-clean) |

Not run, with reasons:

- `make -C src/tokenless test-integration` — local `python3` is 3.8.17 and `tests/test_hook_contract.py` uses PEP 604 unions (`str | None`), which raises `TypeError` under 3.8; CI runs 3.11. Unrelated to this change, which touches no Python file.
- `make test-python-runtime`, `make test-agentscope-integration`, `make npm-package`, `make test-hook-parity`, `make test-raw-package`, `make test-npm-package` — unaffected (shell + markdown only) and need wheel/npm packaging or a release build; skipped to keep the run focused.
- `tests/test-toon-full.sh` — not reachable from any make target, and needs cosh-ng / OpenClaw plugin state this environment does not have.

## Related, deliberately not included

1. `tests/test-toon-full.sh` still asserts pre-#2869 behaviour. With a matching 0.8.x binary, scenario 1 fails 23 of 35 cases because short fixtures now pass through the 500-char TOON gate unchanged; it needs `--min-toon-chars 0` or updated expectations. Separate change.
2. `make test-hooks` and `make test-adapters` are still not invoked by any CI job. That is #3211, which needs a maintainer because it edits `.github/workflows/ci.yaml`.
