### PR TITLE
feat(chore): support migrated Pages hosting

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -51,8 +51,8 @@ jobs:
       ${{ github.repository == 'alibaba/anolisa' &&
       'anolisa-k8s-general-ci-x64' || 'ubuntu-latest' }}
     env:
-      SITE_URL: ${{ github.repository == 'alibaba/anolisa' && 'https://agentic-os.sh' || format('https://{0}.github.io', github.repository_owner) }}
-      BASE_URL: ${{ github.repository == 'alibaba/anolisa' && '/' || format('/{0}/', github.event.repository.name) }}
+      SITE_URL: ${{ github.repository == 'agentic-os-org/ANOLISA' && 'https://agentic-os.sh' || format('https://{0}.github.io', github.repository_owner) }}
+      BASE_URL: ${{ github.repository == 'agentic-os-org/ANOLISA' && '/' || format('/{0}/', github.event.repository.name) }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -67,8 +67,22 @@ jobs:
           cache-dependency-path: website/package-lock.json
 
       - name: Configure GitHub Pages
+        id: pages
         if: github.event_name != 'pull_request'
         uses: actions/configure-pages@v5
+
+      - name: Verify the build URL matches GitHub Pages
+        if: github.event_name != 'pull_request'
+        env:
+          PAGES_URL: ${{ steps.pages.outputs.base_url }}
+        run: |
+          node --input-type=module <<'NODE'
+          import assert from 'node:assert/strict';
+          const buildUrl = new URL(process.env.BASE_URL, process.env.SITE_URL);
+          const pagesUrl = new URL(`${process.env.PAGES_URL.replace(/\/$/, '')}/`);
+          assert.equal(buildUrl.href, pagesUrl.href,
+            'SITE_URL and BASE_URL must match the configured GitHub Pages URL');
+          NODE
 
       - name: Install website dependencies
         run: npm ci --prefix website
@@ -85,6 +99,11 @@ jobs:
           SITE_URL: https://example.github.io
           BASE_URL: /base-url-check/
         run: npm run build --prefix website
+
+      # Webpack's cached CSS can retain the sub-path font URLs.
+      - name: Clear the sub-path build cache
+        working-directory: website
+        run: npm exec -- docusaurus clear
 
       - name: Build Docusaurus and check Markdown links
         run: npm run build --prefix website
@@ -108,7 +127,7 @@ jobs:
         run: npm run check:links --prefix website
 
       - name: Remove production custom domain from fork preview
-        if: github.repository != 'alibaba/anolisa'
+        if: github.repository != 'agentic-os-org/ANOLISA'
         run: rm -f website/build/CNAME
 
       - name: Upload Pages artifact
@@ -122,7 +141,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' &&
       (github.ref == 'refs/heads/main' ||
-      (github.repository != 'alibaba/anolisa' &&
+      (github.repository != 'agentic-os-org/ANOLISA' &&
       github.ref == 'refs/heads/chore/gh-pages')))
     needs: build
     permissions:

--- a/website/agent-index/overrides.json
+++ b/website/agent-index/overrides.json
@@ -1,5 +1,5 @@
 {
-  "repository": "https://github.com/alibaba/anolisa",
+  "repository": "https://github.com/agentic-os-org/ANOLISA",
   "license": "Apache-2.0",
   "components": {
     "copilot-shell": {

--- a/website/content.config.ts
+++ b/website/content.config.ts
@@ -1,4 +1,4 @@
 export type Locale = 'en' | 'zh';
 
-export const repositoryUrl = 'https://github.com/alibaba/anolisa';
+export const repositoryUrl = 'https://github.com/agentic-os-org/ANOLISA';
 export const installCommand = 'curl -fsSL https://get.agentic-os.sh | bash';

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -10,8 +10,8 @@ const config: Config = {
   tagline: 'The operating layer for agent workloads',
   url: siteUrl,
   baseUrl,
-  organizationName: 'alibaba',
-  projectName: 'anolisa',
+  organizationName: 'agentic-os-org',
+  projectName: 'ANOLISA',
   favicon: 'img/brand/favicon.ico',
   trailingSlash: true,
   onBrokenLinks: 'throw',
@@ -105,7 +105,7 @@ const config: Config = {
         {to: '/changelog', label: 'Changelog', position: 'left'},
         {to: '/agents/', label: 'For Agents', position: 'left'},
         {
-          href: 'https://github.com/alibaba/anolisa',
+          href: 'https://github.com/agentic-os-org/ANOLISA',
           label: 'GitHub',
           position: 'right',
           className: 'headerGithubLink',
@@ -137,14 +137,14 @@ const config: Config = {
         {
           title: 'Community',
           items: [
-            {label: 'GitHub', href: 'https://github.com/alibaba/anolisa'},
+            {label: 'GitHub', href: 'https://github.com/agentic-os-org/ANOLISA'},
             {
               label: 'Contributing',
-              href: 'https://github.com/alibaba/anolisa/blob/main/CONTRIBUTING.md',
+              href: 'https://github.com/agentic-os-org/ANOLISA/blob/main/CONTRIBUTING.md',
             },
             {
               label: 'Security',
-              href: 'https://github.com/alibaba/anolisa/blob/main/SECURITY.md',
+              href: 'https://github.com/agentic-os-org/ANOLISA/blob/main/SECURITY.md',
             },
           ],
         },

--- a/website/scripts/check-links.mjs
+++ b/website/scripts/check-links.mjs
@@ -65,10 +65,23 @@ for (const htmlFile of htmlFiles) {
   }
 }
 
+for (const cssFile of await walkFiles(buildDir, (file) => file.endsWith('.css'))) {
+  const css = await readFile(cssFile, 'utf8');
+  const relativePath = path.relative(buildDir, cssFile).split(path.sep).join('/');
+  const cssUrl = new URL(`${basePath ? `${basePath}/` : ''}${relativePath}`, `${siteUrl}/`);
+  for (const match of css.matchAll(/url\(["']?([^"')]+)["']?\)/g)) {
+    const asset = new URL(match[1], cssUrl);
+    if (asset.origin !== cssUrl.origin) continue;
+    if (!(await exists(await targetFile(asset.pathname)))) {
+      errors.push(`${relativePath}: broken CSS asset ${match[1]}`);
+    }
+  }
+}
+
 if (errors.length > 0) {
   console.error(`Static link validation failed with ${errors.length} error(s):`);
   for (const error of errors.slice(0, 100)) console.error(`- ${error}`);
   process.exit(1);
 }
 
-console.log(`Static link and duplicate-ID validation passed for ${htmlFiles.length} HTML files.`);
+console.log(`Static link, CSS asset, and duplicate-ID validation passed for ${htmlFiles.length} HTML files.`);

--- a/website/scripts/generate-agent-index.mjs
+++ b/website/scripts/generate-agent-index.mjs
@@ -218,7 +218,7 @@ for (const row of componentRows) {
   const defaultInstall =
     defaultInstallMethod === 'bootstrap'
       ? installCommand
-      : `https://github.com/alibaba/anolisa/tree/main/${row.source_path}`;
+      : `https://github.com/agentic-os-org/ANOLISA/tree/main/${row.source_path}`;
   const installMethod = componentOverride.install_method || defaultInstallMethod;
   const install = componentOverride.install || defaultInstall;
   const installVariants = componentOverride.install_variants || [
@@ -244,7 +244,7 @@ for (const row of componentRows) {
     version: await componentVersion(row.source_path),
     description: await componentDescription(row.source_path, row.name),
     source_path: row.source_path,
-    documentation_path: `https://github.com/alibaba/anolisa/tree/main/${row.source_path}`,
+    documentation_path: `https://github.com/agentic-os-org/ANOLISA/tree/main/${row.source_path}`,
     install,
     install_method: installMethod,
     install_variants: installVariants,
@@ -293,7 +293,7 @@ const index = {
     source,
     url: source === 'docs/QUICKSTART.md'
       ? siteHref('docs/quickstart/')
-      : `https://github.com/alibaba/anolisa/blob/main/${source}`,
+      : `https://github.com/agentic-os-org/ANOLISA/blob/main/${source}`,
   })),
   components,
   platform_support: {

--- a/website/scripts/generate-changelog.mjs
+++ b/website/scripts/generate-changelog.mjs
@@ -26,7 +26,7 @@ async function document(source, language) {
     language,
     markdown: markdown.replace(/(!?)\[([^\]]*)\]\((?!https?:|#|mailto:)([^)]+)\)/g, (_match, image, label, target) => {
       const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(source), target));
-      return `${image}[${label}](https://github.com/alibaba/anolisa/blob/main/${resolved})`;
+      return `${image}[${label}](https://github.com/agentic-os-org/ANOLISA/blob/main/${resolved})`;
     }),
   };
 }

--- a/website/scripts/prepare-docs.mjs
+++ b/website/scripts/prepare-docs.mjs
@@ -10,7 +10,7 @@ import {
   websiteDir,
 } from './lib.mjs';
 
-const repository = 'https://github.com/alibaba/anolisa';
+const repository = 'https://github.com/agentic-os-org/ANOLISA';
 const siteUrl = process.env.SITE_URL ?? 'https://agentic-os.sh';
 const baseUrl = process.env.BASE_URL ?? '/';
 const docsOutput = path.join(generatedDir, 'docs');

--- a/website/src/pages/changelog.tsx
+++ b/website/src/pages/changelog.tsx
@@ -38,7 +38,7 @@ export default function ChangelogPage() {
               <article id={`changelog-source-${index}`} key={document.source} className="changelogDocument">
                 <div className="sourceLabel">
                   <span>{document.name}</span>
-                  <a href={`https://github.com/alibaba/anolisa/blob/main/${document.source}`}>{document.source}</a>
+                  <a href={`https://github.com/agentic-os-org/ANOLISA/blob/main/${document.source}`}>{document.source}</a>
                 </div>
                 <ReactMarkdown remarkPlugins={[remarkGfm]}>{document.markdown}</ReactMarkdown>
               </article>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -295,7 +295,7 @@ const capabilityShowcases: readonly CapabilityShowcase[] = [
       zh: '这里展示仓库中的 Benchmark 区间。实际结果会随 Payload 变化，也不能直接换算成 Provider 账单的节省比例。',
     },
     noteLink: {en: 'Read the benchmark methodology', zh: '查看 Benchmark 方法'},
-    noteHref: 'https://github.com/alibaba/anolisa/tree/main/src/tokenless/benchmark',
+    noteHref: 'https://github.com/agentic-os-org/ANOLISA/tree/main/src/tokenless/benchmark',
     views: tokenlessViews,
   },
   {


### PR DESCRIPTION
## Why

After the transfer to `agentic-os-org/ANOLISA`, the Pages workflow treats the
production repository as a fork. It publishes HTML referencing `/ANOLISA/`
assets at `https://agentic-os.sh/`, so CSS, JavaScript, images, and navigation
return 404 even though the deployment succeeds.

## What changed

Recognize the new production repository when selecting `SITE_URL`, `BASE_URL`,
and fork-only behavior. Compare the build URL with `actions/configure-pages`
metadata before deployment builds, so a future domain/path mismatch fails
before publishing. Clear Docusaurus caches between the sub-path test build and
production build: cached CSS otherwise retains `/base-url-check/` font URLs.
Extend static validation to CSS asset URLs and update website repository metadata
and generated source links.

## Related issue

no-issue: scoped website configuration repair following the organization transfer.

## User / Agent impact

The production site loads assets and routes from `/`, retains `/zh/` for Chinese,
and points generated repository links to `agentic-os-org/ANOLISA`.
Fork builds retain their repository sub-path.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [x] Migration or rollback guidance is needed

Low risk: changes are limited to website publishing configuration and source links.
The URL check requires Pages settings to match the configured build URL. PR builds
skip the Pages metadata check and continue to build without deploying.
Runner selection is unchanged; CI machine migration is being handled separately.
No DNS, Pages settings, installer behavior, or other component code is changed.

## Validation

Local macOS, Node.js 22.22.1, dependencies installed from the existing lockfile:

- `npm run typecheck --prefix website`
- `SITE_URL=https://example.github.io BASE_URL=/base-url-check/ npm run build --prefix website`
- `SITE_URL=https://example.github.io BASE_URL=/base-url-check/ npm run check:links --prefix website`
- `(cd website && npm exec -- docusaurus clear)` between sub-path and production builds
- `SITE_URL=https://agentic-os.sh BASE_URL=/ npm run build --prefix website`
- `SITE_URL=https://agentic-os.sh BASE_URL=/ npm run check:links --prefix website`
- `npm run validate:agent-index --prefix website`
- Both builds include English and Chinese; each passes checks for 192 HTML files.
- Parsed the workflow YAML and executed its URL check: production, fork, and
  trailing-slash cases pass; the observed migration mismatch, wrong path, and
  missing Pages metadata fail as expected. Confirmed runner selection is unchanged.
- Served the production artifact at `/`: home, Chinese home, both quickstarts,
  and `/agents/` return 200, as do their CSS/JS/image references; canonical URLs
  point to the production domain. Sub-path asset/canonical checks also pass.
- The new CSS check reproduces six broken English/Chinese font URLs before cache
  clearing; rebuilding after clearing passes the same check.
- Browser verification: homepage styling and images load, with working tab switching.
- `node --check` on modified generator scripts; `git diff --check`.

## Documentation and rollback

No canonical documentation content or generated build files are committed.
Generated website source links now target the transferred repository.
After merge/deployment, verify live English/Chinese pages, assets, and canonical
URLs. DNS and repository Pages settings must be checked separately as part of
migration closeout. For emergency rollback, redeploy a known-good artifact built
with `SITE_URL=https://agentic-os.sh` and `BASE_URL=/`; reverting only this fix
would restore the migration bug.
